### PR TITLE
Fix generator output for typed protos and update tests

### DIFF
--- a/src/RemoteMvvmTool/Generators.cs
+++ b/src/RemoteMvvmTool/Generators.cs
@@ -16,7 +16,23 @@ public static class Generators
         int field = 1;
         foreach (var p in props)
         {
-            body.AppendLine($"  string {ToSnake(p.Name)} = {field++};");
+            string wkt = GetProtoWellKnownTypeFor(p.FullTypeSymbol!);
+            string protoType = wkt switch
+            {
+                "StringValue" => "string",
+                "BoolValue" => "bool",
+                "Int32Value" => "int32",
+                "Int64Value" => "int64",
+                "UInt32Value" => "uint32",
+                "UInt64Value" => "uint64",
+                "FloatValue" => "float",
+                "DoubleValue" => "double",
+                "BytesValue" => "bytes",
+                "Timestamp" => "google.protobuf.Timestamp",
+                "Duration" => "google.protobuf.Duration",
+                _ => "string"
+            };
+            body.AppendLine($"  {protoType} {ToSnake(p.Name)} = {field++}; // Original C#: {p.TypeString} {p.Name}");
         }
         body.AppendLine("}");
         body.AppendLine();
@@ -256,6 +272,31 @@ public static class Generators
         sb.AppendLine("            clearInterval(this.pingIntervalId);");
         sb.AppendLine("            this.pingIntervalId = undefined;");
         sb.AppendLine("        }");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    public static string GenerateOptions()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("namespace PeakSWC.Mvvm.Remote");
+        sb.AppendLine("{");
+        sb.AppendLine("    public class ServerOptions");
+        sb.AppendLine("    {");
+        sb.AppendLine("        public int Port { get; set; } = MonsterClicker.NetworkConfig.Port;");
+        sb.AppendLine("        public bool UseHttps { get; set; } = true;");
+        sb.AppendLine("        public string? CorsPolicyName { get; set; } = \"AllowAll\";");
+        sb.AppendLine("        public string[]? AllowedOrigins { get; set; } = null;");
+        sb.AppendLine("        public string[]? AllowedHeaders { get; set; } = null;");
+        sb.AppendLine("        public string[]? AllowedMethods { get; set; } = null;");
+        sb.AppendLine("        public string[]? ExposedHeaders { get; set; } = null;");
+        sb.AppendLine("        public string? LogLevel { get; set; } = \"Debug\";");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    public class ClientOptions");
+        sb.AppendLine("    {");
+        sb.AppendLine("        public string Address { get; set; } = MonsterClicker.NetworkConfig.ServerAddress;");
         sb.AppendLine("    }");
         sb.AppendLine("}");
         return sb.ToString();

--- a/src/RemoteMvvmTool/Program.cs
+++ b/src/RemoteMvvmTool/Program.cs
@@ -95,6 +95,11 @@ public class Program
                 var client = Generators.GenerateClient(result.ViewModelName, protoNamespace, serviceName, result.Properties, result.Commands, clientNamespace);
                 await File.WriteAllTextAsync(Path.Combine(output, result.ViewModelName + "RemoteClient.cs"), client);
             }
+            if (genServer || genClient)
+            {
+                var opts = Generators.GenerateOptions();
+                await File.WriteAllTextAsync(Path.Combine(output, "GrpcRemoteOptions.cs"), opts);
+            }
         }, generateOption, outputOption, protoOutputOption, vmArgument, protoNsOption, serviceNameOption, clientNsOption);
 
         return await root.InvokeAsync(args);

