### PR TITLE
Use Dispatcher for default WPF and WinForms server generation

### DIFF
--- a/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
+++ b/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
@@ -43,13 +43,13 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
 
     private readonly GameViewModel _viewModel;
     private static readonly ConcurrentDictionary<IServerStreamWriter<MonsterClicker.ViewModels.Protos.PropertyChangeNotification>, Channel<MonsterClicker.ViewModels.Protos.PropertyChangeNotification>> _subscriberChannels = new ConcurrentDictionary<IServerStreamWriter<MonsterClicker.ViewModels.Protos.PropertyChangeNotification>, Channel<MonsterClicker.ViewModels.Protos.PropertyChangeNotification>>();
-    private readonly Action<Action> _dispatch;
+    private readonly Dispatcher _dispatcher;
     private readonly ILogger? _logger;
 
     public GameViewModelGrpcServiceImpl(GameViewModel viewModel, Dispatcher dispatcher, ILogger<GameViewModelGrpcServiceImpl>? logger = null)
     {
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
-        _dispatch = action => dispatcher.Invoke(action);
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         _logger = logger;
         if (_viewModel is INotifyPropertyChanged inpc) { inpc.PropertyChanged += ViewModel_PropertyChanged; }
     }
@@ -138,7 +138,7 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
 
     public override Task<Empty> UpdatePropertyValue(MonsterClicker.ViewModels.Protos.UpdatePropertyValueRequest request, ServerCallContext context)
     {
-        _dispatch(() => {
+        _dispatcher.Invoke(() => {
         var propertyInfo = _viewModel.GetType().GetProperty(request.PropertyName);
         if (propertyInfo != null && propertyInfo.CanWrite)
         {
@@ -161,7 +161,7 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
 
     public override async Task<MonsterClicker.ViewModels.Protos.AttackMonsterResponse> AttackMonster(MonsterClicker.ViewModels.Protos.AttackMonsterRequest request, ServerCallContext context)
     {
-        try { _dispatch(() => {
+        try { await await _dispatcher.InvokeAsync(async () => {
             var command = _viewModel.AttackMonsterCommand as CommunityToolkit.Mvvm.Input.IRelayCommand;
             if (command != null)
             {
@@ -177,7 +177,7 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
 
     public override async Task<MonsterClicker.ViewModels.Protos.SpecialAttackAsyncResponse> SpecialAttackAsync(MonsterClicker.ViewModels.Protos.SpecialAttackAsyncRequest request, ServerCallContext context)
     {
-        try { _dispatch(() => {
+        try { await await _dispatcher.InvokeAsync(async () => {
             var command = _viewModel.SpecialAttackCommand as CommunityToolkit.Mvvm.Input.IAsyncRelayCommand;
             if (command != null)
             {
@@ -193,7 +193,7 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
 
     public override async Task<MonsterClicker.ViewModels.Protos.ResetGameResponse> ResetGame(MonsterClicker.ViewModels.Protos.ResetGameRequest request, ServerCallContext context)
     {
-        try { _dispatch(() => {
+        try { await await _dispatcher.InvokeAsync(async () => {
             var command = _viewModel.ResetGameCommand as CommunityToolkit.Mvvm.Input.IRelayCommand;
             if (command != null)
             {

--- a/test/PointerTestModel/RemoteGenerated/PointerViewModelGrpcServiceImpl.cs
+++ b/test/PointerTestModel/RemoteGenerated/PointerViewModelGrpcServiceImpl.cs
@@ -15,9 +15,9 @@ using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading.Channels;
-using System.Windows.Threading;
 using Channel = System.Threading.Channels.Channel;
 using Microsoft.Extensions.Logging;
+using System.Windows.Threading;
 
 public partial class PointerViewModelGrpcServiceImpl : PointerViewModelService.PointerViewModelServiceBase
 {

--- a/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelGrpcServiceImpl.cs
+++ b/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelGrpcServiceImpl.cs
@@ -43,13 +43,13 @@ public partial class HP3LSThermalTestViewModelGrpcServiceImpl : HP3LSThermalTest
 
     private readonly HP3LSThermalTestViewModel _viewModel;
     private static readonly ConcurrentDictionary<IServerStreamWriter<Generated.Protos.PropertyChangeNotification>, Channel<Generated.Protos.PropertyChangeNotification>> _subscriberChannels = new ConcurrentDictionary<IServerStreamWriter<Generated.Protos.PropertyChangeNotification>, Channel<Generated.Protos.PropertyChangeNotification>>();
-    private readonly Action<Action> _dispatch;
+    private readonly Dispatcher _dispatcher;
     private readonly ILogger? _logger;
 
     public HP3LSThermalTestViewModelGrpcServiceImpl(HP3LSThermalTestViewModel viewModel, Dispatcher dispatcher, ILogger<HP3LSThermalTestViewModelGrpcServiceImpl>? logger = null)
     {
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
-        _dispatch = action => dispatcher.Invoke(action);
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         _logger = logger;
         if (_viewModel is INotifyPropertyChanged inpc) { inpc.PropertyChanged += ViewModel_PropertyChanged; }
     }
@@ -110,7 +110,7 @@ public partial class HP3LSThermalTestViewModelGrpcServiceImpl : HP3LSThermalTest
 
     public override Task<Empty> UpdatePropertyValue(Generated.Protos.UpdatePropertyValueRequest request, ServerCallContext context)
     {
-        _dispatch(() => {
+        _dispatcher.Invoke(() => {
         var propertyInfo = _viewModel.GetType().GetProperty(request.PropertyName);
         if (propertyInfo != null && propertyInfo.CanWrite)
         {
@@ -133,7 +133,7 @@ public partial class HP3LSThermalTestViewModelGrpcServiceImpl : HP3LSThermalTest
 
     public override async Task<Generated.Protos.StateChangedResponse> StateChanged(Generated.Protos.StateChangedRequest request, ServerCallContext context)
     {
-        try { _dispatch(() => {
+        try { await await _dispatcher.InvokeAsync(async () => {
             var command = _viewModel.StateChangedCommand as CommunityToolkit.Mvvm.Input.IRelayCommand;
             if (command != null)
             {
@@ -150,7 +150,7 @@ public partial class HP3LSThermalTestViewModelGrpcServiceImpl : HP3LSThermalTest
 
     public override async Task<Generated.Protos.CancelTestResponse> CancelTest(Generated.Protos.CancelTestRequest request, ServerCallContext context)
     {
-        try { _dispatch(() => {
+        try { await await _dispatcher.InvokeAsync(async () => {
             var command = _viewModel.CancelTestCommand as CommunityToolkit.Mvvm.Input.IRelayCommand;
             if (command != null)
             {


### PR DESCRIPTION
## Summary
- generate WinForms gRPC service implementations with a Control dispatcher
- test that WinForms mode includes a dispatcher while console mode omits it

## Testing
- `dotnet test` *(fails: ThermalTests.ThermalViewModelGenerationTests.RemoteMvvmTool_Generates_Code_Successfully; Bugs.MoreFailingBugTests.*)*

------
https://chatgpt.com/codex/tasks/task_e_68a52fb705408320ab494fcac25641b3