### PR TITLE
Add failing tests for unsupported type handling

### DIFF
--- a/test/RemoteMvvmTool.Tests/NewExposedBugTests.cs
+++ b/test/RemoteMvvmTool.Tests/NewExposedBugTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using RemoteMvvmTool.Generators;
+using Xunit;
+
+namespace Bugs;
+
+public class NewExposedBugTests
+{
+    [Fact]
+    public void GetWrapperType_UShort_NotHandled()
+    {
+        Assert.Equal("UInt32Value", GeneratorHelpers.GetWrapperType("ushort"));
+    }
+
+    [Fact]
+    public void GetWrapperType_NInt_NotHandled()
+    {
+        Assert.Equal("Int64Value", GeneratorHelpers.GetWrapperType("nint"));
+    }
+
+    [Fact]
+    public void GetWrapperType_NUInt_NotHandled()
+    {
+        Assert.Equal("UInt64Value", GeneratorHelpers.GetWrapperType("nuint"));
+    }
+
+    [Fact]
+    public void GetProtoWellKnownTypeFor_Half_NotHandled()
+    {
+        var code = "using System; class C { System.Half F; }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test", new[] { tree }, new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Half).Assembly.Location)
+        });
+        var field = (IFieldSymbol)compilation.GetTypeByMetadataName("C")!.GetMembers("F").Single();
+        Assert.Equal("FloatValue", GeneratorHelpers.GetProtoWellKnownTypeFor(field.Type));
+    }
+
+    [Fact]
+    public void TryGetEnumerableElementType_Array_NotHandled()
+    {
+        var code = "class C { int[] Numbers; }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test", new[] { tree }, new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
+        });
+        var field = (IFieldSymbol)compilation.GetTypeByMetadataName("C")!.GetMembers("Numbers").Single();
+        Assert.True(GeneratorHelpers.TryGetEnumerableElementType(field.Type, out var elem));
+        Assert.Equal("System.Int32", elem!.ToDisplayString());
+    }
+
+    [Fact]
+    public void GetProtoWellKnownTypeFor_DateOnly_NotHandled()
+    {
+        var code = "using System; class C { DateOnly D; }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("Test", new[] { tree }, new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(DateOnly).Assembly.Location)
+        });
+        var field = (IFieldSymbol)compilation.GetTypeByMetadataName("C")!.GetMembers("D").Single();
+        Assert.Equal("StringValue", GeneratorHelpers.GetProtoWellKnownTypeFor(field.Type));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests exposing missing `GeneratorHelpers` mappings for `ushort`, `nint`, and `nuint`
- highlight gaps in `GetProtoWellKnownTypeFor` for `Half` and `DateOnly`
- demonstrate `TryGetEnumerableElementType` fails to detect array element types

## Testing
- `dotnet test` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop)*
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj` *(fails: 6 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fa59edc883208a033157a7084cec