### PR TITLE
Switch web demo to google grpc-web

### DIFF
--- a/src/demo/TypeScriptMonsterClicker/wwwroot/app.js
+++ b/src/demo/TypeScriptMonsterClicker/wwwroot/app.js
@@ -9,13 +9,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const grpc_web_1 = require("@improbable-eng/grpc-web");
-const GameViewModelService_pb_service_1 = require("./generated/GameViewModelService_pb_service");
+const GameViewModelServiceServiceClientPb_1 = require("./generated/GameViewModelServiceServiceClientPb");
 const GameViewModelRemoteClient_1 = require("./GameViewModelRemoteClient");
 const grpcHost = 'http://localhost:50052';
-const grpcClient = new GameViewModelService_pb_service_1.GameViewModelServiceClient(grpcHost, {
-    transport: grpc_web_1.grpc.CrossBrowserHttpTransport({ withCredentials: false })
-});
+const grpcClient = new GameViewModelServiceServiceClientPb_1.GameViewModelServiceClient(grpcHost);
 const vm = new GameViewModelRemoteClient_1.GameViewModelRemoteClient(grpcClient);
 function render() {
     return __awaiter(this, void 0, void 0, function* () {

--- a/src/demo/TypeScriptMonsterClicker/wwwroot/app.ts
+++ b/src/demo/TypeScriptMonsterClicker/wwwroot/app.ts
@@ -1,11 +1,8 @@
-import { grpc } from '@improbable-eng/grpc-web';
-import { GameViewModelServiceClient } from './generated/GameViewModelService_pb_service';
+import { GameViewModelServiceClient } from './generated/GameViewModelServiceServiceClientPb';
 import { GameViewModelRemoteClient } from './GameViewModelRemoteClient';
 
 const grpcHost = 'http://localhost:50052';
-const grpcClient = new GameViewModelServiceClient(grpcHost, {
-    transport: grpc.CrossBrowserHttpTransport({ withCredentials: false })
-});
+const grpcClient = new GameViewModelServiceClient(grpcHost);
 const vm = new GameViewModelRemoteClient(grpcClient);
 
 async function render() {


### PR DESCRIPTION
## Summary
- update `app.ts` to use the google `grpc-web` package
- adjust compiled JS

## Testing
- `dotnet test` *(fails: command not found)*
- `npm ci` *(fails: ENETUNREACH github.com)*

------
https://chatgpt.com/codex/tasks/task_e_6862896898a08320acdb6e562d387011