### PR TITLE
Make CLI not depend on attribute

### DIFF
--- a/src/GrpcRemoteMvvmModelUtil/Helpers.cs
+++ b/src/GrpcRemoteMvvmModelUtil/Helpers.cs
@@ -39,5 +39,17 @@ namespace GrpcRemoteMvvmModelUtil
 
             return simpleName == targetShort || shortName == targetShort || shortName == fullyQualifiedAttributeName;
         }
+
+        public static bool InheritsFrom(INamedTypeSymbol? typeSymbol, string baseTypeFullName)
+        {
+            while (typeSymbol != null && typeSymbol.SpecialType != SpecialType.System_Object)
+            {
+                var fqn = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
+                if (fqn == baseTypeFullName)
+                    return true;
+                typeSymbol = typeSymbol.BaseType;
+            }
+            return false;
+        }
     }
 }

--- a/src/RemoteMvvmTool/GameViewModel.cs
+++ b/src/RemoteMvvmTool/GameViewModel.cs
@@ -1,15 +1,11 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using PeakSWC.Mvvm.Remote; // Your custom attribute's namespace
 using System;
 using System.Threading.Tasks;
 // using System.Windows; // No longer directly using WPF dispatcher here
 
 namespace MonsterClicker.ViewModels
 {
-    [GenerateGrpcRemoteAttribute("MonsterClicker.ViewModels.Protos","GameViewModelService",
-            ServerImplNamespace = "MonsterClicker.GrpcServices",
-            ClientProxyNamespace = "MonsterClicker.RemoteClients")]
     public partial class GameViewModel : ObservableObject
     {
         [ObservableProperty]


### PR DESCRIPTION
## Summary
- update `ViewModelAnalyzer` to optionally find a view model without using `GenerateGrpcRemoteAttribute`
- add helper to detect inheritance from `ObservableObject`
- rework `RemoteMvvmTool` to accept namespaces from command line
- drop `GenerateGrpcRemoteAttribute` usage in tool's sample

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697f7024b08320b9494c077cbc3b9d