### PR TITLE
Fix protoc generation script

### DIFF
--- a/src/demo/TypeScriptMonsterClicker/package.json
+++ b/src/demo/TypeScriptMonsterClicker/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "wwwroot/app.js",
   "scripts": {
-    "protoc": "protoc --proto_path=protos --js_out=import_style=commonjs,binary:./wwwroot/generated --grpc-web_out=import_style=commonjs,mode=grpcwebtext:./wwwroot/generated protos/*.proto && protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=service=grpc-web:./wwwroot/generated --proto_path=protos protos/*.proto",
+    "protoc": "protoc --proto_path=protos --js_out=import_style=commonjs,binary:./wwwroot/generated --grpc-web_out=import_style=commonjs,mode=grpcwebtext:./wwwroot/generated protos/*.proto && npm run protoc:ts",
+    "protoc:ts": "protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --ts_out=service=grpc-web:./wwwroot/generated --proto_path=protos protos/*.proto",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc --build",
     "clean": "tsc --build --clean",
@@ -21,6 +22,7 @@
     "@types/node": "^24.0.7",
     "eslint": "^9.30.0",
     "protoc-gen-grpc-web": "^1.5.0",
+    "ts-protoc-gen": "^0.15.0",
     "typescript": "^5.8.3"
   }
  


### PR DESCRIPTION
## Summary
- add `ts-protoc-gen` plugin as a dev dependency
- break out TypeScript generation into `protoc:ts` script
- use the new script from `protoc`

This resolves a missing plugin error when running `npm run protoc:ts` on Windows.

## Testing
- `npm view ts-protoc-gen version`

------
https://chatgpt.com/codex/tasks/task_e_6861f8cc32a48320b7ef2fac4ef7cf72