### PR TITLE
Fix TS client special attack timing

### DIFF
--- a/src/demo/TypeScriptMonsterClicker/src/app.ts
+++ b/src/demo/TypeScriptMonsterClicker/src/app.ts
@@ -42,6 +42,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     (document.getElementById('special-btn') as HTMLButtonElement).addEventListener('click', async () => {
         await vm.specialAttackAsync();
+        // Special attack executes asynchronously on the server. Give it a
+        // moment to update the ViewModel before refreshing the client state.
+        await new Promise(r => setTimeout(r, 800));
         await vm.refreshState();
         await render();
     });


### PR DESCRIPTION
## Summary
- in the TypeScript demo, delay the refresh after calling the special attack so the async server logic has time to run

## Testing
- `npm install` *(fails: ENETUNREACH when downloading protoc)*

------
https://chatgpt.com/codex/tasks/task_e_6862f161dd188320bbc5bf06c600b6e7