--- a/src/demo/MonsterClicker/protos/GameViewModelService.proto
+++ b/src/demo/MonsterClicker/protos/GameViewModelService.proto
@@ -9,14 +9,14 @@ import "google/protobuf/empty.proto";
 
 // Message representing the full state of the GameViewModel
 message GameViewModelState {
-  string monster_name = 1;
-  string monster_max_health = 2;
-  string monster_current_health = 3;
-  string player_damage = 4;
-  string game_message = 5;
-  string is_monster_defeated = 6;
-  string can_use_special_attack = 7;
-  string is_special_attack_on_cooldown = 8;
+  string monster_name = 1; // Original C#: string MonsterName
+  int32 monster_max_health = 2; // Original C#: int MonsterMaxHealth
+  int32 monster_current_health = 3; // Original C#: int MonsterCurrentHealth
+  int32 player_damage = 4; // Original C#: int PlayerDamage
+  string game_message = 5; // Original C#: string GameMessage
+  bool is_monster_defeated = 6; // Original C#: bool IsMonsterDefeated
+  bool can_use_special_attack = 7; // Original C#: bool CanUseSpecialAttack
+  bool is_special_attack_on_cooldown = 8; // Original C#: bool IsSpecialAttackOnCooldown
 }
 
 message UpdatePropertyValueRequest {

--- a/test/GameViewModel/UnitTest1.cs
+++ b/test/GameViewModel/UnitTest1.cs
@@ -44,14 +44,20 @@ namespace GameViewModel
             string root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
             string vmFile = Path.Combine(root, "src", "demo", "MonsterClicker", "ViewModels", "GameViewModel.cs");
             string attrSource = await File.ReadAllTextAsync(Path.Combine(root, "src", "GrpcRemoteMvvmGenerator", "attributes", "GenerateGrpcRemoteAttribute.cs"));
-            var references = new[] { typeof(object).GetTypeInfo().Assembly.Location, typeof(Console).GetTypeInfo().Assembly.Location };
+            var references = new[]
+            {
+                typeof(object).GetTypeInfo().Assembly.Location,
+                typeof(Console).GetTypeInfo().Assembly.Location,
+                typeof(CommunityToolkit.Mvvm.ComponentModel.ObservableObject).Assembly.Location
+            };
             var (sym, name, props, cmds, comp) = await ViewModelAnalyzer.AnalyzeAsync(new[] { vmFile },
                 "CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute",
                 "CommunityToolkit.Mvvm.Input.RelayCommandAttribute",
                 "PeakSWC.Mvvm.Remote.GenerateGrpcRemoteAttribute",
                 references,
                 attrSource,
-                "GenerateGrpcRemoteAttribute.cs");
+                "GenerateGrpcRemoteAttribute.cs",
+                requireGenerateAttribute: false);
             Assert.NotNull(sym);
             const string protoNs = "MonsterClicker.ViewModels.Protos";
             const string serviceName = "GameViewModelService";

