### PR TITLE
Update TypeScript client generator for grpc-web

### DIFF
--- a/src/GrpcRemoteMvvvmTsClientGen/Program.cs
+++ b/src/GrpcRemoteMvvvmTsClientGen/Program.cs
@@ -125,7 +125,7 @@ namespace GrpcRemoteMvvmTsClientGen
         {
             var sb = new System.Text.StringBuilder();
             sb.AppendLine($"// Auto-generated TypeScript client for {vmName}");
-            sb.AppendLine($"import {{ {serviceName}Client }} from './generated/{serviceName}_pb_service';");
+            sb.AppendLine($"import {{ {serviceName}Client }} from './generated/{serviceName}ServiceClientPb';");
             var requestTypes = string.Join(", ", commands.Select(c => c.MethodName + "Request").Distinct());
             if (!string.IsNullOrWhiteSpace(requestTypes))
             {
@@ -153,11 +153,7 @@ namespace GrpcRemoteMvvmTsClientGen
             sb.AppendLine("    }");
             sb.AppendLine();
             sb.AppendLine("    async initializeRemote(): Promise<void> {");
-            sb.AppendLine($"        const state = await new Promise<{vmName}State>((resolve, reject) => {{");
-            sb.AppendLine("            this.grpcClient.getState(new Empty(), (err, res) => {");
-            sb.AppendLine("                if (err) reject(err); else resolve(res!);");
-            sb.AppendLine("            });");
-            sb.AppendLine("        });");
+            sb.AppendLine($"        const state = await this.grpcClient.getState(new Empty());");
             foreach (var prop in properties)
             {
                 sb.AppendLine($"        this.{ToCamelCase(prop.Name)} = (state as any)['{ToSnakeCase(prop.Name)}'];");
@@ -167,11 +163,7 @@ namespace GrpcRemoteMvvmTsClientGen
             sb.AppendLine();
             // Method to refresh state without altering connection status
             sb.AppendLine("    async refreshState(): Promise<void> {");
-            sb.AppendLine($"        const state = await new Promise<{vmName}State>((resolve, reject) => {{");
-            sb.AppendLine("            this.grpcClient.getState(new Empty(), (err, res) => {");
-            sb.AppendLine("                if (err) reject(err); else resolve(res!);");
-            sb.AppendLine("            });");
-            sb.AppendLine("        });");
+            sb.AppendLine($"        const state = await this.grpcClient.getState(new Empty());");
             foreach (var prop in properties)
             {
                 sb.AppendLine($"        this.{ToCamelCase(prop.Name)} = (state as any)['{ToSnakeCase(prop.Name)}'];");
@@ -182,11 +174,7 @@ namespace GrpcRemoteMvvmTsClientGen
             sb.AppendLine("        const req = new UpdatePropertyValueRequest();");
             sb.AppendLine("        req.setPropertyName(propertyName);");
             sb.AppendLine("        req.setNewValue(this.createAnyValue(value));");
-            sb.AppendLine("        await new Promise<void>((resolve, reject) => {");
-            sb.AppendLine("            this.grpcClient.updatePropertyValue(req, (err) => {");
-            sb.AppendLine("                if (err) reject(err); else resolve();");
-            sb.AppendLine("            });");
-            sb.AppendLine("        });");
+            sb.AppendLine("        await this.grpcClient.updatePropertyValue(req);");
             sb.AppendLine("    }");
             sb.AppendLine();
             sb.AppendLine("    private createAnyValue(value: any): Any {");
@@ -219,11 +207,7 @@ namespace GrpcRemoteMvvmTsClientGen
                 {
                     sb.AppendLine($"        (req as any)['{ToSnakeCase(p.Name)}'] = {ToCamelCase(p.Name)};");
                 }
-                sb.AppendLine("        await new Promise<void>((resolve, reject) => {");
-                sb.AppendLine($"            this.grpcClient.{ToCamelCase(cmd.MethodName)}(req, (err) => {{");
-                sb.AppendLine("                if (err) reject(err); else resolve();");
-                sb.AppendLine("            });");
-                sb.AppendLine("        });");
+                sb.AppendLine($"        await this.grpcClient.{ToCamelCase(cmd.MethodName)}(req);");
                 sb.AppendLine("    }");
             }
             sb.AppendLine("}");

--- a/src/demo/TypeScriptMonsterClicker/wwwroot/GameViewModelRemoteClient.ts
+++ b/src/demo/TypeScriptMonsterClicker/wwwroot/GameViewModelRemoteClient.ts
@@ -1,5 +1,5 @@
 // Auto-generated TypeScript client for GameViewModel
-import { GameViewModelServiceClient } from './generated/GameViewModelService_pb_service';
+import { GameViewModelServiceClient } from './generated/GameViewModelServiceServiceClientPb';
 import { GameViewModelState, UpdatePropertyValueRequest, SubscribeRequest, AttackMonsterRequest, SpecialAttackAsyncRequest, ResetGameRequest } from './generated/GameViewModelService_pb';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { Any } from 'google-protobuf/google/protobuf/any_pb';
@@ -23,11 +23,7 @@ export class GameViewModelRemoteClient {
     }
 
     async initializeRemote(): Promise<void> {
-        const state = await new Promise<GameViewModelState>((resolve, reject) => {
-            this.grpcClient.getState(new Empty(), (err, res) => {
-                if (err) reject(err); else resolve(res!);
-            });
-        });
+        const state = await this.grpcClient.getState(new Empty());
         this.monsterName = (state as any)['monster_name'];
         this.monsterMaxHealth = (state as any)['monster_max_health'];
         this.monsterCurrentHealth = (state as any)['monster_current_health'];
@@ -40,11 +36,7 @@ export class GameViewModelRemoteClient {
     }
 
     async refreshState(): Promise<void> {
-        const state = await new Promise<GameViewModelState>((resolve, reject) => {
-            this.grpcClient.getState(new Empty(), (err, res) => {
-                if (err) reject(err); else resolve(res!);
-            });
-        });
+        const state = await this.grpcClient.getState(new Empty());
         this.monsterName = (state as any)['monster_name'];
         this.monsterMaxHealth = (state as any)['monster_max_health'];
         this.monsterCurrentHealth = (state as any)['monster_current_health'];
@@ -59,11 +51,7 @@ export class GameViewModelRemoteClient {
         const req = new UpdatePropertyValueRequest();
         req.setPropertyName(propertyName);
         req.setNewValue(this.createAnyValue(value));
-        await new Promise<void>((resolve, reject) => {
-            this.grpcClient.updatePropertyValue(req, (err) => {
-                if (err) reject(err); else resolve();
-            });
-        });
+        await this.grpcClient.updatePropertyValue(req);
     }
 
     private createAnyValue(value: any): Any {
@@ -88,26 +76,14 @@ export class GameViewModelRemoteClient {
 
     async attackMonster(): Promise<void> {
         const req = new AttackMonsterRequest();
-        await new Promise<void>((resolve, reject) => {
-            this.grpcClient.attackMonster(req, (err) => {
-                if (err) reject(err); else resolve();
-            });
-        });
+        await this.grpcClient.attackMonster(req);
     }
     async specialAttackAsync(): Promise<void> {
         const req = new SpecialAttackAsyncRequest();
-        await new Promise<void>((resolve, reject) => {
-            this.grpcClient.specialAttackAsync(req, (err) => {
-                if (err) reject(err); else resolve();
-            });
-        });
+        await this.grpcClient.specialAttackAsync(req);
     }
     async resetGame(): Promise<void> {
         const req = new ResetGameRequest();
-        await new Promise<void>((resolve, reject) => {
-            this.grpcClient.resetGame(req, (err) => {
-                if (err) reject(err); else resolve();
-            });
-        });
+        await this.grpcClient.resetGame(req);
     }
 }


### PR DESCRIPTION
## Summary
- update `GrpcRemoteMvvmTsClientGen` to target grpc-web generated stubs
- adjust sample generated `GameViewModelRemoteClient.ts`

## Testing
- `dotnet build` *(fails: command not found)*
- `npm run build` *(fails: protoc include errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862934cf22083208e4306836f6d0521