### PR TITLE
Add launch.json generation for tsproject option

### DIFF
--- a/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
@@ -106,4 +106,24 @@ public static class TsProjectGenerator
         sb.AppendLine("};");
         return sb.ToString();
     }
+
+    public static string GenerateLaunchJson()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("{");
+        sb.AppendLine("  \"version\": \"0.2.0\",");
+        sb.AppendLine("  \"configurations\": [");
+        sb.AppendLine("    {");
+        sb.AppendLine("      \"type\": \"node\",");
+        sb.AppendLine("      \"request\": \"launch\",");
+        sb.AppendLine("      \"name\": \"Launch Program\",");
+        sb.AppendLine("      \"skipFiles\": [ \"<node_internals>/**\" ],");
+        sb.AppendLine("      \"program\": \"${workspaceFolder}/src/app.js\",");
+        sb.AppendLine("      \"cwd\": \"${workspaceFolder}\",");
+        sb.AppendLine("      \"console\": \"externalTerminal\"");
+        sb.AppendLine("    }");
+        sb.AppendLine("  ]");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
 }

--- a/src/RemoteMvvmTool/Program.cs
+++ b/src/RemoteMvvmTool/Program.cs
@@ -111,6 +111,7 @@ public class Program
                 Directory.CreateDirectory(Path.Combine(projDir, "src"));
                 Directory.CreateDirectory(Path.Combine(projDir, "src", "generated"));
                 Directory.CreateDirectory(Path.Combine(projDir, "wwwroot"));
+                Directory.CreateDirectory(Path.Combine(projDir, ".vscode"));
 
                 string tsClientPath = Path.Combine(projDir, "src", result.ViewModelName + "RemoteClient.ts");
                 var tsClient = TypeScriptClientGenerator.Generate(result.ViewModelName, protoNamespace, serviceName, result.Properties, result.Commands);
@@ -125,6 +126,8 @@ public class Program
                 await File.WriteAllTextAsync(Path.Combine(projDir, "package.json"), TsProjectGenerator.GeneratePackageJson(result.ViewModelName));
                 await File.WriteAllTextAsync(Path.Combine(projDir, "tsconfig.json"), TsProjectGenerator.GenerateTsConfig());
                 await File.WriteAllTextAsync(Path.Combine(projDir, "webpack.config.js"), TsProjectGenerator.GenerateWebpackConfig());
+
+                await File.WriteAllTextAsync(Path.Combine(projDir, ".vscode", "launch.json"), TsProjectGenerator.GenerateLaunchJson());
 
                 string protoDir = Path.Combine(projDir, "protos");
                 Directory.CreateDirectory(protoDir);

--- a/test/GameViewModel/UnitTest1.cs
+++ b/test/GameViewModel/UnitTest1.cs
@@ -103,5 +103,13 @@ namespace GameViewModel
             string root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
             AssertEqualWithDiff(Path.Combine(root, "test", "GameViewModel", "expected", "GameViewModelRemoteClient.ts"), ts);
         }
+
+        [Fact]
+        public void LaunchJsonMatchesExpected()
+        {
+            string root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
+            var launch = TsProjectGenerator.GenerateLaunchJson();
+            AssertEqualWithDiff(Path.Combine(root, "test", "GameViewModel", "expected", "launch.json"), launch);
+        }
     }
 }

--- a/test/GameViewModel/expected/launch.json
+++ b/test/GameViewModel/expected/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "skipFiles": [ "<node_internals>/**" ],
+      "program": "${workspaceFolder}/src/app.js",
+      "cwd": "${workspaceFolder}",
+      "console": "externalTerminal"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- generate a VSCode launch.json file when `tsproject` output is selected
- include helper method `GenerateLaunchJson`
- test launch.json contents

## Testing
- `dotnet test --no-build` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac7e14f8483209acf14a3048e1e51