--- a/test/GameViewModel/expected/GameViewModelService.proto
+++ b/test/GameViewModel/expected/GameViewModelService.proto
@@ -9,14 +9,14 @@ import "google/protobuf/empty.proto";
 
 // Message representing the full state of the GameViewModel
 message GameViewModelState {
-  string monster_name = 1;
-  string monster_max_health = 2;
-  string monster_current_health = 3;
-  string player_damage = 4;
-  string game_message = 5;
-  string is_monster_defeated = 6;
-  string can_use_special_attack = 7;
-  string is_special_attack_on_cooldown = 8;
+  string monster_name = 1; // Original C#: string MonsterName
+  int32 monster_max_health = 2; // Original C#: int MonsterMaxHealth
+  int32 monster_current_health = 3; // Original C#: int MonsterCurrentHealth
+  int32 player_damage = 4; // Original C#: int PlayerDamage
+  string game_message = 5; // Original C#: string GameMessage
+  bool is_monster_defeated = 6; // Original C#: bool IsMonsterDefeated
+  bool can_use_special_attack = 7; // Original C#: bool CanUseSpecialAttack
+  bool is_special_attack_on_cooldown = 8; // Original C#: bool IsSpecialAttackOnCooldown
 }
 
 message UpdatePropertyValueRequest {

--- a/test/SampleViewModel/GenerationTests.cs
+++ b/test/SampleViewModel/GenerationTests.cs
@@ -38,7 +38,7 @@ public class GenerationTests
     {
         Directory.CreateDirectory(outputDir);
         var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
-        var vmFile = Path.Combine(root, "src","tests","MvvmClass","SampleViewModel.cs");
+        var vmFile = Path.Combine(root, "test","SampleViewModel","SampleViewModel.cs");
         var attrSource = await File.ReadAllTextAsync(Path.Combine(root, "src","GrpcRemoteMvvmGenerator","attributes","GenerateGrpcRemoteAttribute.cs"));
         var refs = LoadDefaultRefs();
         var (sym,name,props,cmds,comp) = await ViewModelAnalyzer.AnalyzeAsync(new[]{vmFile},

--- a/test/SampleViewModel/SampleViewModel.Tests.csproj
+++ b/test/SampleViewModel/SampleViewModel.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Compile Remove="expected/*.cs" />
+    <Compile Remove="actual/**" />
     <None Include="expected/*.cs" />
 	  <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <ProjectReference Include="../../src/RemoteMvvmTool/RemoteMvvmTool.csproj" />

--- a/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
@@ -1,16 +1,185 @@
 using Grpc.Core;
 using SampleApp.ViewModels.Protos;
 using Google.Protobuf.WellKnownTypes;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Threading.Channels;
+using System.Windows.Threading;
 
-public class SampleViewModelGrpcServiceImpl : CounterService.CounterServiceBase
+public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServiceBase
 {
-  private readonly SampleViewModel _vm;
-  public SampleViewModelGrpcServiceImpl(SampleViewModel vm) => _vm = vm;
-  public override Task<SampleViewModelState> GetState(Empty request, ServerCallContext context)
-  {
-    var state = new SampleViewModelState();
-    state.Name = _vm.Name;
-    state.Count = _vm.Count;
-    return Task.FromResult(state);
-  }
+    public static event System.EventHandler<int>? ClientCountChanged;
+    private static int _clientCount = -1;
+    public static int ClientCount
+    {
+        get => _clientCount;
+        private set
+        {
+            if (_clientCount != value)
+            {
+                _clientCount = value;
+                ClientCountChanged?.Invoke(null, value);
+            }
+        }
+    }
+
+    static SampleViewModelGrpcServiceImpl()
+    {
+        ClientCount = 0;
+    }
+
+    private readonly SampleViewModel _viewModel;
+    private static readonly ConcurrentDictionary<IServerStreamWriter<SampleApp.ViewModels.Protos.PropertyChangeNotification>, Channel<SampleApp.ViewModels.Protos.PropertyChangeNotification>> _subscriberChannels = new ConcurrentDictionary<IServerStreamWriter<SampleApp.ViewModels.Protos.PropertyChangeNotification>, Channel<SampleApp.ViewModels.Protos.PropertyChangeNotification>>();
+    private readonly Dispatcher _dispatcher;
+
+    public SampleViewModelGrpcServiceImpl(SampleViewModel viewModel, Dispatcher dispatcher)
+    {
+        _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        if (_viewModel is INotifyPropertyChanged inpc) { inpc.PropertyChanged += ViewModel_PropertyChanged; }
+    }
+
+    public override Task<SampleViewModelState> GetState(Empty request, ServerCallContext context)
+    {
+        var state = new SampleViewModelState();
+        // Mapping property: Name to state.Name
+        try
+        {
+            var propValue = _viewModel.Name;
+            state.Name = propValue;
+        }
+        catch (Exception ex) { Debug.WriteLine("[GrpcService:SampleViewModel] Error mapping property Name to state.Name: " + ex.Message); }
+        // Mapping property: Count to state.Count
+        try
+        {
+            var propValue = _viewModel.Count;
+            state.Count = propValue;
+        }
+        catch (Exception ex) { Debug.WriteLine("[GrpcService:SampleViewModel] Error mapping property Count to state.Count: " + ex.Message); }
+        return Task.FromResult(state);
+    }
+
+    public override async Task SubscribeToPropertyChanges(SampleApp.ViewModels.Protos.SubscribeRequest request, IServerStreamWriter<SampleApp.ViewModels.Protos.PropertyChangeNotification> responseStream, ServerCallContext context)
+    {
+        var channel = Channel.CreateUnbounded<SampleApp.ViewModels.Protos.PropertyChangeNotification>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+        _subscriberChannels.TryAdd(responseStream, channel);
+        ClientCount = _subscriberChannels.Count;
+        try
+        {
+            await foreach (var notification in channel.Reader.ReadAllAsync(context.CancellationToken))
+            {
+                await responseStream.WriteAsync(notification);
+            }
+        }
+        finally
+        {
+            _subscriberChannels.TryRemove(responseStream, out _);
+            channel.Writer.TryComplete();
+            ClientCount = _subscriberChannels.Count;
+        }
+    }
+
+    public override Task<Empty> UpdatePropertyValue(SampleApp.ViewModels.Protos.UpdatePropertyValueRequest request, ServerCallContext context)
+    {
+        _dispatcher.Invoke(() => {
+            var propertyInfo = _viewModel.GetType().GetProperty(request.PropertyName);
+            if (propertyInfo != null && propertyInfo.CanWrite)
+            {
+                try {
+                    if (request.NewValue.Is(StringValue.Descriptor) && propertyInfo.PropertyType == typeof(string)) propertyInfo.SetValue(_viewModel, request.NewValue.Unpack<StringValue>().Value);
+                    else if (request.NewValue.Is(Int32Value.Descriptor) && propertyInfo.PropertyType == typeof(int)) propertyInfo.SetValue(_viewModel, request.NewValue.Unpack<Int32Value>().Value);
+                    else if (request.NewValue.Is(BoolValue.Descriptor) && propertyInfo.PropertyType == typeof(bool)) propertyInfo.SetValue(_viewModel, request.NewValue.Unpack<BoolValue>().Value);
+                    else { Debug.WriteLine("[GrpcService:SampleViewModel] UpdatePropertyValue: Unpacking not implemented for property " + request.PropertyName + " and type " + request.NewValue.TypeUrl + "."); }
+                } catch (Exception ex) { Debug.WriteLine("[GrpcService:SampleViewModel] Error setting property " + request.PropertyName + ": " + ex.Message); }
+            }
+            else { Debug.WriteLine("[GrpcService:SampleViewModel] UpdatePropertyValue: Property " + request.PropertyName + " not found or not writable."); }
+        });
+        return Task.FromResult(new Empty());
+    }
+
+    public override Task<ConnectionStatusResponse> Ping(Google.Protobuf.WellKnownTypes.Empty request, ServerCallContext context)
+    {
+        return Task.FromResult(new ConnectionStatusResponse { Status = ConnectionStatus.Connected });
+    }
+
+    public override async Task<SampleApp.ViewModels.Protos.IncrementCountResponse> IncrementCount(SampleApp.ViewModels.Protos.IncrementCountRequest request, ServerCallContext context)
+    {
+        try { await await _dispatcher.InvokeAsync(async () => {
+            var command = _viewModel.IncrementCountCommand as CommunityToolkit.Mvvm.Input.IRelayCommand;
+            if (command != null)
+            {
+                command.Execute(null);
+            }
+            else { Debug.WriteLine("[GrpcService:SampleViewModel] Command IncrementCountCommand not found or not IRelayCommand."); }
+        }); } catch (Exception ex) {
+        Debug.WriteLine("[GrpcService:SampleViewModel] Exception during command execution for IncrementCount: " + ex.ToString());
+        throw new RpcException(new Status(StatusCode.Internal, "Error executing command on server: " + ex.Message));
+        }
+        return new SampleApp.ViewModels.Protos.IncrementCountResponse();
+    }
+
+    public override async Task<SampleApp.ViewModels.Protos.DelayedIncrementAsyncResponse> DelayedIncrementAsync(SampleApp.ViewModels.Protos.DelayedIncrementAsyncRequest request, ServerCallContext context)
+    {
+        try { await await _dispatcher.InvokeAsync(async () => {
+            var command = _viewModel.DelayedIncrementCommand as CommunityToolkit.Mvvm.Input.IAsyncRelayCommand;
+            if (command != null)
+            {
+                var typedCommand = _viewModel.DelayedIncrementCommand as CommunityToolkit.Mvvm.Input.IAsyncRelayCommand<int>;
+                if (typedCommand != null) await typedCommand.ExecuteAsync(request.DelayMilliseconds); else await command.ExecuteAsync(request);
+            }
+            else { Debug.WriteLine("[GrpcService:SampleViewModel] Command DelayedIncrementCommand not found or not IAsyncRelayCommand."); }
+        }); } catch (Exception ex) {
+        Debug.WriteLine("[GrpcService:SampleViewModel] Exception during command execution for DelayedIncrementAsync: " + ex.ToString());
+        throw new RpcException(new Status(StatusCode.Internal, "Error executing command on server: " + ex.Message));
+        }
+        return new SampleApp.ViewModels.Protos.DelayedIncrementAsyncResponse();
+    }
+
+    public override async Task<SampleApp.ViewModels.Protos.SetNameToValueResponse> SetNameToValue(SampleApp.ViewModels.Protos.SetNameToValueRequest request, ServerCallContext context)
+    {
+        try { await await _dispatcher.InvokeAsync(async () => {
+            var command = _viewModel.SetNameToValueCommand as CommunityToolkit.Mvvm.Input.IRelayCommand;
+            if (command != null)
+            {
+                var typedCommand = _viewModel.SetNameToValueCommand as CommunityToolkit.Mvvm.Input.IRelayCommand<string?>;
+                if (typedCommand != null) typedCommand.Execute(request.Value); else command.Execute(request);
+            }
+            else { Debug.WriteLine("[GrpcService:SampleViewModel] Command SetNameToValueCommand not found or not IRelayCommand."); }
+        }); } catch (Exception ex) {
+        Debug.WriteLine("[GrpcService:SampleViewModel] Exception during command execution for SetNameToValue: " + ex.ToString());
+        throw new RpcException(new Status(StatusCode.Internal, "Error executing command on server: " + ex.Message));
+        }
+        return new SampleApp.ViewModels.Protos.SetNameToValueResponse();
+    }
+
+    private async void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (string.IsNullOrEmpty(e.PropertyName)) return;
+        object? newValue = null;
+        try { newValue = sender?.GetType().GetProperty(e.PropertyName)?.GetValue(sender); }
+        catch (Exception ex) { Debug.WriteLine("[GrpcService:SampleViewModel] Error getting property value for " + e.PropertyName + ": " + ex.Message); return; }
+
+        var notification = new SampleApp.ViewModels.Protos.PropertyChangeNotification { PropertyName = e.PropertyName };
+        if (newValue == null) notification.NewValue = Any.Pack(new Empty());
+        else if (newValue is string s) notification.NewValue = Any.Pack(new StringValue { Value = s });
+        else if (newValue is int i) notification.NewValue = Any.Pack(new Int32Value { Value = i });
+        else if (newValue is bool b) notification.NewValue = Any.Pack(new BoolValue { Value = b });
+        else if (newValue is double d) notification.NewValue = Any.Pack(new DoubleValue { Value = d });
+        else if (newValue is float f) notification.NewValue = Any.Pack(new FloatValue { Value = f });
+        else if (newValue is long l) notification.NewValue = Any.Pack(new Int64Value { Value = l });
+        else if (newValue is DateTime dt) notification.NewValue = Any.Pack(Timestamp.FromDateTime(dt.ToUniversalTime()));
+        else { Debug.WriteLine($"[GrpcService:SampleViewModel] PropertyChanged: Packing not implemented for type {(newValue?.GetType().FullName ?? "null")} of property {e.PropertyName}."); notification.NewValue = Any.Pack(new StringValue { Value = newValue.ToString() }); }
+
+        foreach (var channelWriter in _subscriberChannels.Values.Select(c => c.Writer))
+        {
+            try { await channelWriter.WriteAsync(notification); }
+            catch (ChannelClosedException) { Debug.WriteLine("[GrpcService:SampleViewModel] Channel closed for a subscriber, cannot write notification for '" + e.PropertyName + "'. Subscriber likely disconnected."); }
+            catch (Exception ex) { Debug.WriteLine("[GrpcService:SampleViewModel] Error writing to subscriber channel for '" + e.PropertyName + "': " + ex.Message); }
+        }
+    }
 }

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
@@ -1,10 +1,220 @@
+// Client Proxy ViewModel for SampleViewModel
+
+#nullable enable
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Grpc.Core;
 using Grpc.Net.Client;
 using SampleApp.ViewModels.Protos;
+using Google.Protobuf.WellKnownTypes;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Diagnostics;
+#if WPF_DISPATCHER
+using System.Windows;
+#endif
 
-public partial class SampleViewModelRemoteClient : ObservableObject
+namespace SampleApp.ViewModels.RemoteClients
 {
-  public string Name { get; private set; }
-  public int Count { get; private set; }
-  public SampleViewModelRemoteClient(CounterService.CounterServiceClient client) {}
+    public partial class SampleViewModelRemoteClient : ObservableObject, IDisposable
+    {
+        private readonly SampleApp.ViewModels.Protos.CounterService.CounterServiceClient _grpcClient;
+        private CancellationTokenSource _cts = new CancellationTokenSource();
+        private bool _isInitialized = false;
+        private bool _isDisposed = false;
+
+        private string _connectionStatus = "Unknown";
+        public string ConnectionStatus
+        {
+            get => _connectionStatus;
+            private set => SetProperty(ref _connectionStatus, value);
+        }
+
+        private string _name = default!;
+        public string Name
+        {
+            get => _name;
+            private set => SetProperty(ref _name, value);
+        }
+
+        private int _count = default!;
+        public int Count
+        {
+            get => _count;
+            private set => SetProperty(ref _count, value);
+        }
+
+        public IRelayCommand IncrementCountCommand { get; }
+        public IAsyncRelayCommand<int> DelayedIncrementCommand { get; }
+        public IRelayCommand<string?> SetNameToValueCommand { get; }
+
+        public SampleViewModelRemoteClient(SampleApp.ViewModels.Protos.CounterService.CounterServiceClient grpcClient)
+        {
+            _grpcClient = grpcClient ?? throw new ArgumentNullException(nameof(grpcClient));
+            IncrementCountCommand = new RelayCommand(RemoteExecute_IncrementCount);
+            DelayedIncrementCommand = new AsyncRelayCommand<int>(RemoteExecute_DelayedIncrementAsyncAsync);
+            SetNameToValueCommand = new RelayCommand<string?>(RemoteExecute_SetNameToValue);
+        }
+
+        private async Task StartPingLoopAsync()
+        {
+            string lastStatus = ConnectionStatus;
+            while (!_isDisposed)
+            {
+                try
+                {
+                    var response = await _grpcClient.PingAsync(new Google.Protobuf.WellKnownTypes.Empty(), cancellationToken: _cts.Token);
+                    if (response.Status == SampleApp.ViewModels.Protos.ConnectionStatus.Connected)
+                    {
+                        if (lastStatus != "Connected")
+                        {
+                            try
+                            {
+                                var state = await _grpcClient.GetStateAsync(new Empty(), cancellationToken: _cts.Token);
+                                this.Name = state.Name;
+                                this.Count = state.Count;
+                                Debug.WriteLine("[ClientProxy] State re-synced after reconnect.");
+                            }
+                            catch (Exception ex)
+                            {
+                                Debug.WriteLine($"[ClientProxy] Error re-syncing state after reconnect: {ex.Message}");
+                            }
+                        }
+                        ConnectionStatus = "Connected";
+                        lastStatus = "Connected";
+                    }
+                    else
+                    {
+                        ConnectionStatus = "Disconnected";
+                        lastStatus = "Disconnected";
+                    }
+                }
+                catch (Exception ex)
+                {
+                    ConnectionStatus = "Disconnected";
+                    lastStatus = "Disconnected";
+                    Debug.WriteLine($"[ClientProxy] Ping failed: {ex.Message}. Attempting to reconnect...");
+                }
+                await Task.Delay(5000);
+            }
+        }
+
+        public async Task InitializeRemoteAsync(CancellationToken cancellationToken = default)
+        {
+            if (_isInitialized || _isDisposed) return;
+            Debug.WriteLine("[SampleViewModelRemoteClient] Initializing...");
+            try
+            {
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
+                var state = await _grpcClient.GetStateAsync(new Empty(), cancellationToken: linkedCts.Token);
+                Debug.WriteLine("[SampleViewModelRemoteClient] Initial state received.");
+                this.Name = state.Name;
+                this.Count = state.Count;
+                _isInitialized = true;
+                Debug.WriteLine("[SampleViewModelRemoteClient] Initialized successfully.");
+                StartListeningToPropertyChanges(_cts.Token);
+                _ = StartPingLoopAsync();
+            }
+            catch (RpcException ex) { Debug.WriteLine("[ClientProxy:SampleViewModel] Failed to initialize: " + ex.Status.StatusCode + " - " + ex.Status.Detail); }
+            catch (OperationCanceledException) { Debug.WriteLine("[ClientProxy:SampleViewModel] Initialization cancelled."); }
+            catch (Exception ex) { Debug.WriteLine("[ClientProxy:SampleViewModel] Unexpected error during initialization: " + ex.Message); }
+        }
+
+        private void RemoteExecute_IncrementCount()
+        {
+            if (!_isInitialized || _isDisposed) { Debug.WriteLine("[ClientProxy:SampleViewModel] Not initialized or disposed, command IncrementCount skipped."); return; }
+            Debug.WriteLine("[ClientProxy:SampleViewModel] Executing command IncrementCount remotely...");
+            try
+            {
+                _ = _grpcClient.IncrementCountAsync(new SampleApp.ViewModels.Protos.IncrementCountRequest(), cancellationToken: _cts.Token);
+            }
+            catch (RpcException ex) { Debug.WriteLine("[ClientProxy:SampleViewModel] Error executing command IncrementCount: " + ex.Status.StatusCode + " - " + ex.Status.Detail); }
+            catch (OperationCanceledException) { Debug.WriteLine("[ClientProxy:SampleViewModel] Command IncrementCount cancelled."); }
+            catch (Exception ex) { Debug.WriteLine("[ClientProxy:SampleViewModel] Unexpected error executing command IncrementCount: " + ex.Message); }
+        }
+
+        private async Task RemoteExecute_DelayedIncrementAsyncAsync(int delayMilliseconds)
+        {
+            if (!_isInitialized || _isDisposed) { Debug.WriteLine("[ClientProxy:SampleViewModel] Not initialized or disposed, command DelayedIncrementAsync skipped."); return; }
+            Debug.WriteLine("[ClientProxy:SampleViewModel] Executing command DelayedIncrementAsync remotely...");
+            try
+            {
+                await _grpcClient.DelayedIncrementAsyncAsync(new SampleApp.ViewModels.Protos.DelayedIncrementAsyncRequest { DelayMilliseconds = delayMilliseconds }, cancellationToken: _cts.Token);
+            }
+            catch (RpcException ex) { Debug.WriteLine("[ClientProxy:SampleViewModel] Error executing command DelayedIncrementAsync: " + ex.Status.StatusCode + " - " + ex.Status.Detail); }
+            catch (OperationCanceledException) { Debug.WriteLine("[ClientProxy:SampleViewModel] Command DelayedIncrementAsync cancelled."); }
+            catch (Exception ex) { Debug.WriteLine("[ClientProxy:SampleViewModel] Unexpected error executing command DelayedIncrementAsync: " + ex.Message); }
+        }
+
+        private void RemoteExecute_SetNameToValue(string? value)
+        {
+            if (!_isInitialized || _isDisposed) { Debug.WriteLine("[ClientProxy:SampleViewModel] Not initialized or disposed, command SetNameToValue skipped."); return; }
+            Debug.WriteLine("[ClientProxy:SampleViewModel] Executing command SetNameToValue remotely...");
+            try
+            {
+                _ = _grpcClient.SetNameToValueAsync(new SampleApp.ViewModels.Protos.SetNameToValueRequest { Value = value }, cancellationToken: _cts.Token);
+            }
+            catch (RpcException ex) { Debug.WriteLine("[ClientProxy:SampleViewModel] Error executing command SetNameToValue: " + ex.Status.StatusCode + " - " + ex.Status.Detail); }
+            catch (OperationCanceledException) { Debug.WriteLine("[ClientProxy:SampleViewModel] Command SetNameToValue cancelled."); }
+            catch (Exception ex) { Debug.WriteLine("[ClientProxy:SampleViewModel] Unexpected error executing command SetNameToValue: " + ex.Message); }
+        }
+
+        private void StartListeningToPropertyChanges(CancellationToken cancellationToken)
+        {
+            _ = Task.Run(async () => 
+            {
+                if (_isDisposed) return;
+                Debug.WriteLine("[SampleViewModelRemoteClient] Starting property change listener...");
+                try
+                {
+                    var subscribeRequest = new SampleApp.ViewModels.Protos.SubscribeRequest { ClientId = Guid.NewGuid().ToString() };
+                    using var call = _grpcClient.SubscribeToPropertyChanges(subscribeRequest, cancellationToken: cancellationToken);
+                    Debug.WriteLine("[SampleViewModelRemoteClient] Subscribed to property changes. Waiting for updates...");
+                    int updateCount = 0;
+                    await foreach (var update in call.ResponseStream.ReadAllAsync(cancellationToken))
+                    {
+                        updateCount++;
+                        if (_isDisposed) { Debug.WriteLine("[SampleViewModelRemoteClient] Disposed during update " + updateCount + ", exiting property update loop."); break; }
+                        Debug.WriteLine($"[SampleViewModelRemoteClient] RAW UPDATE #" + updateCount + " RECEIVED: PropertyName=\"" + update.PropertyName + "\", ValueTypeUrl=\"" + (update.NewValue?.TypeUrl ?? "null_type_url") + "\"");
+                        Action updateAction = () => {
+                           try {
+                               Debug.WriteLine("[SampleViewModelRemoteClient] Dispatcher: Attempting to update \"" + update.PropertyName + "\" (Update #" + updateCount + ").");
+                               switch (update.PropertyName)
+                               {
+                                   case nameof(Name):
+                 if (update.NewValue!.Is(StringValue.Descriptor)) { var val = update.NewValue.Unpack<StringValue>().Value; Debug.WriteLine($"Updating Name from \"{this.Name}\" to '\"{val}\"."); this.Name = val; Debug.WriteLine($"After update, Name is '\"{this.Name}\"."); } else { Debug.WriteLine($"Mismatched descriptor for Name, expected StringValue."); } break;
+                                   case nameof(Count):
+                     if (update.NewValue!.Is(Int32Value.Descriptor)) { var val = update.NewValue.Unpack<Int32Value>().Value; Debug.WriteLine($"Updating Count from {this.Count} to {val}."); this.Count = val; Debug.WriteLine($"After update, Count is {this.Count}."); } else { Debug.WriteLine($"Mismatched descriptor for Count, expected Int32Value."); } break;
+                                   default: Debug.WriteLine($"[ClientProxy:SampleViewModel] Unknown property in notification: \"{update.PropertyName}\""); break;
+                               }
+                           } catch (Exception exInAction) { Debug.WriteLine($"[ClientProxy:SampleViewModel] EXCEPTION INSIDE updateAction for \"{update.PropertyName}\": " + exInAction.ToString()); }
+                        };
+                        #if WPF_DISPATCHER
+                        Application.Current?.Dispatcher.Invoke(updateAction);
+                        #else
+                        updateAction();
+                        #endif
+                        Debug.WriteLine("[SampleViewModelRemoteClient] Processed update #" + updateCount + " for \"" + update.PropertyName + "\". Still listening...");
+                    }
+                    Debug.WriteLine("[SampleViewModelRemoteClient] ReadAllAsync completed or cancelled after " + updateCount + " updates.");
+                }
+                catch (RpcException ex) when (ex.StatusCode == StatusCode.Cancelled) { Debug.WriteLine("[ClientProxy:SampleViewModel] Property subscription RpcException Cancelled."); }
+                catch (OperationCanceledException) { Debug.WriteLine($"[ClientProxy:SampleViewModel] Property subscription OperationCanceledException."); }
+                catch (Exception ex) { if (!_isDisposed) Debug.WriteLine($"[ClientProxy:SampleViewModel] Error in property listener: " + ex.GetType().Name + " - " + ex.Message + "\nStackTrace: " + ex.StackTrace); }
+                Debug.WriteLine("[SampleViewModelRemoteClient] Property change listener task finished.");
+            }, cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed) return;
+            _isDisposed = true;
+            Debug.WriteLine("[SampleViewModelRemoteClient] Disposing...");
+            _cts.Cancel();
+            _cts.Dispose();
+        }
+    }
 }

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
@@ -144,4 +144,3 @@ export class SampleViewModelRemoteClient {
         }
     }
 }
