### PR TITLE
Fix awaiting async commands

### DIFF
--- a/src/GrpcRemoteMvvmGenerator/GrpcRemoteMvvmGenerator.cs
+++ b/src/GrpcRemoteMvvmGenerator/GrpcRemoteMvvmGenerator.cs
@@ -466,7 +466,7 @@ namespace PeakSWC.MvvmSourceGenerator
                 sb.AppendLine("        {");
                 sb.AppendLine("            Debug.WriteLine(\"[GrpcService:" + vmName + $"] Executing command {cmd.MethodName}.\");");
                 sb.AppendLine("            try {");
-                sb.AppendLine("                await _dispatcher.InvokeAsync(async () => {");
+                sb.AppendLine("                await await _dispatcher.InvokeAsync(async () => {");
                 string commandPropertyAccess = $"_viewModel.{cmd.CommandPropertyName}";
                 if (cmd.IsAsync)
                 {


### PR DESCRIPTION
## Summary
- ensure async relay commands on server wait until completion

## Testing
- `npm run test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862ff5ee3fc8320b2ed3f04b1a4362f