### PR TITLE
Fix missing using in generated server

### DIFF
--- a/src/RemoteMvvmTool/Generators.cs
+++ b/src/RemoteMvvmTool/Generators.cs
@@ -302,11 +302,12 @@ public static class Generators
         return sb.ToString();
     }
 
-    public static string GenerateServer(string vmName, string protoNs, string serviceName, List<PropertyInfo> props, List<CommandInfo> cmds)
+    public static string GenerateServer(string vmName, string protoNs, string serviceName, List<PropertyInfo> props, List<CommandInfo> cmds, string viewModelNamespace)
     {
         var sb = new StringBuilder();
         sb.AppendLine("using Grpc.Core;");
         sb.AppendLine($"using {protoNs};");
+        sb.AppendLine($"using {viewModelNamespace};");
         sb.AppendLine("using Google.Protobuf.WellKnownTypes;");
         sb.AppendLine("using System;");
         sb.AppendLine("using System.Linq;");

--- a/src/RemoteMvvmTool/Program.cs
+++ b/src/RemoteMvvmTool/Program.cs
@@ -83,7 +83,8 @@ public class Program
             }
             if (genServer)
             {
-                var server = Generators.GenerateServer(result.ViewModelName, protoNamespace, serviceName, result.Properties, result.Commands);
+                var vmNamespace = result.ViewModelSymbol?.ContainingNamespace.ToDisplayString() ?? string.Empty;
+                var server = Generators.GenerateServer(result.ViewModelName, protoNamespace, serviceName, result.Properties, result.Commands, vmNamespace);
                 await File.WriteAllTextAsync(Path.Combine(output, result.ViewModelName + "GrpcServiceImpl.cs"), server);
             }
             if (genClient)

--- a/test/GameViewModel/UnitTest1.cs
+++ b/test/GameViewModel/UnitTest1.cs
@@ -64,7 +64,8 @@ namespace GameViewModel
             const string protoNs = "MonsterClicker.ViewModels.Protos";
             const string serviceName = "GameViewModelService";
             var proto = Generators.GenerateProto(protoNs, serviceName, name, props, cmds, comp);
-            var server = Generators.GenerateServer(name, protoNs, serviceName, props, cmds);
+            var vmNamespace = sym!.ContainingNamespace.ToDisplayString();
+            var server = Generators.GenerateServer(name, protoNs, serviceName, props, cmds, vmNamespace);
             var client = Generators.GenerateClient(name, protoNs, serviceName, props, cmds);
             var ts = Generators.GenerateTypeScriptClient(name, protoNs, serviceName, props, cmds);
             return (proto, server, client, ts);

--- a/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
+++ b/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
@@ -1,5 +1,6 @@
 using Grpc.Core;
 using MonsterClicker.ViewModels.Protos;
+using MonsterClicker.ViewModels;
 using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Linq;

--- a/test/SampleViewModel/GenerationTests.cs
+++ b/test/SampleViewModel/GenerationTests.cs
@@ -49,7 +49,8 @@ public class GenerationTests
         if(sym==null) throw new Exception("ViewModel not found");
         File.WriteAllText(Path.Combine(outputDir,"SampleViewModelService.proto"), Generators.GenerateProto("SampleApp.ViewModels.Protos","CounterService",name,props,cmds,comp));
         File.WriteAllText(Path.Combine(outputDir,"SampleViewModelRemoteClient.ts"), Generators.GenerateTypeScriptClient(name,"SampleApp.ViewModels.Protos","CounterService",props,cmds));
-        File.WriteAllText(Path.Combine(outputDir,"SampleViewModelGrpcServiceImpl.cs"), Generators.GenerateServer(name,"SampleApp.ViewModels.Protos","CounterService",props,cmds));
+        var vmNamespace = sym.ContainingNamespace.ToDisplayString();
+        File.WriteAllText(Path.Combine(outputDir,"SampleViewModelGrpcServiceImpl.cs"), Generators.GenerateServer(name,"SampleApp.ViewModels.Protos","CounterService",props,cmds, vmNamespace));
         File.WriteAllText(Path.Combine(outputDir,"SampleViewModelRemoteClient.cs"), Generators.GenerateClient(name,"SampleApp.ViewModels.Protos","CounterService",props,cmds));
         return (name, Directory.GetFiles(outputDir));
     }

--- a/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
@@ -1,5 +1,6 @@
 using Grpc.Core;
 using SampleApp.ViewModels.Protos;
+using SampleApp.ViewModels;
 using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Linq;


### PR DESCRIPTION
## Summary
- add ViewModel namespace parameter to `GenerateServer`
- include ViewModel namespace using directive when generating grpc service
- propagate namespace through program and tests
- update expected test outputs

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869bb308af883209ab0b880c9f99aad