### PR TITLE
Add failing tests to demonstrate bugs in RemoteMvvmTool helpers

### DIFF
--- a/RemoteMvvm.sln
+++ b/RemoteMvvm.sln
@@ -78,6 +78,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Components", "Components", 
 		test\ThermalTest\Views\Components\ThermalZoneCompoonent.razor.css = test\ThermalTest\Views\Components\ThermalZoneCompoonent.razor.css
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteMvvmTool.Tests", "test\RemoteMvvmTool.Tests\RemoteMvvmTool.Tests.csproj", "{CFE5665D-F575-454B-81D1-5F794BF2E45C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -118,6 +120,10 @@ Global
 		{39A95025-3C20-45BA-83A2-8CBC38AC310F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{39A95025-3C20-45BA-83A2-8CBC38AC310F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{39A95025-3C20-45BA-83A2-8CBC38AC310F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CFE5665D-F575-454B-81D1-5F794BF2E45C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CFE5665D-F575-454B-81D1-5F794BF2E45C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CFE5665D-F575-454B-81D1-5F794BF2E45C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CFE5665D-F575-454B-81D1-5F794BF2E45C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -141,6 +147,7 @@ Global
 		{39A95025-3C20-45BA-83A2-8CBC38AC310F} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{D91D557E-CB93-4DCC-9AD6-EA278278CA81} = {6300CAB3-2808-4D0D-8267-33EE6BD7E115}
 		{BDD5E06C-6A72-4DB8-9FF7-A73BDA36EFBC} = {D91D557E-CB93-4DCC-9AD6-EA278278CA81}
+		{CFE5665D-F575-454B-81D1-5F794BF2E45C} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {012EEB0A-22C5-4971-A229-3CC35E554B71}

--- a/test/RemoteMvvmTool.Tests/AnalyzerBugTests.cs
+++ b/test/RemoteMvvmTool.Tests/AnalyzerBugTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using GrpcRemoteMvvmModelUtil;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+public class AnalyzerBugTests
+{
+    [Fact]
+    public void AttributeMatches_DifferentNamespace_ReturnsFalse()
+    {
+        var code = @"
+namespace NamespaceA {
+    public class FooAttribute : System.Attribute {}
+    [Foo]
+    public class TestClass {}
+}";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test", new[] { tree }, new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) });
+        var classSymbol = compilation.GetTypeByMetadataName("NamespaceA.TestClass");
+        var attribute = classSymbol!.GetAttributes().Single();
+        Assert.False(Helpers.AttributeMatches(attribute, "NamespaceB.FooAttribute"));
+    }
+
+    [Fact]
+    public void GetAllMembers_IncludesDefaultInterfaceMembers()
+    {
+        var code = @"
+public interface IFoo {
+    void Bar() {}
+}
+public class Foo : IFoo { }
+";
+        var tree = CSharpSyntaxTree.ParseText(code, new CSharpParseOptions(LanguageVersion.Latest));
+        var compilation = CSharpCompilation.Create("Test", new[] { tree }, new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) });
+        var classSymbol = compilation.GetTypeByMetadataName("Foo");
+        var members = Helpers.GetAllMembers(classSymbol!).ToList();
+        Assert.Contains(members.OfType<IMethodSymbol>(), m => m.Name == "Bar");
+    }
+
+    [Fact]
+    public void GetRelayCommands_ValueTaskDetectedAsAsync()
+    {
+        var code = @"
+using CommunityToolkit.Mvvm.Input;
+public partial class MyViewModel {
+    [RelayCommand]
+    public System.Threading.Tasks.ValueTask DoWorkAsync() => default;
+}
+namespace CommunityToolkit.Mvvm.Input {
+    public class RelayCommandAttribute : System.Attribute {}
+}
+";
+        var tree = CSharpSyntaxTree.ParseText(code, new CSharpParseOptions(LanguageVersion.Latest));
+        var references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+            .Select(a => MetadataReference.CreateFromFile(a.Location));
+        var compilation = CSharpCompilation.Create("Test", new[] { tree }, references);
+        var classSymbol = compilation.GetTypeByMetadataName("MyViewModel");
+        var cmds = ViewModelAnalyzer.GetRelayCommands(classSymbol!, "CommunityToolkit.Mvvm.Input.RelayCommandAttribute", compilation);
+        Assert.True(cmds[0].IsAsync);
+    }
+}

--- a/test/RemoteMvvmTool.Tests/GlobalUsings.cs
+++ b/test/RemoteMvvmTool.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj
+++ b/test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/RemoteMvvmTool/RemoteMvvmTool.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add unit tests for `Helpers.AttributeMatches` to show false positive matches across namespaces
- add unit test showing `Helpers.GetAllMembers` misses default interface members
- add unit test showing `ViewModelAnalyzer.GetRelayCommands` fails to flag `ValueTask` methods as async

## Testing
- `dotnet test` *(fails: AttributeMatches_DifferentNamespace_ReturnsFalse, GetAllMembers_IncludesDefaultInterfaceMembers, GetRelayCommands_ValueTaskDetectedAsAsync)*

------
https://chatgpt.com/codex/tasks/task_e_68a45f89cbf48320b230b7b461dc784e