### PR TITLE
Handle enums in ProtoGenerator

### DIFF
--- a/src/RemoteMvvmTool/Generators/ProtoGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ProtoGenerator.cs
@@ -78,6 +78,15 @@ public static class ProtoGenerator
                     return "google.protobuf.Duration";
             }
 
+            if (type.TypeKind == TypeKind.Enum)
+                return "int32";
+
+            if (type.TypeKind == TypeKind.Error)
+            {
+                Console.Error.WriteLine($"Warning: Type '{type.ToDisplayString()}' is not supported. Using 'int32'.");
+                return "int32";
+            }
+
             if (type is INamedTypeSymbol taskNamed)
             {
                 var constructed = taskNamed.ConstructedFrom?.ToDisplayString();

--- a/test/RemoteMvvmTool.Tests/ThermalViewModelGenerationTests.cs
+++ b/test/RemoteMvvmTool.Tests/ThermalViewModelGenerationTests.cs
@@ -67,6 +67,8 @@ public class ThermalViewModelGenerationTests
             };
             if (Directory.Exists(Path.Combine(vmDir, "generated")))
                 Directory.Delete(Path.Combine(vmDir, "generated"), true);
+            if (Directory.Exists(Path.Combine(vmDir, "protos")))
+                Directory.Delete(Path.Combine(vmDir, "protos"), true);
 
             var exitCode = await Program.Main(args);
             Assert.Equal(0, exitCode);


### PR DESCRIPTION
## Summary
- allow ProtoGenerator to map enums and unresolved types to `int32` with a warning
- ensure ThermalViewModel generation test regenerates protos

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a5b16257d883209f3a6d08e70cc74a