### PR TITLE
Fix TypeScript generator imports

### DIFF
--- a/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
@@ -10,7 +10,7 @@ public static class TsProjectGenerator
     public static string GenerateAppTs(string vmName, string serviceName, List<PropertyInfo> props, List<CommandInfo> cmds)
     {
         var sb = new StringBuilder();
-        sb.AppendLine($"import {{ {serviceName}Client }} from './generated/{serviceName}ServiceClientPb.js';");
+        sb.AppendLine($"import {{ {serviceName}Client }} from './generated/{serviceName}ServiceClientPb';");
         sb.AppendLine($"import {{ {vmName}RemoteClient }} from './{vmName}RemoteClient';");
         sb.AppendLine();
         sb.AppendLine("const grpcHost = 'http://localhost:50052';");

--- a/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
@@ -12,7 +12,7 @@ public static class TypeScriptClientGenerator
     {
         var sb = new StringBuilder();
         sb.AppendLine($"// Auto-generated TypeScript client for {vmName}");
-        sb.AppendLine($"import {{ {serviceName}Client }} from './generated/{serviceName}ServiceClientPb.js';");
+        sb.AppendLine($"import {{ {serviceName}Client }} from './generated/{serviceName}ServiceClientPb';");
         var requestTypes = string.Join(", ", cmds.Select(c => c.MethodName + "Request").Distinct());
         if (!string.IsNullOrWhiteSpace(requestTypes))
         {


### PR DESCRIPTION
## Summary
- remove `.js` extension from generated TypeScript imports so webpack can resolve TS stubs

## Testing
- `dotnet test` *(fails: compatible .NET SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae0690af88320bc545df5b6d8c187