### PR TITLE
Include Task in standard type set

### DIFF
--- a/src/RemoteMvvmTool/Generators/GeneratorHelpers.cs
+++ b/src/RemoteMvvmTool/Generators/GeneratorHelpers.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using System;
 using System.Linq;
 using System.Text;
 
@@ -80,6 +81,9 @@ public static class GeneratorHelpers
         }
 
         string fullTypeName = typeSymbol.OriginalDefinition.ToDisplayString();
+        if (fullTypeName.StartsWith("System.Threading.Tasks.Task", StringComparison.Ordinal))
+            return "Any";
+
         switch (fullTypeName)
         {
             case "System.TimeSpan": return "Duration";

--- a/src/RemoteMvvmTool/Generators/ProtoGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ProtoGenerator.cs
@@ -80,6 +80,17 @@ public static class ProtoGenerator
                     return "google.protobuf.Duration";
             }
 
+            if (type is INamedTypeSymbol taskNamed)
+            {
+                var constructed = taskNamed.ConstructedFrom?.ToDisplayString();
+                if (constructed != null && constructed.StartsWith("System.Threading.Tasks.Task", StringComparison.Ordinal))
+                {
+                    if (taskNamed.TypeArguments.Length == 1)
+                        return MapProtoType(taskNamed.TypeArguments[0], allowMessage: true);
+                    return "google.protobuf.Any";
+                }
+            }
+
             if (allowMessage && type is INamedTypeSymbol namedType &&
                 (type.TypeKind == TypeKind.Class || type.TypeKind == TypeKind.Struct || type.TypeKind == TypeKind.Error))
             {


### PR DESCRIPTION
## Summary
- treat `System.Threading.Tasks.Task` as a built-in type during dependency analysis
- map Task and Task<T> in proto generation and helper utilities

## Testing
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a4954956188320b3eac675e3f951dd