### PR TITLE
Warn on missing view model types

### DIFF
--- a/test/RemoteMvvmTool.Tests/ExposedBugTests.cs
+++ b/test/RemoteMvvmTool.Tests/ExposedBugTests.cs
@@ -35,7 +35,7 @@ public class ExposedBugTests
     }
 
     [Fact]
-    public async Task AnalyzeAsync_MissingType_Detected()
+    public async Task AnalyzeAsync_MissingType_WarnsButContinues()
     {
         var code = @"using CommunityToolkit.Mvvm.ComponentModel;\npublic partial class Vm : ObservableObject {\n    [ObservableProperty]\n    private MissingType _value;\n}";
         var tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".cs");
@@ -43,9 +43,10 @@ public class ExposedBugTests
         var referencePaths = AppDomain.CurrentDomain.GetAssemblies()
             .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
             .Select(a => a.Location);
-        await Assert.ThrowsAsync<InvalidOperationException>(() => ViewModelAnalyzer.AnalyzeAsync(new[] { tempFile },
+        var result = await ViewModelAnalyzer.AnalyzeAsync(new[] { tempFile },
             "CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute",
             "CommunityToolkit.Mvvm.Input.RelayCommandAttribute",
-            referencePaths));
+            referencePaths);
+        Assert.Equal("Vm", result.ViewModelName);
     }
 }

--- a/test/SampleViewModel/ErrorHandlingTests.cs
+++ b/test/SampleViewModel/ErrorHandlingTests.cs
@@ -21,7 +21,7 @@ namespace SampleViewModel
         }
 
         [Fact]
-        public async Task MissingType_ReportsError()
+        public async Task MissingType_WarnsButContinues()
         {
             var code = @"using CommunityToolkit.Mvvm.ComponentModel;
 public partial class MissingTypeViewModel : ObservableObject
@@ -37,12 +37,12 @@ public partial class MissingTypeViewModel : ObservableObject
 
             var refs = LoadDefaultRefs();
 
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => ViewModelAnalyzer.AnalyzeAsync(new[] { filePath },
+            var result = await ViewModelAnalyzer.AnalyzeAsync(new[] { filePath },
                 "CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute",
                 "CommunityToolkit.Mvvm.Input.RelayCommandAttribute",
-                refs));
+                refs);
 
-            Assert.Contains("UnknownType", ex.Message);
+            Assert.Equal("MissingTypeViewModel", result.ViewModelName);
         }
     }
 }


### PR DESCRIPTION
## Summary
- warn when view model analysis encounters unresolved types
- adjust tests to expect warnings instead of errors

## Testing
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj`
- `dotnet test test/SampleViewModel/SampleViewModel.Tests.csproj`
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a49104103883208cccb78100eff53a