### PR TITLE
Fix attribute matching and interface inheritance

### DIFF
--- a/src/RemoteMvvmTool/Generators/GeneratorHelpers.cs
+++ b/src/RemoteMvvmTool/Generators/GeneratorHelpers.cs
@@ -15,6 +15,8 @@ public static class GeneratorHelpers
         "string" => "StringValue",
         "int" => "Int32Value",
         "System.Int32" => "Int32Value",
+        "long" => "Int64Value",
+        "System.Int64" => "Int64Value",
         "bool" => "BoolValue",
         "System.Boolean" => "BoolValue",
         _ => null


### PR DESCRIPTION
## Summary
- fix attribute matching to respect containing types
- search interfaces when checking type inheritance
- add wrapper mapping for `long`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a46869c2b883209d276b5cd3d17d33