### PR TITLE
Add failing tests for known issues

### DIFF
--- a/test/RemoteMvvmTool.Tests/NewBugTests.cs
+++ b/test/RemoteMvvmTool.Tests/NewBugTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using GrpcRemoteMvvmModelUtil;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using RemoteMvvmTool.Generators;
+using Xunit;
+
+namespace Bugs;
+
+public class NewBugTests
+{
+    [Fact]
+    public void ToSnake_ConsecutiveCaps()
+    {
+        Assert.Equal("http_server", GeneratorHelpers.ToSnake("HTTPServer"));
+    }
+
+    [Fact]
+    public void AttributeMatches_WithGlobalPrefix()
+    {
+        var code = "[System.Obsolete] public class TestClass {}";
+        var tree = CSharpSyntaxTree.ParseText(code, new CSharpParseOptions(LanguageVersion.Latest));
+        var compilation = CSharpCompilation.Create("Test", new[] { tree }, new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) }, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var classSymbol = compilation.GetTypeByMetadataName("TestClass");
+        var attribute = classSymbol!.GetAttributes().Single();
+        Assert.True(Helpers.AttributeMatches(attribute, "global::System.ObsoleteAttribute"));
+    }
+
+    [Fact]
+    public void ToSnake_UsesInvariantCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+            Assert.Equal("indigo", GeneratorHelpers.ToSnake("Indigo"));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for `ToSnake` handling of consecutive capitals
- add test exposing `AttributeMatches` failure with `global::` prefix
- add culture-sensitivity test for `ToSnake`

## Testing
- `dotnet test` *(fails: Bugs.NewBugTests.AttributeMatches_WithGlobalPrefix, Bugs.NewBugTests.ToSnake_ConsecutiveCaps, Bugs.NewBugTests.ToSnake_UsesInvariantCulture)*

------
https://chatgpt.com/codex/tasks/task_e_68a46b315b3c83209cbfbb50699e5f75