### PR TITLE
Run RemoteMvvmTool during MonsterClicker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,4 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 /test/GameViewModel/actual
+src/demo/MonsterClicker/RemoteGenerated/

--- a/src/demo/MonsterClicker/MonsterClicker.csproj
+++ b/src/demo/MonsterClicker/MonsterClicker.csproj
@@ -55,8 +55,23 @@
 		</MvvmViewModelProtoSource>
 	</ItemGroup>
 
-	<ItemGroup>
-		<Folder Include="protos\" />
-	</ItemGroup>
+  <ItemGroup>
+    <Folder Include="protos\" />
+  </ItemGroup>
+
+  <!-- Run RemoteMvvmTool when the ViewModel or generated files change -->
+  <ItemGroup>
+    <RemoteMvvmViewModel Include="ViewModels\GameViewModel.cs" />
+    <RemoteGenerated Include="RemoteGenerated\**\*" />
+  </ItemGroup>
+
+  <Target Name="RunRemoteMvvmTool"
+          Inputs="@(RemoteMvvmViewModel)"
+          Outputs="@(RemoteGenerated)">
+    <Exec Command="dotnet run --project ..\..\RemoteMvvmTool\RemoteMvvmTool.csproj --output \&quot;$(ProjectDir)RemoteGenerated\&quot; @(RemoteMvvmViewModel->'\"%(FullPath)\"')" />
+  </Target>
+
+  <Target Name="BeforeBuild" DependsOnTargets="RunRemoteMvvmTool" />
 
 </Project>
+


### PR DESCRIPTION
## Summary
- run `RemoteMvvmTool` from MonsterClicker build
- keep generated files out of git
- check the `RemoteGenerated` folder instead of using a stamp file

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869809a97bc83209c382c805a0b84e3