### PR TITLE
Add tests for additional collection types

### DIFF
--- a/test/ComplexTypes/ComplexTypeTests.cs
+++ b/test/ComplexTypes/ComplexTypeTests.cs
@@ -117,6 +117,31 @@ public class ComplexTypeTests
             "CommunityToolkit.Mvvm.ComponentModel.ObservableObject");
         var proto = ProtoGenerator.Generate("ComplexTypes.Protos", name + "Service", name, props, cmds, comp);
         Assert.Contains("SupportedCollectionsViewModelState", proto);
+
+        // Generic collections
+        Assert.Contains("repeated int32 int_list", proto);
+        Assert.Contains("map<string, int32> dictionary", proto);
+        Assert.Contains("map<string, int32> sorted_list", proto);
+        Assert.Contains("map<string, int32> sorted_dictionary", proto);
+        Assert.Contains("repeated int32 queue", proto);
+        Assert.Contains("repeated string stack", proto);
+        Assert.Contains("repeated string hash_set", proto);
+        Assert.Contains("repeated double linked_list", proto);
+        Assert.Contains("repeated float enumerable", proto);
+        Assert.Contains("repeated int32 collection", proto);
+        Assert.Contains("repeated string string_list", proto);
+        Assert.Contains("map<string, int32> dictionary_interface", proto);
+
+        // Thread-safe collections
+        Assert.Contains("map<string, int32> concurrent_dictionary", proto);
+        Assert.Contains("repeated string concurrent_queue", proto);
+        Assert.Contains("repeated int32 concurrent_stack", proto);
+        Assert.Contains("repeated double concurrent_bag", proto);
+        Assert.Contains("repeated int64 blocking_collection", proto);
+
+        // Memory-based types
+        Assert.Contains("bytes memory", proto);
+        Assert.Contains("repeated string read_only_memory", proto);
     }
 
     [Fact]

--- a/test/ComplexTypes/ViewModels/SupportedCollectionsViewModel.cs
+++ b/test/ComplexTypes/ViewModels/SupportedCollectionsViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -6,12 +7,63 @@ namespace ComplexTypes.ViewModels;
 
 public partial class SupportedCollectionsViewModel : ObservableObject
 {
+    // Generic collections
     [ObservableProperty]
-    private HashSet<string> tags = new();
+    private List<int> intList = new();
 
     [ObservableProperty]
-    private ConcurrentDictionary<string, int> counts = new();
+    private Dictionary<string, int> dictionary = new();
 
     [ObservableProperty]
-    private Queue<int> numbers = new();
+    private SortedList<string, int> sortedList = new();
+
+    [ObservableProperty]
+    private SortedDictionary<string, int> sortedDictionary = new();
+
+    [ObservableProperty]
+    private Queue<int> queue = new();
+
+    [ObservableProperty]
+    private Stack<string> stack = new();
+
+    [ObservableProperty]
+    private HashSet<string> hashSet = new();
+
+    [ObservableProperty]
+    private LinkedList<double> linkedList = new();
+
+    [ObservableProperty]
+    private IEnumerable<float> enumerable = new List<float>();
+
+    [ObservableProperty]
+    private ICollection<int> collection = new List<int>();
+
+    [ObservableProperty]
+    private IList<string> stringList = new List<string>();
+
+    [ObservableProperty]
+    private IDictionary<string, int> dictionaryInterface = new Dictionary<string, int>();
+
+    // Thread-safe collections
+    [ObservableProperty]
+    private ConcurrentDictionary<string, int> concurrentDictionary = new();
+
+    [ObservableProperty]
+    private ConcurrentQueue<string> concurrentQueue = new();
+
+    [ObservableProperty]
+    private ConcurrentStack<int> concurrentStack = new();
+
+    [ObservableProperty]
+    private ConcurrentBag<double> concurrentBag = new();
+
+    [ObservableProperty]
+    private BlockingCollection<long> blockingCollection = new();
+
+    // Memory-based types
+    [ObservableProperty]
+    private Memory<byte> memory = Memory<byte>.Empty;
+
+    [ObservableProperty]
+    private ReadOnlyMemory<char> readOnlyMemory = ReadOnlyMemory<char>.Empty;
 }

--- a/test/ComplexTypes/ViewModels/UnsupportedViewModels.cs
+++ b/test/ComplexTypes/ViewModels/UnsupportedViewModels.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ComplexTypes.ViewModels;
@@ -14,4 +16,51 @@ public partial class UnsupportedTypesViewModel : ObservableObject
 
     [ObservableProperty]
     private Tuple<int, string> coordinates = new(0, string.Empty);
+
+    // Non-generic collections
+    [ObservableProperty]
+    private ArrayList arrayList = new();
+
+    [ObservableProperty]
+    private Hashtable hashtable = new();
+
+    [ObservableProperty]
+    private Queue queue = new();
+
+    [ObservableProperty]
+    private Stack stack = new();
+
+    [ObservableProperty]
+    private SortedList sortedList = new();
+
+    [ObservableProperty]
+    private IEnumerable enumerable = new ArrayList();
+
+    [ObservableProperty]
+    private ICollection collection = new ArrayList();
+
+    [ObservableProperty]
+    private IList list = new ArrayList();
+
+    [ObservableProperty]
+    private IDictionary dictionary = new Hashtable();
+
+    // Specialized collections
+    [ObservableProperty]
+    private NameValueCollection nameValueCollection = new();
+
+    [ObservableProperty]
+    private StringCollection stringCollection = new();
+
+    [ObservableProperty]
+    private StringDictionary stringDictionary = new();
+
+    [ObservableProperty]
+    private HybridDictionary hybridDictionary = new();
+
+    [ObservableProperty]
+    private OrderedDictionary orderedDictionary = new();
+
+    [ObservableProperty]
+    private BitVector32 bitVector = new();
 }


### PR DESCRIPTION
## Summary
- expand `SupportedCollectionsViewModel` to include many generic, concurrent and memory-based collection types
- cover unsupported non-generic and specialized collections in `UnsupportedTypesViewModel`
- verify proto generation for all supported collection types

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e1b735b883208a48cd59444eb196