### PR TITLE
Add SampleViewModel generation tests

### DIFF
--- a/test/SampleViewModel/GenerationTests.cs
+++ b/test/SampleViewModel/GenerationTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using GrpcRemoteMvvmModelUtil;
+
+public class GenerationTests
+{
+    static async Task<(string vmName, string[] outputs)> GenerateAsync(string outputDir)
+    {
+        Directory.CreateDirectory(outputDir);
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
+        var vmFile = Path.Combine(root, "src","tests","MvvmClass","SampleViewModel.cs");
+        var attrSource = await File.ReadAllTextAsync(Path.Combine(root, "src","GrpcRemoteMvvmGenerator","attributes","GenerateGrpcRemoteAttribute.cs"));
+        var refs = LoadDefaultRefs();
+        var (sym,name,props,cmds,comp) = await ViewModelAnalyzer.AnalyzeAsync(new[]{vmFile},
+            "CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute",
+            "CommunityToolkit.Mvvm.Input.RelayCommandAttribute",
+            "PeakSWC.Mvvm.Remote.GenerateGrpcRemoteAttribute",
+            refs,
+            attrSource,
+            "embedded://PeakSWC/Mvvm/Remote/GenerateGrpcRemoteAttribute.cs");
+        if(sym==null) throw new Exception("ViewModel not found");
+        File.WriteAllText(Path.Combine(outputDir,"SampleViewModelService.proto"), Generators.GenerateProto("SampleApp.ViewModels.Protos","CounterService",name,props,cmds,comp));
+        File.WriteAllText(Path.Combine(outputDir,"SampleViewModelRemoteClient.ts"), Generators.GenerateTypeScriptClient(name,"SampleApp.ViewModels.Protos","CounterService",props,cmds));
+        File.WriteAllText(Path.Combine(outputDir,"SampleViewModelGrpcServiceImpl.cs"), Generators.GenerateServer(name,"SampleApp.ViewModels.Protos","CounterService",props,cmds));
+        File.WriteAllText(Path.Combine(outputDir,"SampleViewModelRemoteClient.cs"), Generators.GenerateClient(name,"SampleApp.ViewModels.Protos","CounterService",props,cmds));
+        return (name, Directory.GetFiles(outputDir));
+    }
+
+    static System.Collections.Generic.List<string> LoadDefaultRefs()
+    {
+        var list = new System.Collections.Generic.List<string>();
+        string? tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if(tpa!=null)
+        {
+            foreach(var p in tpa.Split(Path.PathSeparator))
+                if(!string.IsNullOrEmpty(p) && File.Exists(p)) list.Add(p);
+        }
+        return list;
+    }
+
+    [Fact]
+    public async Task GeneratedOutputs_MatchExpected()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var (_, files) = await GenerateAsync(tempDir);
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
+        var expectedDir = Path.Combine(root, "test","SampleViewModel","expected");
+        foreach(var expected in Directory.GetFiles(expectedDir))
+        {
+            var generatedPath = Path.Combine(tempDir, Path.GetFileName(expected));
+            Assert.True(File.Exists(generatedPath), $"Expected output {generatedPath} not found");
+            Assert.Equal(File.ReadAllText(expected).Trim().Replace("\r\n","\n"), File.ReadAllText(generatedPath).Trim().Replace("\r\n","\n"));
+        }
+    }
+}

--- a/test/SampleViewModel/SampleViewModel.Tests.csproj
+++ b/test/SampleViewModel/SampleViewModel.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="expected/*.cs" />
+    <None Include="expected/*.cs" />
+    <ProjectReference Include="../../src/RemoteMvvmTool/RemoteMvvmTool.csproj" />
+    <ProjectReference Include="../../src/GrpcRemoteMvvmModelUtil/GrpcRemoteMvvmModelUtil.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/test/SampleViewModel/Usings.cs
+++ b/test/SampleViewModel/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
@@ -1,0 +1,16 @@
+using Grpc.Core;
+using SampleApp.ViewModels.Protos;
+using Google.Protobuf.WellKnownTypes;
+
+public class SampleViewModelGrpcServiceImpl : CounterService.CounterServiceBase
+{
+  private readonly SampleViewModel _vm;
+  public SampleViewModelGrpcServiceImpl(SampleViewModel vm) => _vm = vm;
+  public override Task<SampleViewModelState> GetState(Empty request, ServerCallContext context)
+  {
+    var state = new SampleViewModelState();
+    state.Name = _vm.Name;
+    state.Count = _vm.Count;
+    return Task.FromResult(state);
+  }
+}

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
@@ -1,0 +1,10 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Grpc.Net.Client;
+using SampleApp.ViewModels.Protos;
+
+public partial class SampleViewModelRemoteClient : ObservableObject
+{
+  public string Name { get; private set; }
+  public int Count { get; private set; }
+  public SampleViewModelRemoteClient(CounterService.CounterServiceClient client) {}
+}

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
@@ -1,0 +1,6 @@
+// Auto-generated TypeScript client for SampleViewModel
+export class SampleViewModelRemoteClient {
+  name: any;
+  count: any;
+  constructor(public grpcClient: any) {}
+}

--- a/test/SampleViewModel/expected/SampleViewModelService.proto
+++ b/test/SampleViewModel/expected/SampleViewModelService.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+option csharp_namespace = "SampleApp.ViewModels.Protos";
+import "google/protobuf/empty.proto";
+import "google/protobuf/any.proto";
+
+message SampleViewModelState {
+  string name = 1;
+  string count = 2;
+}
+
+message UpdatePropertyValueRequest {
+  string property_name = 1;
+  google.protobuf.Any new_value = 2;
+}
+
+message PropertyChangeNotification {
+  string property_name = 1;
+  google.protobuf.Any new_value = 2;
+}
+
+message IncrementCountRequest {}
+message IncrementCountResponse {}
+
+message DelayedIncrementAsyncRequest {}
+message DelayedIncrementAsyncResponse {}
+
+message SetNameToValueRequest {}
+message SetNameToValueResponse {}
+
+service CounterService {
+  rpc GetState (google.protobuf.Empty) returns (SampleViewModelState);
+  rpc UpdatePropertyValue (UpdatePropertyValueRequest) returns (google.protobuf.Empty);
+  rpc SubscribeToPropertyChanges (google.protobuf.Empty) returns (stream PropertyChangeNotification);
+  rpc IncrementCount (IncrementCountRequest) returns (IncrementCountResponse);
+  rpc DelayedIncrementAsync (DelayedIncrementAsyncRequest) returns (DelayedIncrementAsyncResponse);
+  rpc SetNameToValue (SetNameToValueRequest) returns (SetNameToValueResponse);
+  rpc Ping (google.protobuf.Empty) returns (google.protobuf.Empty);
+}


### PR DESCRIPTION
## Summary
- add a new xUnit test project under `test/SampleViewModel`
- generate expected outputs for `SampleViewModel` with `RemoteMvvmTool` helpers
- compare generated outputs with expected files

## Testing
- `dotnet test test/SampleViewModel/SampleViewModel.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6867bfa6cb748320bd836a0c0ea6a35c