### PR TITLE
Add tsproject option to generate help

### DIFF
--- a/src/RemoteMvvmTool/Program.cs
+++ b/src/RemoteMvvmTool/Program.cs
@@ -24,7 +24,7 @@ public class Program
 
     public static async Task<int> Main(string[] args)
     {
-        var generateOption = new Option<string>("--generate", () => "all", "Comma separated list of outputs: proto,server,client,ts");
+        var generateOption = new Option<string>("--generate", () => "all", "Comma separated list of outputs: proto,server,client,ts,tsproject");
         var outputOption = new Option<string>("--output", () => "generated", "Output directory for generated code files");
         var protoOutputOption = new Option<string>("--protoOutput", () => "protos", "Directory for generated .proto file");
         var vmArgument = new Argument<List<string>>("viewmodels", "ViewModel .cs files") { Arity = ArgumentArity.OneOrMore };


### PR DESCRIPTION
## Summary
- include tsproject in the generate option help text

## Testing
- `dotnet test` *(fails: Failed: 4, Passed: 10)*

------
https://chatgpt.com/codex/tasks/task_e_68a48e3bea888320bab5de761d80ff80