### PR TITLE
Fix tsProject package generator

### DIFF
--- a/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
@@ -79,7 +79,7 @@ public static class TsProjectGenerator
 
     public static string GeneratePackageJson(string projectName)
     {
-        return $"{{\n  \"name\": \"{projectName.ToLowerInvariant()}\",\n  \"version\": \"1.0.0\",\n  \"scripts\": {{\n    \"build\": \"webpack --mode development\",\n    \"dev\": \"webpack serve --mode development --open\"\n  }},\n  \"devDependencies\": {{\n    \"ts-loader\": \"^9.5.2\",\n    \"typescript\": \"^5.0.0\",\n    \"webpack\": \"^5.0.0\",\n    \"webpack-cli\": \"^4.0.0\",\n    \"webpack-dev-server\": \"^4.0.0\"\n  }},\n  \"dependencies\": {{\n    \"grpc-web\": \"^1.5.0\",\n    \"google-protobuf\": \"3.21.4\"\n  }}\n}}";
+        return $"{{\n  \"name\": \"{projectName.ToLowerInvariant()}\",\n  \"version\": \"1.0.0\",\n  \"scripts\": {{\n    \"protoc\": \"protoc --plugin=protoc-gen-ts=\\\".\\\\node_modules\\\\.bin\\\\protoc-gen-ts.cmd\\\" --plugin=protoc-gen-grpc-web=\\\".\\\\node_modules\\\\protoc-gen-grpc-web\\\\bin\\\\protoc-gen-grpc-web.exe\\\" --js_out=\\\"import_style=commonjs,binary:./src/generated\\\" --grpc-web_out=\\\"import_style=typescript,mode=grpcwebtext:./src/generated\\\" -Iprotos -I.\\\\protoc\\\\include {projectName}Service.proto\",\n    \"build\": \"webpack --mode development\",\n    \"dev\": \"webpack serve --mode development --open\"\n  }},\n  \"devDependencies\": {{\n    \"ts-loader\": \"^9.5.2\",\n    \"typescript\": \"^5.0.0\",\n    \"webpack\": \"^5.0.0\",\n    \"webpack-cli\": \"^4.0.0\",\n    \"webpack-dev-server\": \"^4.0.0\",\n    \"ts-protoc-gen\": \"0.15.0\"\n  }},\n  \"dependencies\": {{\n    \"grpc-web\": \"^1.5.0\",\n    \"google-protobuf\": \"3.21.4\",\n    \"protoc\": \"^1.1.3\",\n    \"protoc-gen-grpc-web\": \"^1.5.0\"\n  }}\n}}";
     }
 
     public static string GenerateTsConfig()


### PR DESCRIPTION
## Summary
- include protoc script and related dependencies in generated tsProject's package.json

## Testing
- `dotnet test` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_686ac752a1048320baef8f45f1f4e309