### PR TITLE
Add GameViewModel generator tests

### DIFF
--- a/test/GameViewModel/GameViewModelTests.csproj
+++ b/test/GameViewModel/GameViewModelTests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/GrpcRemoteMvvmModelUtil/GrpcRemoteMvvmModelUtil.csproj" />
+    <ProjectReference Include="../../src/RemoteMvvmTool/RemoteMvvmTool.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="expected/*" />
+    <Compile Remove="expected/*.cs" />
+  </ItemGroup>
+
+</Project>

--- a/test/GameViewModel/GlobalUsings.cs
+++ b/test/GameViewModel/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/test/GameViewModel/UnitTest1.cs
+++ b/test/GameViewModel/UnitTest1.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using GrpcRemoteMvvmModelUtil;
+using Xunit;
+
+public class GameViewModelGenerationTests
+{
+    private static async Task<(string Proto,string Server,string Client,string Ts)> GenerateAsync()
+    {
+        string root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
+        string vmFile = Path.Combine(root, "src","demo","MonsterClicker","ViewModels","GameViewModel.cs");
+        string attrSource = await File.ReadAllTextAsync(Path.Combine(root, "src","GrpcRemoteMvvmGenerator","attributes","GenerateGrpcRemoteAttribute.cs"));
+        var references = new[]{typeof(object).GetTypeInfo().Assembly.Location, typeof(Console).GetTypeInfo().Assembly.Location};
+        var (sym,name,props,cmds,comp) = await ViewModelAnalyzer.AnalyzeAsync(new[]{vmFile},
+            "CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute",
+            "CommunityToolkit.Mvvm.Input.RelayCommandAttribute",
+            "PeakSWC.Mvvm.Remote.GenerateGrpcRemoteAttribute",
+            references,
+            attrSource,
+            "GenerateGrpcRemoteAttribute.cs");
+        Assert.NotNull(sym);
+        const string protoNs = "MonsterClicker.ViewModels.Protos";
+        const string serviceName = "GameViewModelService";
+        var proto = Generators.GenerateProto(protoNs, serviceName, name, props, cmds, comp);
+        var server = Generators.GenerateServer(name, protoNs, serviceName, props, cmds);
+        var client = Generators.GenerateClient(name, protoNs, serviceName, props, cmds);
+        var ts = Generators.GenerateTypeScriptClient(name, protoNs, serviceName, props, cmds);
+        return (proto, server, client, ts);
+    }
+
+    [Fact]
+    public async Task ProtoMatchesExpected()
+    {
+        var (proto,_,_,_) = await GenerateAsync();
+        string root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
+        var expected = await File.ReadAllTextAsync(Path.Combine(root,"test","GameViewModel","expected","GameViewModelService.proto"));
+        Assert.Equal(expected, proto);
+    }
+
+    [Fact]
+    public async Task ServerMatchesExpected()
+    {
+        var (_,server,_,_) = await GenerateAsync();
+        string root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
+        var expected = await File.ReadAllTextAsync(Path.Combine(root,"test","GameViewModel","expected","GameViewModelGrpcServiceImpl.cs"));
+        Assert.Equal(expected, server);
+    }
+
+    [Fact]
+    public async Task ClientMatchesExpected()
+    {
+        var (_,_,client,_) = await GenerateAsync();
+        string root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
+        var expected = await File.ReadAllTextAsync(Path.Combine(root,"test","GameViewModel","expected","GameViewModelRemoteClient.cs"));
+        Assert.Equal(expected, client);
+    }
+
+    [Fact]
+    public async Task TypeScriptMatchesExpected()
+    {
+        var (_,_,_,ts) = await GenerateAsync();
+        string root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
+        var expected = await File.ReadAllTextAsync(Path.Combine(root,"test","GameViewModel","expected","GameViewModelRemoteClient.ts"));
+        Assert.Equal(expected, ts);
+    }
+}

--- a/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
+++ b/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
@@ -1,0 +1,22 @@
+using Grpc.Core;
+using MonsterClicker.ViewModels.Protos;
+using Google.Protobuf.WellKnownTypes;
+
+public class GameViewModelGrpcServiceImpl : GameViewModelService.GameViewModelServiceBase
+{
+  private readonly GameViewModel _vm;
+  public GameViewModelGrpcServiceImpl(GameViewModel vm) => _vm = vm;
+  public override Task<GameViewModelState> GetState(Empty request, ServerCallContext context)
+  {
+    var state = new GameViewModelState();
+    state.MonsterName = _vm.MonsterName;
+    state.MonsterMaxHealth = _vm.MonsterMaxHealth;
+    state.MonsterCurrentHealth = _vm.MonsterCurrentHealth;
+    state.PlayerDamage = _vm.PlayerDamage;
+    state.GameMessage = _vm.GameMessage;
+    state.IsMonsterDefeated = _vm.IsMonsterDefeated;
+    state.CanUseSpecialAttack = _vm.CanUseSpecialAttack;
+    state.IsSpecialAttackOnCooldown = _vm.IsSpecialAttackOnCooldown;
+    return Task.FromResult(state);
+  }
+}

--- a/test/GameViewModel/expected/GameViewModelRemoteClient.cs
+++ b/test/GameViewModel/expected/GameViewModelRemoteClient.cs
@@ -1,0 +1,16 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Grpc.Net.Client;
+using MonsterClicker.ViewModels.Protos;
+
+public partial class GameViewModelRemoteClient : ObservableObject
+{
+  public string MonsterName { get; private set; }
+  public int MonsterMaxHealth { get; private set; }
+  public int MonsterCurrentHealth { get; private set; }
+  public int PlayerDamage { get; private set; }
+  public string GameMessage { get; private set; }
+  public bool IsMonsterDefeated { get; private set; }
+  public bool CanUseSpecialAttack { get; private set; }
+  public bool IsSpecialAttackOnCooldown { get; private set; }
+  public GameViewModelRemoteClient(GameViewModelService.GameViewModelServiceClient client) {}
+}

--- a/test/GameViewModel/expected/GameViewModelRemoteClient.ts
+++ b/test/GameViewModel/expected/GameViewModelRemoteClient.ts
@@ -1,0 +1,12 @@
+// Auto-generated TypeScript client for GameViewModel
+export class GameViewModelRemoteClient {
+  monsterName: any;
+  monsterMaxHealth: any;
+  monsterCurrentHealth: any;
+  playerDamage: any;
+  gameMessage: any;
+  isMonsterDefeated: any;
+  canUseSpecialAttack: any;
+  isSpecialAttackOnCooldown: any;
+  constructor(public grpcClient: any) {}
+}

--- a/test/GameViewModel/expected/GameViewModelService.proto
+++ b/test/GameViewModel/expected/GameViewModelService.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+option csharp_namespace = "MonsterClicker.ViewModels.Protos";
+import "google/protobuf/empty.proto";
+import "google/protobuf/any.proto";
+
+message GameViewModelState {
+  string monster_name = 1;
+  string monster_max_health = 2;
+  string monster_current_health = 3;
+  string player_damage = 4;
+  string game_message = 5;
+  string is_monster_defeated = 6;
+  string can_use_special_attack = 7;
+  string is_special_attack_on_cooldown = 8;
+}
+
+message UpdatePropertyValueRequest {
+  string property_name = 1;
+  google.protobuf.Any new_value = 2;
+}
+
+message PropertyChangeNotification {
+  string property_name = 1;
+  google.protobuf.Any new_value = 2;
+}
+
+message AttackMonsterRequest {}
+message AttackMonsterResponse {}
+
+message SpecialAttackAsyncRequest {}
+message SpecialAttackAsyncResponse {}
+
+message ResetGameRequest {}
+message ResetGameResponse {}
+
+service GameViewModelService {
+  rpc GetState (google.protobuf.Empty) returns (GameViewModelState);
+  rpc UpdatePropertyValue (UpdatePropertyValueRequest) returns (google.protobuf.Empty);
+  rpc SubscribeToPropertyChanges (google.protobuf.Empty) returns (stream PropertyChangeNotification);
+  rpc AttackMonster (AttackMonsterRequest) returns (AttackMonsterResponse);
+  rpc SpecialAttackAsync (SpecialAttackAsyncRequest) returns (SpecialAttackAsyncResponse);
+  rpc ResetGame (ResetGameRequest) returns (ResetGameResponse);
+  rpc Ping (google.protobuf.Empty) returns (google.protobuf.Empty);
+}


### PR DESCRIPTION
## Summary
- add test project `GameViewModelTests`
- include expected output for GameViewModel generation
- tests generate proto, server, client and TypeScript files and compare to expected

## Testing
- `dotnet test test/GameViewModel/GameViewModelTests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6867bec41a548320b6b2aed273eefd85