### PR TITLE
Update TypeScript client page

### DIFF
--- a/src/demo/TypeScriptMonsterClicker/README.md
+++ b/src/demo/TypeScriptMonsterClicker/README.md
@@ -1,0 +1,16 @@
+# TypeScript Monster Clicker
+
+This sample demonstrates a TypeScript client using gRPC‑Web to communicate with the MonsterClicker server.
+
+The `generated` folder contains the service stubs and message types produced from `GameViewModelService.proto`. If `GameViewModelService_pb.js` is missing you can regenerate the files with `protoc`:
+
+```bash
+protoc \
+  --proto_path=../MonsterClicker/protos \
+  --proto_path=/usr/include \
+  --js_out=import_style=commonjs,binary:generated \
+  --grpc-web_out=import_style=commonjs,mode=grpcwebtext:generated \
+  ../MonsterClicker/protos/GameViewModelService.proto
+```
+
+The command requires both `protoc` and the `protoc-gen-grpc-web` plugin to be installed and on your `PATH`.

--- a/src/demo/TypeScriptMonsterClicker/wwwroot/index.html
+++ b/src/demo/TypeScriptMonsterClicker/wwwroot/index.html
@@ -4,29 +4,45 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BlazorMonsterClicker</title>
+    <title>TypeScriptMonsterClicker</title>
     <base href="/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link rel="stylesheet" href="css/app.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
-    <link href="BlazorMonsterClicker.styles.css" rel="stylesheet" />
 </head>
 
 <body>
-    <div id="app">
-        <svg class="loading-progress">
-            <circle r="40%" cx="50%" cy="50%" />
-            <circle r="40%" cx="50%" cy="50%" />
-        </svg>
-        <div class="loading-progress-text"></div>
+    <div id="loading">Initializing game...</div>
+    <div id="game-container" style="display:none; padding:20px; border:1px solid #ccc; border-radius:8px; max-width:500px; margin:auto;">
+        <h3 style="text-align:center;">Monster Clicker (TypeScript Client)</h3>
+
+        <h4 id="monster-name" style="text-align:center; margin-bottom:10px;"></h4>
+
+        <div style="display:flex; align-items:center; justify-content:center; margin-bottom:20px;">
+            <span>Health: </span>
+            <progress id="monster-health" style="width:200px; margin:0 10px;"></progress>
+            <span id="health-text"></span>
+        </div>
+
+        <div style="text-align:center; margin-bottom:20px;">
+            <button id="attack-btn" class="btn btn-success btn-lg">
+                ATTACK!<br />
+                <img src="sword.png" alt="Attack" style="width:50px; height:50px;" />
+            </button>
+        </div>
+
+        <p id="game-message" style="text-align:center; font-style:italic; color:dodgerblue; min-height:2em;"></p>
+
+        <div style="text-align:center; margin-top:20px;">
+            <button id="special-btn" class="btn btn-warning">Special Attack</button>
+            <button id="newgame-btn" class="btn btn-info" style="margin-left:10px;">New Game</button>
+        </div>
+
+        <p id="cooldown-text" style="text-align:center; color:orange; display:none;">Special Attack on Cooldown!</p>
+        <p id="connection-status" style="text-align:center; margin-top:10px;"></p>
     </div>
 
-    <div id="blazor-error-ui">
-        An unhandled error has occurred.
-        <a href="" class="reload">Reload</a>
-        <a class="dismiss">🗙</a>
-    </div>
-    <script src="_framework/blazor.webassembly.js"></script>
+    <script src="../app.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- switch the TypeScript client index page to a simple HTML UI
- add instructions for regenerating gRPC web stubs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6861e8d75fc08320a6fa5b37d5192322