### PR TITLE
Fix TypeScript client generator attribute detection

### DIFF
--- a/src/GrpcRemoteMvvmModelUtil/ViewModelAnalyzer.cs
+++ b/src/GrpcRemoteMvvmModelUtil/ViewModelAnalyzer.cs
@@ -53,7 +53,9 @@ namespace GrpcRemoteMvvmModelUtil
                         foreach (var attr in classSymbol.GetAttributes())
                         {
                             string? attrFqn = attr.AttributeClass?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
-                            if (attrFqn == generateGrpcRemoteAttributeFullName)
+                            string? attrShortName = attr.AttributeClass?.Name;
+                            if (attrFqn == generateGrpcRemoteAttributeFullName ||
+                                (attr.AttributeClass != null && !attr.AttributeClass.IsUnboundGenericType && attrFqn == null && attrShortName == Path.GetFileNameWithoutExtension(generateGrpcRemoteAttributeFullName)))
                             {
                                 mainViewModelSymbol = classSymbol;
                                 originalVmName = classSymbol.Name;


### PR DESCRIPTION
## Summary
- improve ViewModelAnalyzer attribute lookup so `grpc-remote-mvvm-ts-client` can find `[GenerateGrpcRemote]` when the attribute isn't referenced

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861955b81248320adadd643af64dfc2