### PR TITLE
Add post-build tool install

### DIFF
--- a/src/RemoteMvvmTool/RemoteMvvmTool.csproj
+++ b/src/RemoteMvvmTool/RemoteMvvmTool.csproj
@@ -21,4 +21,7 @@
     <ProjectReference Include="../GrpcRemoteMvvmModelUtil/GrpcRemoteMvvmModelUtil.csproj" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
+  <Target Name="InstallTool" AfterTargets="Build">
+    <Exec Command="dotnet tool install --global --add-source $(OutputPath) $(PackageId) --version $(Version) || dotnet tool update --global --add-source $(OutputPath) $(PackageId) --version $(Version)" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
- install the RemoteMvvm tool automatically after building the project

## Testing
- `dotnet restore` *(fails: Unable to find package PeakSWC.MvvmSourceGenerator)*
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696465fe848320a9eb5ecbc6913164