### PR TITLE
Fix generator helpers and analyzer

### DIFF
--- a/src/RemoteMvvmTool/Generators/GeneratorHelpers.cs
+++ b/src/RemoteMvvmTool/Generators/GeneratorHelpers.cs
@@ -17,7 +17,7 @@ public static class GeneratorHelpers
         {
             char c = s[i];
 
-            bool addUnderscore = i > 0 && char.IsUpper(c) &&
+            bool addUnderscore = i > 0 && s[i - 1] != '_' && char.IsUpper(c) &&
                                  (char.IsLower(s[i - 1]) ||
                                   (i + 1 < s.Length && char.IsLower(s[i + 1])));
 
@@ -131,6 +131,13 @@ public static class GeneratorHelpers
             if (elementType?.SpecialType == SpecialType.System_Byte)
                 return "BytesValue";
         }
+
+        if (TryGetEnumerableElementType(typeSymbol, out var enumElem))
+        {
+            if (enumElem?.SpecialType == SpecialType.System_Byte)
+                return "BytesValue";
+        }
+
         return "Any";
     }
 
@@ -163,9 +170,14 @@ public static class GeneratorHelpers
     public static bool TryGetEnumerableElementType(ITypeSymbol typeSymbol, out ITypeSymbol? elementType)
     {
         elementType = null;
+        if (typeSymbol.SpecialType == SpecialType.System_String)
+        {
+            return false;
+        }
+
         if (typeSymbol is IArrayTypeSymbol arraySymbol)
         {
-            elementType = arraySymbol.ElementType.OriginalDefinition;
+            elementType = arraySymbol.ElementType;
             return true;
         }
 

--- a/src/RemoteMvvmTool/Program.cs
+++ b/src/RemoteMvvmTool/Program.cs
@@ -24,6 +24,7 @@ public class Program
 
     public static async Task<int> Main(string[] args)
     {
+        Environment.ExitCode = 0;
         var generateOption = new Option<string>("--generate", () => "all", "Comma separated list of outputs: proto,server,client,ts,tsproject");
         var outputOption = new Option<string>("--output", () => "generated", "Output directory for generated code files");
         var protoOutputOption = new Option<string>("--protoOutput", () => "protos", "Directory for generated .proto file");
@@ -64,6 +65,11 @@ public class Program
             bool genClient = gens.Contains("client") || gens.Contains("all");
             bool genTsProject = gens.Contains("tsproject");
             bool genTs = gens.Contains("ts") || gens.Contains("all") || gens.Contains("tsclient") || genTsProject;
+
+            var baseDir = Environment.CurrentDirectory;
+            output = Path.GetFullPath(output, baseDir);
+            protoOutput = Path.GetFullPath(protoOutput, baseDir);
+            vms = vms.Select(v => Path.GetFullPath(v, baseDir)).ToList();
 
             Directory.CreateDirectory(output);
             Directory.CreateDirectory(protoOutput);

--- a/src/RemoteMvvmTool/ViewModelAnalyzer.cs
+++ b/src/RemoteMvvmTool/ViewModelAnalyzer.cs
@@ -113,6 +113,7 @@ namespace GrpcRemoteMvvmModelUtil
             {
                 if (member is IFieldSymbol fieldSymbol)
                 {
+                    if (fieldSymbol.IsStatic) continue;
                     var obsPropAttribute = fieldSymbol.GetAttributes().FirstOrDefault(a =>
                         Helpers.AttributeMatches(a, observablePropertyAttributeFullName));
                     if (obsPropAttribute != null)
@@ -128,6 +129,7 @@ namespace GrpcRemoteMvvmModelUtil
                 }
                 else if (member is IPropertySymbol propertySymbol)
                 {
+                    if (propertySymbol.IsStatic) continue;
                     var obsPropAttribute = propertySymbol.GetAttributes().FirstOrDefault(a =>
                         Helpers.AttributeMatches(a, observablePropertyAttributeFullName));
                     if (obsPropAttribute != null)
@@ -145,6 +147,7 @@ namespace GrpcRemoteMvvmModelUtil
             {
                 if (member is IMethodSymbol methodSymbol)
                 {
+                if (methodSymbol.IsStatic) continue;
                 var relayCmdAttribute = methodSymbol.GetAttributes().FirstOrDefault(a =>
                     Helpers.AttributeMatches(a, relayCommandAttributeFullName));
                     if (relayCmdAttribute != null)


### PR DESCRIPTION
## Summary
- handle existing underscores when converting to snake case
- ignore static members when gathering observable properties and commands
- normalize paths and improve enumerable type handling for code generation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a53084e3a48320a6ee2ab719f09683