### PR TITLE
Add failing tests exposing helper issues

### DIFF
--- a/test/RemoteMvvmTool.Tests/AdditionalBugTests.cs
+++ b/test/RemoteMvvmTool.Tests/AdditionalBugTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using GrpcRemoteMvvmModelUtil;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using RemoteMvvmTool.Generators;
+using Xunit;
+
+namespace Bugs;
+
+public class AdditionalBugTests
+{
+    [Fact]
+    public void AttributeMatches_NestedAttribute_DoesNotMatch()
+    {
+        var code = @"
+namespace NamespaceA {
+    public class Outer {
+        public class FooAttribute : System.Attribute {}
+    }
+    [Outer.Foo]
+    public class TestClass {}
+}";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test", new[] { tree }, new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) });
+        var classSymbol = compilation.GetTypeByMetadataName("NamespaceA.TestClass");
+        var attribute = classSymbol!.GetAttributes().Single();
+        Assert.False(Helpers.AttributeMatches(attribute, "NamespaceA.FooAttribute"));
+    }
+
+    [Fact]
+    public void InheritsFrom_InterfacesShouldMatch()
+    {
+        var code = @"
+public interface IFoo {}
+public class FooImpl : IFoo {}";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test", new[] { tree }, new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) });
+        var classSymbol = compilation.GetTypeByMetadataName("FooImpl");
+        Assert.True(Helpers.InheritsFrom(classSymbol, "IFoo"));
+    }
+
+    [Fact]
+    public void GetWrapperType_HandlesLong()
+    {
+        Assert.Equal("Int64Value", GeneratorHelpers.GetWrapperType("long"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests for nested attribute detection
- expose missing interface handling in `InheritsFrom`
- demonstrate missing long support in `GetWrapperType`

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj -v minimal` *(fails: 3 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4660256288320944a712922775c10