### PR TITLE
Detect missing view model types

### DIFF
--- a/src/RemoteMvvmTool/ViewModelAnalyzer.cs
+++ b/src/RemoteMvvmTool/ViewModelAnalyzer.cs
@@ -46,6 +46,23 @@ namespace GrpcRemoteMvvmModelUtil
                 references: references,
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
 
+            var missingTypeDiagnostics = compilation.GetDiagnostics()
+                .Where(d => d.Severity == DiagnosticSeverity.Error && d.Id == "CS0246")
+                .ToArray();
+            if (missingTypeDiagnostics.Length > 0)
+            {
+                var missingNames = missingTypeDiagnostics
+                    .Select(d =>
+                    {
+                        var msg = d.GetMessage();
+                        var start = msg.IndexOf('\'');
+                        var end = msg.IndexOf('\'', start + 1);
+                        return start >= 0 && end > start ? msg.Substring(start + 1, end - start - 1) : msg;
+                    })
+                    .Distinct();
+                throw new InvalidOperationException("Unable to locate the following type definitions: " + string.Join(", ", missingNames));
+            }
+
             INamedTypeSymbol? mainViewModelSymbol = null;
             string originalVmName = "";
             foreach (var tree in syntaxTrees)


### PR DESCRIPTION
## Summary
- fail fast when view model analysis encounters unresolved types

## Testing
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj`
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a49104103883208cccb78100eff53a