### PR TITLE
Add HTML interface for newapp.ts demo

### DIFF
--- a/test/PointerTestModel/RemoteGenerated/tsProject/wwwroot/newindex.html
+++ b/test/PointerTestModel/RemoteGenerated/tsProject/wwwroot/newindex.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>PointerViewModel Test UI</title>
+</head>
+<body>
+    <div id="mouse-pointer-test" style="display:none">
+        <div id="initializing-spinner" role="status">
+            <span>Loading...</span>
+            <span class="sr-only">Loading test, please wait...</span>
+        </div>
+        <div class="top">
+            <div id="pointer-test-instructions" style="display:none" aria-live="polite"></div>
+        </div>
+        <div class="content">
+            <div id="test-area"></div>
+        </div>
+        <div id="timer" aria-live="polite" style="display:none"></div>
+        <div class="bottom" style="display:none">
+            <button id="btn-cancel" class="hp-btn" aria-label="Cancel test">Cancel</button>
+            <button id="btn-finish" class="hp-btn" aria-label="Finish test">Finish</button>
+        </div>
+    </div>
+    <div id="connection-status"></div>
+    <script src="newbundle.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `newindex.html` for the pointer test demo to run with `newapp.ts`

## Testing
- `dotnet test` *(fails: SampleViewModel.GenerationTests.GeneratedOutputs_MatchExpected)*

------
https://chatgpt.com/codex/tasks/task_e_686d22d4acf0832096c42a21f3217eb2