### PR TITLE
Update TS client generator for grpc-web

### DIFF
--- a/src/demo/TypeScriptMonsterClicker/GameViewModelRemoteClient.ts
+++ b/src/demo/TypeScriptMonsterClicker/GameViewModelRemoteClient.ts
@@ -1,5 +1,6 @@
 // Auto-generated TypeScript client for GameViewModel
-import { GameViewModelServiceClient, GameViewModelState, UpdatePropertyValueRequest, SubscribeRequest } from './protos/GameViewModelService';
+import { GameViewModelServiceClient } from './generated/GameViewModelService_pb_service';
+import { GameViewModelState, UpdatePropertyValueRequest, SubscribeRequest } from './generated/GameViewModelService_pb';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 
 export class GameViewModelRemoteClient {
@@ -20,7 +21,15 @@ export class GameViewModelRemoteClient {
     }
 
     async initializeRemote(): Promise<void> {
-        const state = await this.grpcClient.getState(new Empty());
+        const state = await new Promise<GameViewModelState>((resolve, reject) => {
+            this.grpcClient.getState(new Empty(), (err, res) => {
+                if (err || !res) {
+                    reject(err);
+                } else {
+                    resolve(res);
+                }
+            });
+        });
         this.monsterName = (state as any)['monster_name'];
         this.monsterMaxHealth = (state as any)['monster_max_health'];
         this.monsterCurrentHealth = (state as any)['monster_current_health'];
@@ -33,8 +42,16 @@ export class GameViewModelRemoteClient {
     }
 
     async updatePropertyValue(propertyName: string, value: any): Promise<void> {
-        const req: UpdatePropertyValueRequest = { propertyName, newValue: value }; 
-        await this.grpcClient.updatePropertyValue(req); 
+        const req: UpdatePropertyValueRequest = { propertyName, newValue: value };
+        await new Promise<void>((resolve, reject) => {
+            this.grpcClient.updatePropertyValue(req, err => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
     }
 
 }


### PR DESCRIPTION
## Summary
- import gRPC-web service and message modules when generating TypeScript clients
- wrap service calls in Promises for callback-based API
- update demo client to match new imports and async style

## Testing
- `npm run build` *(fails: cannot find module 'google-protobuf/google/protobuf/empty_pb')*

------
https://chatgpt.com/codex/tasks/task_e_6861b0281a40832089000abd5f95850e