### PR TITLE
Fix TypeScript client generator

### DIFF
--- a/src/GrpcRemoteMvvvmTsClientGen/Program.cs
+++ b/src/GrpcRemoteMvvvmTsClientGen/Program.cs
@@ -156,7 +156,7 @@ namespace GrpcRemoteMvvmTsClientGen
             sb.AppendLine($"        const state = await this.grpcClient.getState(new Empty());");
             foreach (var prop in properties)
             {
-                sb.AppendLine($"        this.{ToCamelCase(prop.Name)} = (state as any)['{ToSnakeCase(prop.Name)}'];");
+                sb.AppendLine($"        this.{ToCamelCase(prop.Name)} = (state as any).get{prop.Name}();");
             }
             sb.AppendLine("        this.connectionStatus = 'Connected';");
             sb.AppendLine("    }");
@@ -166,7 +166,7 @@ namespace GrpcRemoteMvvmTsClientGen
             sb.AppendLine($"        const state = await this.grpcClient.getState(new Empty());");
             foreach (var prop in properties)
             {
-                sb.AppendLine($"        this.{ToCamelCase(prop.Name)} = (state as any)['{ToSnakeCase(prop.Name)}'];");
+                sb.AppendLine($"        this.{ToCamelCase(prop.Name)} = (state as any).get{prop.Name}();");
             }
             sb.AppendLine("    }");
             sb.AppendLine();
@@ -205,7 +205,7 @@ namespace GrpcRemoteMvvmTsClientGen
                 sb.AppendLine($"        const req = new {reqType}();");
                 foreach (var p in cmd.Parameters)
                 {
-                    sb.AppendLine($"        (req as any)['{ToSnakeCase(p.Name)}'] = {ToCamelCase(p.Name)};");
+                    sb.AppendLine($"        req.set{ToPascalCase(p.Name)}({ToCamelCase(p.Name)});");
                 }
                 sb.AppendLine($"        await this.grpcClient.{ToCamelCase(cmd.MethodName)}(req);");
                 sb.AppendLine("    }");
@@ -230,6 +230,12 @@ namespace GrpcRemoteMvvmTsClientGen
         {
             if (string.IsNullOrEmpty(s) || char.IsLower(s[0])) return s;
             return char.ToLowerInvariant(s[0]) + s.Substring(1);
+        }
+
+        static string ToPascalCase(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return s;
+            return char.ToUpperInvariant(s[0]) + s.Substring(1);
         }
 
         static string ToSnakeCase(string s)

--- a/src/demo/TypeScriptMonsterClicker/src/GameViewModelRemoteClient.ts
+++ b/src/demo/TypeScriptMonsterClicker/src/GameViewModelRemoteClient.ts
@@ -24,27 +24,27 @@ export class GameViewModelRemoteClient {
 
     async initializeRemote(): Promise<void> {
         const state = await this.grpcClient.getState(new Empty());
-        this.monsterName = (state as any)['monster_name'];
-        this.monsterMaxHealth = (state as any)['monster_max_health'];
-        this.monsterCurrentHealth = (state as any)['monster_current_health'];
-        this.playerDamage = (state as any)['player_damage'];
-        this.gameMessage = (state as any)['game_message'];
-        this.isMonsterDefeated = (state as any)['is_monster_defeated'];
-        this.canUseSpecialAttack = (state as any)['can_use_special_attack'];
-        this.isSpecialAttackOnCooldown = (state as any)['is_special_attack_on_cooldown'];
+        this.monsterName = (state as any).getMonsterName();
+        this.monsterMaxHealth = (state as any).getMonsterMaxHealth();
+        this.monsterCurrentHealth = (state as any).getMonsterCurrentHealth();
+        this.playerDamage = (state as any).getPlayerDamage();
+        this.gameMessage = (state as any).getGameMessage();
+        this.isMonsterDefeated = (state as any).getIsMonsterDefeated();
+        this.canUseSpecialAttack = (state as any).getCanUseSpecialAttack();
+        this.isSpecialAttackOnCooldown = (state as any).getIsSpecialAttackOnCooldown();
         this.connectionStatus = 'Connected';
     }
 
     async refreshState(): Promise<void> {
         const state = await this.grpcClient.getState(new Empty());
-        this.monsterName = (state as any)['monster_name'];
-        this.monsterMaxHealth = (state as any)['monster_max_health'];
-        this.monsterCurrentHealth = (state as any)['monster_current_health'];
-        this.playerDamage = (state as any)['player_damage'];
-        this.gameMessage = (state as any)['game_message'];
-        this.isMonsterDefeated = (state as any)['is_monster_defeated'];
-        this.canUseSpecialAttack = (state as any)['can_use_special_attack'];
-        this.isSpecialAttackOnCooldown = (state as any)['is_special_attack_on_cooldown'];
+        this.monsterName = (state as any).getMonsterName();
+        this.monsterMaxHealth = (state as any).getMonsterMaxHealth();
+        this.monsterCurrentHealth = (state as any).getMonsterCurrentHealth();
+        this.playerDamage = (state as any).getPlayerDamage();
+        this.gameMessage = (state as any).getGameMessage();
+        this.isMonsterDefeated = (state as any).getIsMonsterDefeated();
+        this.canUseSpecialAttack = (state as any).getCanUseSpecialAttack();
+        this.isSpecialAttackOnCooldown = (state as any).getIsSpecialAttackOnCooldown();
     }
 
     async updatePropertyValue(propertyName: string, value: any): Promise<void> {


### PR DESCRIPTION
## Summary
- generate getter based state access in TypeScript client
- update command parameter handling
- expose helper for PascalCase names
- update example GameViewModelRemoteClient.ts

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862ea0c567c8320b7d8b783f3a64575