### PR TITLE
Fix detection of RelayCommand methods

### DIFF
--- a/src/GrpcRemoteMvvmModelUtil/Helpers.cs
+++ b/src/GrpcRemoteMvvmModelUtil/Helpers.cs
@@ -26,8 +26,18 @@ namespace GrpcRemoteMvvmModelUtil
                 return true;
 
             var shortName = attributeData.AttributeClass?.Name;
-            var trimmed = Path.GetFileNameWithoutExtension(fullyQualifiedAttributeName);
-            return shortName == trimmed || shortName == fullyQualifiedAttributeName;
+            if (shortName == null)
+                return false;
+
+            var targetShort = fullyQualifiedAttributeName.Split('.').Last();
+            if (targetShort.EndsWith("Attribute"))
+                targetShort = targetShort.Substring(0, targetShort.Length - "Attribute".Length);
+
+            var simpleName = shortName;
+            if (simpleName.EndsWith("Attribute"))
+                simpleName = simpleName.Substring(0, simpleName.Length - "Attribute".Length);
+
+            return simpleName == targetShort || shortName == targetShort || shortName == fullyQualifiedAttributeName;
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix attribute name matching logic so commands decorated with `[RelayCommand]` are detected

## Testing
- `npm install`
- `npm run build` *(fails: Property 'attackMonster' does not exist on GameViewModelRemoteClient)*

------
https://chatgpt.com/codex/tasks/task_e_6861d54de92c8320b9e7a5ee97d3713d