### PR TITLE
Fix TypeScript app.ts generation for non-string properties

### DIFF
--- a/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
@@ -22,7 +22,10 @@ public static class TsProjectGenerator
         foreach (var p in props)
         {
             string camel = GeneratorHelpers.ToCamelCase(p.Name);
-            sb.AppendLine($"    (document.getElementById('{camel}') as HTMLInputElement).value = vm.{camel};");
+            var assignExpr = p.TypeString.ToLowerInvariant().Contains("string")
+                ? $"vm.{camel}"
+                : $"JSON.stringify(vm.{camel})";
+            sb.AppendLine($"    (document.getElementById('{camel}') as HTMLInputElement).value = {assignExpr};");
         }
         sb.AppendLine("    (document.getElementById('connection-status') as HTMLElement).textContent = vm.connectionStatus;");
         sb.AppendLine("}");

--- a/test/PointerTestModel/RemoteGenerated/tsProject/src/app.ts
+++ b/test/PointerTestModel/RemoteGenerated/tsProject/src/app.ts
@@ -10,20 +10,20 @@ const grpcClient = new PointerViewModelServiceClient(grpcHost);
 const vm = new PointerViewModelRemoteClient(grpcClient);
 
 async function render() {
-    (document.getElementById('show') as HTMLInputElement).value = vm.show;
-    (document.getElementById('showSpinner') as HTMLInputElement).value = vm.showSpinner;
-    (document.getElementById('clicksToPass') as HTMLInputElement).value = vm.clicksToPass;
-    (document.getElementById('is3Btn') as HTMLInputElement).value = vm.is3Btn;
-    (document.getElementById('testTimeoutSec') as HTMLInputElement).value = vm.testTimeoutSec;
-    (document.getElementById('instructions') as HTMLInputElement).value = vm.instructions;
-    (document.getElementById('showCursorTest') as HTMLInputElement).value = vm.showCursorTest;
-    (document.getElementById('showConfigSelection') as HTMLInputElement).value = vm.showConfigSelection;
-    (document.getElementById('showClickInstructions') as HTMLInputElement).value = vm.showClickInstructions;
-    (document.getElementById('showTimer') as HTMLInputElement).value = vm.showTimer;
-    (document.getElementById('showBottom') as HTMLInputElement).value = vm.showBottom;
-    (document.getElementById('timerText') as HTMLInputElement).value = vm.timerText;
-    (document.getElementById('selectedDevice') as HTMLInputElement).value = vm.selectedDevice;
-    (document.getElementById('lastClickCount') as HTMLInputElement).value = vm.lastClickCount;
+    (document.getElementById('show') as HTMLInputElement).value = JSON.stringify(vm.show);
+    (document.getElementById('showSpinner') as HTMLInputElement).value = JSON.stringify(vm.showSpinner);
+    (document.getElementById('clicksToPass') as HTMLInputElement).value = JSON.stringify(vm.clicksToPass);
+    (document.getElementById('is3Btn') as HTMLInputElement).value = JSON.stringify(vm.is3Btn);
+    (document.getElementById('testTimeoutSec') as HTMLInputElement).value = JSON.stringify(vm.testTimeoutSec);
+    (document.getElementById('instructions') as HTMLInputElement).value = JSON.stringify(vm.instructions);
+    (document.getElementById('showCursorTest') as HTMLInputElement).value = JSON.stringify(vm.showCursorTest);
+    (document.getElementById('showConfigSelection') as HTMLInputElement).value = JSON.stringify(vm.showConfigSelection);
+    (document.getElementById('showClickInstructions') as HTMLInputElement).value = JSON.stringify(vm.showClickInstructions);
+    (document.getElementById('showTimer') as HTMLInputElement).value = JSON.stringify(vm.showTimer);
+    (document.getElementById('showBottom') as HTMLInputElement).value = JSON.stringify(vm.showBottom);
+    (document.getElementById('timerText') as HTMLInputElement).value = JSON.stringify(vm.timerText);
+    (document.getElementById('selectedDevice') as HTMLInputElement).value = JSON.stringify(vm.selectedDevice);
+    (document.getElementById('lastClickCount') as HTMLInputElement).value = JSON.stringify(vm.lastClickCount);
     (document.getElementById('connection-status') as HTMLElement).textContent = vm.connectionStatus;
 }
 

--- a/test/ThermalTest/ViewModels/generated/tsProject/src/app.ts
+++ b/test/ThermalTest/ViewModels/generated/tsProject/src/app.ts
@@ -10,10 +10,10 @@ const grpcClient = new HP3LSThermalTestViewModelServiceClient(grpcHost);
 const vm = new HP3LSThermalTestViewModelRemoteClient(grpcClient);
 
 async function render() {
-    (document.getElementById('zones') as HTMLInputElement).value = vm.zones;
-    (document.getElementById('testSettings') as HTMLInputElement).value = vm.testSettings;
-    (document.getElementById('showDescription') as HTMLInputElement).value = vm.showDescription;
-    (document.getElementById('showReadme') as HTMLInputElement).value = vm.showReadme;
+    (document.getElementById('zones') as HTMLInputElement).value = JSON.stringify(vm.zones);
+    (document.getElementById('testSettings') as HTMLInputElement).value = JSON.stringify(vm.testSettings);
+    (document.getElementById('showDescription') as HTMLInputElement).value = JSON.stringify(vm.showDescription);
+    (document.getElementById('showReadme') as HTMLInputElement).value = JSON.stringify(vm.showReadme);
     (document.getElementById('connection-status') as HTMLElement).textContent = vm.connectionStatus;
 }
 


### PR DESCRIPTION
## Summary
- ensure generated app.ts stringifies non-string ViewModel values before assigning to DOM
- update existing generated test app.ts files to reflect new stringification

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a49e6372f08320aaa644ad88a28ae8