### PR TITLE
Handle additional wrapper types and ensure analyzer loads toolkit

### DIFF
--- a/src/RemoteMvvmTool/Generators/GeneratorHelpers.cs
+++ b/src/RemoteMvvmTool/Generators/GeneratorHelpers.cs
@@ -40,6 +40,10 @@ public static class GeneratorHelpers
         "System.Int64" => "Int64Value",
         "bool" => "BoolValue",
         "System.Boolean" => "BoolValue",
+        "float" => "FloatValue",
+        "System.Single" => "FloatValue",
+        "double" => "DoubleValue",
+        "System.Double" => "DoubleValue",
         _ => null
     };
     public static string LowercaseFirst(string str) => string.IsNullOrEmpty(str) ? str : char.ToLowerInvariant(str[0]) + str[1..];

--- a/src/RemoteMvvmTool/Helpers.cs
+++ b/src/RemoteMvvmTool/Helpers.cs
@@ -77,10 +77,13 @@ namespace GrpcRemoteMvvmModelUtil
 
         public static bool InheritsFrom(INamedTypeSymbol? typeSymbol, string baseTypeFullName)
         {
+            static string Normalize(string name) =>
+                name.StartsWith("global::", StringComparison.Ordinal) ? name.Substring("global::".Length) : name;
+
             static bool SymbolMatches(INamedTypeSymbol symbol, string fullName)
             {
                 var fqn = symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
-                return string.Equals(fqn, fullName, StringComparison.Ordinal);
+                return string.Equals(Normalize(fqn), Normalize(fullName), StringComparison.Ordinal);
             }
 
             static bool InterfaceMatches(INamedTypeSymbol symbol, string fullName)

--- a/src/RemoteMvvmTool/ViewModelAnalyzer.cs
+++ b/src/RemoteMvvmTool/ViewModelAnalyzer.cs
@@ -36,6 +36,11 @@ namespace GrpcRemoteMvvmModelUtil
                 if (File.Exists(refPath))
                     references.Add(Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(refPath));
             }
+            var mvvmAssemblyPath = typeof(CommunityToolkit.Mvvm.ComponentModel.ObservableObject).Assembly.Location;
+            if (File.Exists(mvvmAssemblyPath) && !references.Any(r => string.Equals(r.Display, mvvmAssemblyPath, StringComparison.OrdinalIgnoreCase)))
+            {
+                references.Add(Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(mvvmAssemblyPath));
+            }
             var compilation = CSharpCompilation.Create("ViewModelAssembly",
                 syntaxTrees: syntaxTrees,
                 references: references,


### PR DESCRIPTION
## Summary
- handle `float` and `double` in wrapper type selection
- normalize `global::` prefixes when checking type inheritance
- include CommunityToolkit.Mvvm assembly during view model analysis

## Testing
- `dotnet test` *(fails: Assert.Throws() Failure: No exception was thrown)*

------
https://chatgpt.com/codex/tasks/task_e_68a4885245c083208392840932edd67d