### PR TITLE
Fix grpc client import in TypeScript demo

### DIFF
--- a/src/demo/TypeScriptMonsterClicker/wwwroot/app.ts
+++ b/src/demo/TypeScriptMonsterClicker/wwwroot/app.ts
@@ -1,4 +1,4 @@
-import { GameViewModelServiceClient } from './generated/GameViewModelServiceServiceClientPb';
+import { GameViewModelServiceClient } from './generated/GameViewModelService_pb_service';
 import { GameViewModelRemoteClient } from './GameViewModelRemoteClient';
 
 const grpcHost = 'http://localhost:50052';


### PR DESCRIPTION
## Summary
- fix `app.ts` to use the correct gRPC-Web client

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build` *(fails: protoc cannot find google protos)*

------
https://chatgpt.com/codex/tasks/task_e_68628e5c4c9c83209fe29ce8f4bfa209