### PR TITLE
Fix snake_case conversion and attribute matching

### DIFF
--- a/src/RemoteMvvmTool/Generators/GeneratorHelpers.cs
+++ b/src/RemoteMvvmTool/Generators/GeneratorHelpers.cs
@@ -6,7 +6,28 @@ namespace RemoteMvvmTool.Generators;
 
 public static class GeneratorHelpers
 {
-    public static string ToSnake(string s) => string.Concat(s.Select((c,i) => i>0 && char.IsUpper(c)?"_"+char.ToLower(c).ToString():char.ToLower(c).ToString()));
+    public static string ToSnake(string s)
+    {
+        if (string.IsNullOrEmpty(s))
+            return s;
+
+        var sb = new StringBuilder(s.Length * 2);
+        for (int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+
+            bool addUnderscore = i > 0 && char.IsUpper(c) &&
+                                 (char.IsLower(s[i - 1]) ||
+                                  (i + 1 < s.Length && char.IsLower(s[i + 1])));
+
+            if (addUnderscore)
+                sb.Append('_');
+
+            sb.Append(char.ToLowerInvariant(c));
+        }
+
+        return sb.ToString();
+    }
     public static string ToCamel(string s) => string.IsNullOrEmpty(s)?s:char.ToLowerInvariant(s[0])+s.Substring(1);
     public static string ToCamelCase(string s) => string.IsNullOrEmpty(s) || char.IsLower(s[0]) ? s : char.ToLowerInvariant(s[0]) + s[1..];
     public static string ToPascalCase(string s) => string.IsNullOrEmpty(s) ? s : char.ToUpperInvariant(s[0]) + s[1..];

--- a/src/RemoteMvvmTool/Helpers.cs
+++ b/src/RemoteMvvmTool/Helpers.cs
@@ -40,9 +40,15 @@ namespace GrpcRemoteMvvmModelUtil
 
             const string suffix = "Attribute";
 
-            static string Normalize(string name) => name.EndsWith(suffix, StringComparison.Ordinal)
-                ? name.Substring(0, name.Length - suffix.Length)
-                : name;
+            static string Normalize(string name)
+            {
+                if (name.StartsWith("global::", StringComparison.Ordinal))
+                    name = name.Substring("global::".Length);
+
+                return name.EndsWith(suffix, StringComparison.Ordinal)
+                    ? name.Substring(0, name.Length - suffix.Length)
+                    : name;
+            }
 
             var attrFull = Normalize(attrClass.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted)));
             var targetFull = Normalize(fullyQualifiedAttributeName);


### PR DESCRIPTION
## Summary
- handle consecutive uppercase letters and use invariant culture in `ToSnake`
- normalize attribute names with `global::` prefix in `AttributeMatches`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a46eb3aaf883209957e6d554a05cbb