### PR TITLE
test: compile generated server and client

### DIFF
--- a/test/RemoteMvvmTool.Tests/DefaultNamespaceGenerationTests.cs
+++ b/test/RemoteMvvmTool.Tests/DefaultNamespaceGenerationTests.cs
@@ -4,6 +4,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using Xunit;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Runtime.InteropServices;
 
 public class DefaultNamespaceGenerationTests
 {
@@ -12,40 +15,106 @@ public class DefaultNamespaceGenerationTests
     {
         var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
         var vmDir = Path.Combine(root, "test", "SimpleViewModelTest", "ViewModels");
-        var oldDir = Environment.CurrentDirectory;
-        try
+        var generatedDir = Path.Combine(vmDir, "generated");
+        if (Directory.Exists(generatedDir))
+            Directory.Delete(generatedDir, true);
+
+        var args = new[]
         {
-            Environment.CurrentDirectory = vmDir;
-            if (Directory.Exists(Path.Combine(vmDir, "generated")))
-                Directory.Delete(Path.Combine(vmDir, "generated"), true);
+            "--output", generatedDir,
+            "--protoOutput", Path.Combine(vmDir, "protos"),
+            Path.Combine(vmDir, "MainViewModel.cs"),
+            Path.Combine(vmDir, "DeviceInfo.cs"),
+            Path.Combine(vmDir, "DeviceStatus.cs"),
+            Path.Combine(vmDir, "NetworkConfig.cs")
+        };
+        var exitCode = await Program.Main(args);
+        Assert.Equal(0, exitCode);
+        // generate gRPC sources from proto
+        var protoDir = Path.Combine(vmDir, "protos");
+        var protoFile = Path.Combine(protoDir, "MainViewModelService.proto");
+        var grpcOut = Path.Combine(generatedDir, "grpc");
+        Directory.CreateDirectory(grpcOut);
+        RunProtoc(protoDir, protoFile, grpcOut);
 
-            var args = new[] { "MainViewModel.cs", "DeviceInfo.cs", "DeviceStatus.cs", "NetworkConfig.cs" };
-            var exitCode = await Program.Main(args);
-            Assert.Equal(0, exitCode);
-
-            var optsPath = Path.Combine(vmDir, "generated", "GrpcRemoteOptions.cs");
-            Assert.True(File.Exists(optsPath));
-            var source = File.ReadAllText(optsPath);
-            var tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(source);
-            var refs = new System.Collections.Generic.List<Microsoft.CodeAnalysis.MetadataReference>();
-            string? tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
-            if (tpa != null)
-            {
-                foreach (var p in tpa.Split(Path.PathSeparator))
-                    if (!string.IsNullOrEmpty(p) && File.Exists(p))
-                        refs.Add(Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(p));
-            }
-            var compilation = Microsoft.CodeAnalysis.CSharp.CSharpCompilation.Create(
-                "GeneratedOpts",
-                new[] { tree },
-                refs,
-                new Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary));
-            var emitResult = compilation.Emit(Stream.Null);
-            Assert.True(emitResult.Success, string.Join("\n", emitResult.Diagnostics));
+        // collect source files
+        var sourceFiles = new[]
+        {
+            Path.Combine(vmDir, "DeviceStatus.cs"),
+            Path.Combine(vmDir, "NetworkConfig.cs"),
+            Path.Combine(generatedDir, "GrpcRemoteOptions.cs"),
+            Path.Combine(generatedDir, "MainViewModel.Remote.g.cs"),
+            Path.Combine(generatedDir, "MainViewModelGrpcServiceImpl.cs"),
+            Path.Combine(generatedDir, "MainViewModelRemoteClient.cs")
         }
-        finally
+        .Concat(Directory.GetFiles(grpcOut, "*.cs"))
+        .ToList();
+
+        // add a dispatcher stub so we don't need the WPF assemblies on non-Windows platforms
+        var dispatcherStub = @"namespace System.Windows.Threading { public class Dispatcher { public void Invoke(System.Action a) => a(); public static Dispatcher CurrentDispatcher { get; } = new Dispatcher(); } }";
+        var deviceInfoStub = @"namespace SimpleViewModelTest.ViewModels { public class DeviceInfo : Generated.Protos.DeviceInfoState { } }";
+        var vmStub = @"namespace SimpleViewModelTest.ViewModels { public partial class MainViewModel : CommunityToolkit.Mvvm.ComponentModel.ObservableObject { public MainViewModel() { } public System.Collections.Generic.List<DeviceInfo> Devices { get; set; } = new(); public CommunityToolkit.Mvvm.Input.IRelayCommand<DeviceStatus> UpdateStatusCommand { get; } = new CommunityToolkit.Mvvm.Input.RelayCommand<DeviceStatus>(_ => { }); } }";
+        var serviceCtorStub = @"public partial class MainViewModelGrpcServiceImpl { public MainViewModelGrpcServiceImpl(MainViewModel vm) : this(vm, System.Windows.Threading.Dispatcher.CurrentDispatcher, null) {} }";
+        var trees = sourceFiles.Select(f => CSharpSyntaxTree.ParseText(File.ReadAllText(f), path: f)).ToList();
+        trees.Add(CSharpSyntaxTree.ParseText(dispatcherStub));
+        trees.Add(CSharpSyntaxTree.ParseText(deviceInfoStub));
+        trees.Add(CSharpSyntaxTree.ParseText(vmStub));
+        trees.Add(CSharpSyntaxTree.ParseText(serviceCtorStub));
+
+        // gather references from runtime (TPA) and test run directory
+        var refs = new System.Collections.Generic.List<MetadataReference>();
+        if (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") is string tpa2)
         {
-            Environment.CurrentDirectory = oldDir;
+            foreach (var p in tpa2.Split(Path.PathSeparator))
+                if (!string.IsNullOrEmpty(p) && File.Exists(p))
+                    refs.Add(MetadataReference.CreateFromFile(p));
+        }
+        foreach (var dll in Directory.GetFiles(AppContext.BaseDirectory, "*.dll"))
+        {
+            if (!refs.OfType<PortableExecutableReference>().Any(r => string.Equals(r.FilePath, dll, StringComparison.OrdinalIgnoreCase)))
+                refs.Add(MetadataReference.CreateFromFile(dll));
+        }
+
+        var compilation = CSharpCompilation.Create(
+            "GeneratedServerClient",
+            trees,
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var emitResult = compilation.Emit(Stream.Null);
+        Assert.True(emitResult.Success, string.Join("\n", emitResult.Diagnostics));
+    }
+
+    static void RunProtoc(string protoDir, string protoFile, string outDir)
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var toolsRoot = Path.Combine(home, ".nuget", "packages", "grpc.tools");
+        var versionDir = Directory.GetDirectories(toolsRoot).OrderBy(p => p).Last();
+        string osPart = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows" : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "macosx" : "linux";
+        string archPart = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.X86 => "x86",
+            Architecture.Arm64 => "arm64",
+            _ => "x64"
+        };
+        bool isWin = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        var protoc = Path.Combine(versionDir, "tools", $"{osPart}_{archPart}", isWin ? "protoc.exe" : "protoc");
+        var plugin = Path.Combine(versionDir, "tools", $"{osPart}_{archPart}", isWin ? "grpc_csharp_plugin.exe" : "grpc_csharp_plugin");
+        var includeDir = Path.Combine(versionDir, "build", "native", "include");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = protoc,
+            Arguments = $"--csharp_out \"{outDir}\" --grpc_out \"{outDir}\" --plugin=protoc-gen-grpc=\"{plugin}\" -I\"{protoDir}\" -I\"{includeDir}\" \"{protoFile}\"",
+            RedirectStandardError = true,
+            RedirectStandardOutput = true
+        };
+        using var proc = Process.Start(psi)!;
+        proc.WaitForExit();
+        if (proc.ExitCode != 0)
+        {
+            var msg = proc.StandardError.ReadToEnd();
+            throw new Exception($"protoc failed: {msg}");
         }
     }
 


### PR DESCRIPTION
## Summary
- extend default namespace test to generate gRPC code and attempt compiling server and client implementations

## Testing
- `dotnet test` *(fails: The type or namespace name 'DeviceInfo' could not be found; Missing conversions between DeviceInfo and DeviceInfoState)*

------
https://chatgpt.com/codex/tasks/task_e_68a52c7348908320a603310c3a17ad02