### PR TITLE
Fix MonsterClicker HTTP/HTTPS mismatch

### DIFF
--- a/src/demo/MonsterClicker/NetworkConfig.cs
+++ b/src/demo/MonsterClicker/NetworkConfig.cs
@@ -4,7 +4,9 @@ namespace MonsterClicker
     public static class NetworkConfig
     {
         public const int Port = 50052;
-        public static string ServerAddress = $"https://localhost:{Port}";
+        // The gRPC server started by the WPF demo uses insecure credentials.
+        // Use HTTP so the client doesn't attempt an HTTPS handshake.
+        public static string ServerAddress = $"http://localhost:{Port}";
         public static string GrpcWebAddress = $"http://localhost:{Port}"; // For Blazor WASM
     }
 }


### PR DESCRIPTION
## Summary
- fix MonsterClicker client to use HTTP when connecting to the insecure gRPC server

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869cb7e468883208fc00546956643d5