### PR TITLE
Implement TS client generation

### DIFF
--- a/src/RemoteMvvmTool/Generators.cs
+++ b/src/RemoteMvvmTool/Generators.cs
@@ -75,12 +75,174 @@ public static class Generators
     {
         var sb = new StringBuilder();
         sb.AppendLine($"// Auto-generated TypeScript client for {vmName}");
-        sb.AppendLine("export class " + vmName + "RemoteClient {");
+        sb.AppendLine($"import {{ {serviceName}Client }} from './generated/{serviceName}ServiceClientPb';");
+        var requestTypes = string.Join(", ", cmds.Select(c => c.MethodName + "Request").Distinct());
+        if (!string.IsNullOrWhiteSpace(requestTypes))
+        {
+            sb.AppendLine($"import {{ {vmName}State, UpdatePropertyValueRequest, SubscribeRequest, PropertyChangeNotification, ConnectionStatusResponse, ConnectionStatus, {requestTypes} }} from './generated/{serviceName}_pb';");
+        }
+        else
+        {
+            sb.AppendLine($"import {{ {vmName}State, UpdatePropertyValueRequest, SubscribeRequest, PropertyChangeNotification, ConnectionStatusResponse, ConnectionStatus }} from './generated/{serviceName}_pb';");
+        }
+        sb.AppendLine("import * as grpcWeb from 'grpc-web';");
+        sb.AppendLine("import { Empty } from 'google-protobuf/google/protobuf/empty_pb';");
+        sb.AppendLine("import { Any } from 'google-protobuf/google/protobuf/any_pb';");
+        sb.AppendLine("import { StringValue, Int32Value, BoolValue } from 'google-protobuf/google/protobuf/wrappers_pb';");
+        sb.AppendLine();
+        sb.AppendLine($"export class {vmName}RemoteClient {{");
+        sb.AppendLine($"    private readonly grpcClient: {serviceName}Client;");
+        sb.AppendLine("    private propertyStream?: grpcWeb.ClientReadableStream<PropertyChangeNotification>;");
+        sb.AppendLine("    private pingIntervalId?: any;");
+        sb.AppendLine("    private changeCallbacks: Array<() => void> = [];");
+        sb.AppendLine();
         foreach (var p in props)
         {
-            sb.AppendLine($"  {ToCamel(p.Name)}: any;");
+            sb.AppendLine($"    {ToCamelCase(p.Name)}: any;");
         }
-        sb.AppendLine("  constructor(public grpcClient: any) {}");
+        sb.AppendLine("    connectionStatus: string = 'Unknown';");
+        sb.AppendLine();
+        sb.AppendLine("    addChangeListener(cb: () => void): void {");
+        sb.AppendLine("        this.changeCallbacks.push(cb);");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    private notifyChange(): void {");
+        sb.AppendLine("        this.changeCallbacks.forEach(cb => cb());");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine($"    constructor(grpcClient: {serviceName}Client) {{");
+        sb.AppendLine("        this.grpcClient = grpcClient;");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    async initializeRemote(): Promise<void> {");
+        sb.AppendLine("        const state = await this.grpcClient.getState(new Empty());");
+        foreach (var p in props)
+        {
+            sb.AppendLine($"        this.{ToCamelCase(p.Name)} = (state as any).get{p.Name}();");
+        }
+        sb.AppendLine("        this.connectionStatus = 'Connected';");
+        sb.AppendLine("        this.notifyChange();");
+        sb.AppendLine("        this.startListeningToPropertyChanges();");
+        sb.AppendLine("        this.startPingLoop();");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    async refreshState(): Promise<void> {");
+        sb.AppendLine("        const state = await this.grpcClient.getState(new Empty());");
+        foreach (var p in props)
+        {
+            sb.AppendLine($"        this.{ToCamelCase(p.Name)} = (state as any).get{p.Name}();");
+        }
+        sb.AppendLine("        this.notifyChange();");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    async updatePropertyValue(propertyName: string, value: any): Promise<void> {");
+        sb.AppendLine("        const req = new UpdatePropertyValueRequest();");
+        sb.AppendLine("        req.setPropertyName(propertyName);");
+        sb.AppendLine("        req.setNewValue(this.createAnyValue(value));");
+        sb.AppendLine("        await this.grpcClient.updatePropertyValue(req);");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    private createAnyValue(value: any): Any {");
+        sb.AppendLine("        const anyVal = new Any();");
+        sb.AppendLine("        if (typeof value === 'string') {");
+        sb.AppendLine("            const wrapper = new StringValue();");
+        sb.AppendLine("            wrapper.setValue(value);");
+        sb.AppendLine("            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.StringValue');");
+        sb.AppendLine("        } else if (typeof value === 'number' && Number.isInteger(value)) {");
+        sb.AppendLine("            const wrapper = new Int32Value();");
+        sb.AppendLine("            wrapper.setValue(value);");
+        sb.AppendLine("            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');");
+        sb.AppendLine("        } else if (typeof value === 'boolean') {");
+        sb.AppendLine("            const wrapper = new BoolValue();");
+        sb.AppendLine("            wrapper.setValue(value);");
+        sb.AppendLine("            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.BoolValue');");
+        sb.AppendLine("        } else {");
+        sb.AppendLine("            throw new Error('Unsupported value type');");
+        sb.AppendLine("        }");
+        sb.AppendLine("        return anyVal;");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        foreach (var cmd in cmds)
+        {
+            var paramList = string.Join(", ", cmd.Parameters.Select(p => ToCamelCase(p.Name) + ": any"));
+            var reqType = cmd.MethodName + "Request";
+            sb.AppendLine($"    async {ToCamelCase(cmd.MethodName)}({paramList}): Promise<void> {{");
+            sb.AppendLine($"        const req = new {reqType}();");
+            foreach (var p in cmd.Parameters)
+            {
+                sb.AppendLine($"        req.set{ToPascalCase(p.Name)}({ToCamelCase(p.Name)});");
+            }
+            sb.AppendLine($"        await this.grpcClient.{ToCamelCase(cmd.MethodName)}(req);");
+            sb.AppendLine("    }");
+        }
+        sb.AppendLine();
+        sb.AppendLine("    private startPingLoop(): void {");
+        sb.AppendLine("        if (this.pingIntervalId) return;");
+        sb.AppendLine("        this.pingIntervalId = setInterval(async () => {");
+        sb.AppendLine("            try {");
+        sb.AppendLine("                const resp: ConnectionStatusResponse = await this.grpcClient.ping(new Empty());");
+        sb.AppendLine("                if (resp.getStatus() === ConnectionStatus.CONNECTED) {");
+        sb.AppendLine("                    if (this.connectionStatus !== 'Connected') {");
+        sb.AppendLine("                        await this.refreshState();");
+        sb.AppendLine("                    }");
+        sb.AppendLine("                    this.connectionStatus = 'Connected';");
+        sb.AppendLine("                } else {");
+        sb.AppendLine("                    this.connectionStatus = 'Disconnected';");
+        sb.AppendLine("                }");
+        sb.AppendLine("            } catch {");
+        sb.AppendLine("                this.connectionStatus = 'Disconnected';");
+        sb.AppendLine("            }");
+        sb.AppendLine("            this.notifyChange();");
+        sb.AppendLine("        }, 5000);");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    private startListeningToPropertyChanges(): void {");
+        sb.AppendLine("        const req = new SubscribeRequest();");
+        sb.AppendLine("        req.setClientId(Math.random().toString());");
+        sb.AppendLine("        this.propertyStream = this.grpcClient.subscribeToPropertyChanges(req);");
+        sb.AppendLine("        this.propertyStream.on('data', (update: PropertyChangeNotification) => {");
+        sb.AppendLine("            const anyVal = update.getNewValue();");
+        sb.AppendLine("            switch (update.getPropertyName()) {");
+        foreach (var p in props)
+        {
+            var wrapper = GetWrapperType(p.TypeString);
+            if (wrapper != null)
+            {
+                string unpack = wrapper switch
+                {
+                    "StringValue" => "StringValue.deserializeBinary",
+                    "Int32Value" => "Int32Value.deserializeBinary",
+                    "BoolValue" => "BoolValue.deserializeBinary",
+                    _ => ""
+                };
+                sb.AppendLine($"                case '{p.Name}':");
+                sb.AppendLine($"                    this.{ToCamelCase(p.Name)} = anyVal?.unpack({unpack}, 'google.protobuf.{wrapper}')?.getValue();");
+                sb.AppendLine("                    break;");
+            }
+        }
+        sb.AppendLine("            }");
+        sb.AppendLine("            this.notifyChange();");
+        sb.AppendLine("        });");
+        sb.AppendLine("        this.propertyStream.on('error', () => {");
+        sb.AppendLine("            this.propertyStream = undefined;");
+        sb.AppendLine("            setTimeout(() => this.startListeningToPropertyChanges(), 1000);");
+        sb.AppendLine("        });");
+        sb.AppendLine("        this.propertyStream.on('end', () => {");
+        sb.AppendLine("            this.propertyStream = undefined;");
+        sb.AppendLine("            setTimeout(() => this.startListeningToPropertyChanges(), 1000);");
+        sb.AppendLine("        });");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    dispose(): void {");
+        sb.AppendLine("        if (this.propertyStream) {");
+        sb.AppendLine("            this.propertyStream.cancel();");
+        sb.AppendLine("            this.propertyStream = undefined;");
+        sb.AppendLine("        }");
+        sb.AppendLine("        if (this.pingIntervalId) {");
+        sb.AppendLine("            clearInterval(this.pingIntervalId);");
+        sb.AppendLine("            this.pingIntervalId = undefined;");
+        sb.AppendLine("        }");
+        sb.AppendLine("    }");
         sb.AppendLine("}");
         return sb.ToString();
     }
@@ -129,4 +291,15 @@ public static class Generators
 
     private static string ToSnake(string s) => string.Concat(s.Select((c,i) => i>0 && char.IsUpper(c)?"_"+char.ToLower(c).ToString():char.ToLower(c).ToString()));
     private static string ToCamel(string s) => string.IsNullOrEmpty(s)?s:char.ToLowerInvariant(s[0])+s.Substring(1);
+    private static string ToCamelCase(string s) => string.IsNullOrEmpty(s) || char.IsLower(s[0]) ? s : char.ToLowerInvariant(s[0]) + s[1..];
+    private static string ToPascalCase(string s) => string.IsNullOrEmpty(s) ? s : char.ToUpperInvariant(s[0]) + s[1..];
+    private static string? GetWrapperType(string typeName) => typeName switch
+    {
+        "string" => "StringValue",
+        "int" => "Int32Value",
+        "System.Int32" => "Int32Value",
+        "bool" => "BoolValue",
+        "System.Boolean" => "BoolValue",
+        _ => null
+    };
 }

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
@@ -1,6 +1,147 @@
 // Auto-generated TypeScript client for SampleViewModel
+import { CounterServiceClient } from './generated/CounterServiceServiceClientPb';
+import { SampleViewModelState, UpdatePropertyValueRequest, SubscribeRequest, PropertyChangeNotification, ConnectionStatusResponse, ConnectionStatus, IncrementCountRequest, DelayedIncrementAsyncRequest, SetNameToValueRequest } from './generated/CounterService_pb';
+import * as grpcWeb from 'grpc-web';
+import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
+import { Any } from 'google-protobuf/google/protobuf/any_pb';
+import { StringValue, Int32Value, BoolValue } from 'google-protobuf/google/protobuf/wrappers_pb';
+
 export class SampleViewModelRemoteClient {
-  name: any;
-  count: any;
-  constructor(public grpcClient: any) {}
+    private readonly grpcClient: CounterServiceClient;
+    private propertyStream?: grpcWeb.ClientReadableStream<PropertyChangeNotification>;
+    private pingIntervalId?: any;
+    private changeCallbacks: Array<() => void> = [];
+
+    name: any;
+    count: any;
+    connectionStatus: string = 'Unknown';
+
+    addChangeListener(cb: () => void): void {
+        this.changeCallbacks.push(cb);
+    }
+
+    private notifyChange(): void {
+        this.changeCallbacks.forEach(cb => cb());
+    }
+
+    constructor(grpcClient: CounterServiceClient) {
+        this.grpcClient = grpcClient;
+    }
+
+    async initializeRemote(): Promise<void> {
+        const state = await this.grpcClient.getState(new Empty());
+        this.name = (state as any).getName();
+        this.count = (state as any).getCount();
+        this.connectionStatus = 'Connected';
+        this.notifyChange();
+        this.startListeningToPropertyChanges();
+        this.startPingLoop();
+    }
+
+    async refreshState(): Promise<void> {
+        const state = await this.grpcClient.getState(new Empty());
+        this.name = (state as any).getName();
+        this.count = (state as any).getCount();
+        this.notifyChange();
+    }
+
+    async updatePropertyValue(propertyName: string, value: any): Promise<void> {
+        const req = new UpdatePropertyValueRequest();
+        req.setPropertyName(propertyName);
+        req.setNewValue(this.createAnyValue(value));
+        await this.grpcClient.updatePropertyValue(req);
+    }
+
+    private createAnyValue(value: any): Any {
+        const anyVal = new Any();
+        if (typeof value === 'string') {
+            const wrapper = new StringValue();
+            wrapper.setValue(value);
+            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.StringValue');
+        } else if (typeof value === 'number' && Number.isInteger(value)) {
+            const wrapper = new Int32Value();
+            wrapper.setValue(value);
+            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');
+        } else if (typeof value === 'boolean') {
+            const wrapper = new BoolValue();
+            wrapper.setValue(value);
+            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.BoolValue');
+        } else {
+            throw new Error('Unsupported value type');
+        }
+        return anyVal;
+    }
+
+    async incrementCount(): Promise<void> {
+        const req = new IncrementCountRequest();
+        await this.grpcClient.incrementCount(req);
+    }
+    async delayedIncrementAsync(delayMilliseconds: any): Promise<void> {
+        const req = new DelayedIncrementAsyncRequest();
+        req.setDelayMilliseconds(delayMilliseconds);
+        await this.grpcClient.delayedIncrementAsync(req);
+    }
+    async setNameToValue(value: any): Promise<void> {
+        const req = new SetNameToValueRequest();
+        req.setValue(value);
+        await this.grpcClient.setNameToValue(req);
+    }
+
+    private startPingLoop(): void {
+        if (this.pingIntervalId) return;
+        this.pingIntervalId = setInterval(async () => {
+            try {
+                const resp: ConnectionStatusResponse = await this.grpcClient.ping(new Empty());
+                if (resp.getStatus() === ConnectionStatus.CONNECTED) {
+                    if (this.connectionStatus !== 'Connected') {
+                        await this.refreshState();
+                    }
+                    this.connectionStatus = 'Connected';
+                } else {
+                    this.connectionStatus = 'Disconnected';
+                }
+            } catch {
+                this.connectionStatus = 'Disconnected';
+            }
+            this.notifyChange();
+        }, 5000);
+    }
+
+    private startListeningToPropertyChanges(): void {
+        const req = new SubscribeRequest();
+        req.setClientId(Math.random().toString());
+        this.propertyStream = this.grpcClient.subscribeToPropertyChanges(req);
+        this.propertyStream.on('data', (update: PropertyChangeNotification) => {
+            const anyVal = update.getNewValue();
+            switch (update.getPropertyName()) {
+                case 'Name':
+                    this.name = anyVal?.unpack(StringValue.deserializeBinary, 'google.protobuf.StringValue')?.getValue();
+                    break;
+                case 'Count':
+                    this.count = anyVal?.unpack(Int32Value.deserializeBinary, 'google.protobuf.Int32Value')?.getValue();
+                    break;
+            }
+            this.notifyChange();
+        });
+        this.propertyStream.on('error', () => {
+            this.propertyStream = undefined;
+            setTimeout(() => this.startListeningToPropertyChanges(), 1000);
+        });
+        this.propertyStream.on('end', () => {
+            this.propertyStream = undefined;
+            setTimeout(() => this.startListeningToPropertyChanges(), 1000);
+        });
+    }
+
+    dispose(): void {
+        if (this.propertyStream) {
+            this.propertyStream.cancel();
+            this.propertyStream = undefined;
+        }
+        if (this.pingIntervalId) {
+            clearInterval(this.pingIntervalId);
+            this.pingIntervalId = undefined;
+        }
+    }
 }
+


### PR DESCRIPTION
## Summary
- expand `GenerateTypeScriptClient` to produce functional client code
- update expected output for SampleViewModel

## Testing
- `dotnet test test/SampleViewModel/SampleViewModel.Tests.csproj -c Release` *(fails: ViewModel file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e5ebea2c8320be11c3615269b6c2