### PR TITLE
Remove demo dependencies from generated options

### DIFF
--- a/src/RemoteMvvmTool/Generators/OptionsGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/OptionsGenerator.cs
@@ -12,7 +12,7 @@ public static class OptionsGenerator
         sb.AppendLine("{");
         sb.AppendLine("    public class ServerOptions");
         sb.AppendLine("    {");
-        sb.AppendLine("        public int Port { get; set; } = MonsterClicker.NetworkConfig.Port;");
+        sb.AppendLine("        public int Port { get; set; } = 50052;");
         sb.AppendLine("        public bool UseHttps { get; set; } = true;");
         sb.AppendLine("        public string? CorsPolicyName { get; set; } = \"AllowAll\";");
         sb.AppendLine("        public string[]? AllowedOrigins { get; set; } = null;");
@@ -24,7 +24,7 @@ public static class OptionsGenerator
         sb.AppendLine();
         sb.AppendLine("    public class ClientOptions");
         sb.AppendLine("    {");
-        sb.AppendLine("        public string Address { get; set; } = MonsterClicker.NetworkConfig.ServerAddress;");
+        sb.AppendLine("        public string Address { get; set; } = \"http://localhost:50052\";");
         sb.AppendLine("    }");
         sb.AppendLine("}");
         return sb.ToString();

--- a/src/demo/BlazorMonsterClicker/BlazorMonsterClicker/RemoteGenerated/GrpcRemoteOptions.cs
+++ b/src/demo/BlazorMonsterClicker/BlazorMonsterClicker/RemoteGenerated/GrpcRemoteOptions.cs
@@ -2,7 +2,7 @@ namespace PeakSWC.Mvvm.Remote
 {
     public class ServerOptions
     {
-        public int Port { get; set; } = MonsterClicker.NetworkConfig.Port;
+        public int Port { get; set; } = 50052;
         public bool UseHttps { get; set; } = true;
         public string? CorsPolicyName { get; set; } = "AllowAll";
         public string[]? AllowedOrigins { get; set; } = null;
@@ -14,6 +14,6 @@ namespace PeakSWC.Mvvm.Remote
 
     public class ClientOptions
     {
-        public string Address { get; set; } = MonsterClicker.NetworkConfig.ServerAddress;
+        public string Address { get; set; } = "http://localhost:50052";
     }
 }

--- a/test/PointerTestModel/RemoteGenerated/GrpcRemoteOptions.cs
+++ b/test/PointerTestModel/RemoteGenerated/GrpcRemoteOptions.cs
@@ -2,7 +2,7 @@ namespace PeakSWC.Mvvm.Remote
 {
     public class ServerOptions
     {
-        public int Port { get; set; } = MonsterClicker.NetworkConfig.Port;
+        public int Port { get; set; } = 50052;
         public bool UseHttps { get; set; } = true;
         public string? CorsPolicyName { get; set; } = "AllowAll";
         public string[]? AllowedOrigins { get; set; } = null;
@@ -14,6 +14,6 @@ namespace PeakSWC.Mvvm.Remote
 
     public class ClientOptions
     {
-        public string Address { get; set; } = MonsterClicker.NetworkConfig.ServerAddress;
+        public string Address { get; set; } = "http://localhost:50052";
     }
 }

--- a/test/PointerTestModel/expected/GrpcRemoteOptions.cs
+++ b/test/PointerTestModel/expected/GrpcRemoteOptions.cs
@@ -6,7 +6,7 @@ namespace PeakSWC.Mvvm.Remote
 {
     public class ServerOptions
     {
-        public int Port { get; set; } = MonsterClicker.NetworkConfig.Port;
+        public int Port { get; set; } = 50052;
         public bool UseHttps { get; set; } = true;
         public string? CorsPolicyName { get; set; } = "AllowAll";
         public string[]? AllowedOrigins { get; set; } = null;
@@ -18,6 +18,6 @@ namespace PeakSWC.Mvvm.Remote
 
     public class ClientOptions
     {
-        public string Address { get; set; } = MonsterClicker.NetworkConfig.ServerAddress;
+        public string Address { get; set; } = "http://localhost:50052";
     }
 }

--- a/test/ThermalTest/ViewModels/generated/GrpcRemoteOptions.cs
+++ b/test/ThermalTest/ViewModels/generated/GrpcRemoteOptions.cs
@@ -6,7 +6,7 @@ namespace PeakSWC.Mvvm.Remote
 {
     public class ServerOptions
     {
-        public int Port { get; set; } = MonsterClicker.NetworkConfig.Port;
+        public int Port { get; set; } = 50052;
         public bool UseHttps { get; set; } = true;
         public string? CorsPolicyName { get; set; } = "AllowAll";
         public string[]? AllowedOrigins { get; set; } = null;
@@ -18,6 +18,6 @@ namespace PeakSWC.Mvvm.Remote
 
     public class ClientOptions
     {
-        public string Address { get; set; } = MonsterClicker.NetworkConfig.ServerAddress;
+        public string Address { get; set; } = "http://localhost:50052";
     }
 }


### PR DESCRIPTION
## Summary
- stop embedding demo-specific `MonsterClicker.NetworkConfig` in generated gRPC options
- default server port to 50052 and client address to http://localhost:50052
- update test fixtures and sample outputs for new defaults

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4edd4e4048320ba4449159e34785d