-

--- a/test/SampleViewModel/expected/SampleViewModelService.proto
+++ b/test/SampleViewModel/expected/SampleViewModelService.proto
@@ -1,16 +1,16 @@
-﻿syntax = "proto3";
+syntax = "proto3";
 
 package sampleapp_viewmodels_protos;
 
 option csharp_namespace = "SampleApp.ViewModels.Protos";
-import "google/protobuf/empty.proto";
+
 import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 
 // Message representing the full state of the SampleViewModel
 message SampleViewModelState {
-  string name = 1;
-  string count = 2;
+  string name = 1; // Original C#: string Name
+  int32 count = 2; // Original C#: int Count
 }
 
 message UpdatePropertyValueRequest {
@@ -26,9 +26,11 @@ message PropertyChangeNotification {
 message IncrementCountRequest {}
 message IncrementCountResponse {}
 
-message SetNameToValueResponse {
-  // Add fields here if the command returns data.
-}
+message DelayedIncrementAsyncRequest {}
+message DelayedIncrementAsyncResponse {}
+
+message SetNameToValueRequest {}
+message SetNameToValueResponse {}
 
 message SubscribeRequest {
   string client_id = 1;
@@ -44,14 +46,12 @@ message ConnectionStatusResponse {
   ConnectionStatus status = 1;
 }
 
-service SampleViewModelService {
+service CounterService {
   rpc GetState (google.protobuf.Empty) returns (SampleViewModelState);
-  rpc SubscribeToPropertyChanges (SubscribeRequest) returns (stream PropertyChangeNotification);
   rpc UpdatePropertyValue (UpdatePropertyValueRequest) returns (google.protobuf.Empty);
-  rpc SubscribeToPropertyChanges (google.protobuf.Empty) returns (stream PropertyChangeNotification);
+  rpc SubscribeToPropertyChanges (SubscribeRequest) returns (stream PropertyChangeNotification);
   rpc IncrementCount (IncrementCountRequest) returns (IncrementCountResponse);
   rpc DelayedIncrementAsync (DelayedIncrementAsyncRequest) returns (DelayedIncrementAsyncResponse);
   rpc SetNameToValue (SetNameToValueRequest) returns (SetNameToValueResponse);
   rpc Ping (google.protobuf.Empty) returns (ConnectionStatusResponse);
 }
-


### PR DESCRIPTION
## Summary
- generate correct proto field types in `RemoteMvvmTool`
- add generation of `ServerOptions` and `ClientOptions`
- emit options file when generating client or server
- update MonsterClicker proto with typed fields
- fix tests to run without the attribute requirement and update expected outputs

## Testing
- `dotnet test test/GameViewModel/GameViewModelTests.csproj --verbosity minimal`
- `dotnet test test/SampleViewModel/SampleViewModel.Tests.csproj --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68699965967083209992ef460a4905a5