### PR TITLE
Skip static properties in generated converters

### DIFF
--- a/src/RemoteMvvmTool/Generators/ConversionGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ConversionGenerator.cs
@@ -45,6 +45,7 @@ public static class ConversionGenerator
         sb.AppendLine($"        var state = new {protoNs}.{stateName}();");
         foreach (var prop in Helpers.GetAllMembers(named).OfType<IPropertySymbol>())
         {
+            if (prop.IsStatic) continue;
             if (prop.DeclaredAccessibility != Accessibility.Public || prop.GetMethod == null) continue;
             var propType = prop.Type;
             string propName = prop.Name;
@@ -78,6 +79,7 @@ public static class ConversionGenerator
         sb.AppendLine($"        var model = new {fullName}();");
         foreach (var prop in Helpers.GetAllMembers(named).OfType<IPropertySymbol>())
         {
+            if (prop.IsStatic) continue;
             if (prop.DeclaredAccessibility != Accessibility.Public || prop.SetMethod == null) continue;
             var propType = prop.Type;
             string propName = prop.Name;

--- a/src/RemoteMvvmTool/Generators/ProtoGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ProtoGenerator.cs
@@ -142,7 +142,7 @@ public static class ProtoGenerator
             {
                 propsForMsg = Helpers.GetAllMembers(msgType)
                     .OfType<IPropertySymbol>()
-                    .Where(p => p.GetMethod != null && p.Parameters.Length == 0)
+                    .Where(p => !p.IsStatic && p.GetMethod != null && p.Parameters.Length == 0)
                     .ToList();
             }
 

--- a/test/RemoteMvvmTool.Tests/ThermalViewModelGenerationTests.cs
+++ b/test/RemoteMvvmTool.Tests/ThermalViewModelGenerationTests.cs
@@ -106,4 +106,44 @@ public class ThermalViewModelGenerationTests
             Environment.CurrentDirectory = oldDir;
         }
     }
+
+    [Fact]
+    public async Task Generated_Code_Omits_Static_Properties()
+    {
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
+        var vmDir = Path.Combine(root, "test", "ThermalTest", "ViewModels");
+        var oldDir = Environment.CurrentDirectory;
+        try
+        {
+            Environment.CurrentDirectory = vmDir;
+            var args = new[]
+            {
+                "HP3LSThermalTestViewModel.cs",
+                "ThermalZoneComponentViewModel.cs",
+                "ThermalStateEnum.cs",
+                "IHpMonitor.cs",
+                "TestSettingsModel.cs",
+                "Zone.cs"
+            };
+            if (Directory.Exists(Path.Combine(vmDir, "generated")))
+                Directory.Delete(Path.Combine(vmDir, "generated"), true);
+            if (Directory.Exists(Path.Combine(vmDir, "protos")))
+                Directory.Delete(Path.Combine(vmDir, "protos"), true);
+
+            var exitCode = await Program.Main(args);
+            Assert.Equal(0, exitCode);
+
+            var protoFile = Path.Combine(vmDir, "protos", "HP3LSThermalTestViewModelService.proto");
+            var protoText = File.ReadAllText(protoFile);
+            Assert.DoesNotContain("dts", protoText, StringComparison.OrdinalIgnoreCase);
+
+            var converterFile = Path.Combine(vmDir, "generated", "ProtoStateConverters.cs");
+            var converterText = File.ReadAllText(converterFile);
+            Assert.DoesNotContain("DTS", converterText);
+        }
+        finally
+        {
+            Environment.CurrentDirectory = oldDir;
+        }
+    }
 }

--- a/test/ThermalTest/ViewModels/generated/ProtoStateConverters.cs
+++ b/test/ThermalTest/ViewModels/generated/ProtoStateConverters.cs
@@ -16,7 +16,6 @@ public static class ProtoStateConverters
         state.CpuTemperatureThreshold = model.CpuTemperatureThreshold;
         state.CpuLoadThreshold = model.CpuLoadThreshold;
         state.CpuLoadTimeSpan = model.CpuLoadTimeSpan;
-        state.DTS = model.DTS;
         return state;
     }
 
@@ -26,7 +25,6 @@ public static class ProtoStateConverters
         model.CpuTemperatureThreshold = state.CpuTemperatureThreshold;
         model.CpuLoadThreshold = state.CpuLoadThreshold;
         model.CpuLoadTimeSpan = state.CpuLoadTimeSpan;
-        model.DTS = state.DTS;
         return model;
     }
 

--- a/test/ThermalTest/ViewModels/generated/tsProject/protos/HP3LSThermalTestViewModelService.proto
+++ b/test/ThermalTest/ViewModels/generated/tsProject/protos/HP3LSThermalTestViewModelService.proto
@@ -39,7 +39,6 @@ message TestSettingsModelState {
   int32 cpu_temperature_threshold = 1; // Original C#: int CpuTemperatureThreshold
   int32 cpu_load_threshold = 2; // Original C#: int CpuLoadThreshold
   int32 cpu_load_time_span = 3; // Original C#: int CpuLoadTimeSpan
-  map<string, int32> dts = 4; // Original C#: System.Collections.Generic.Dictionary<string, int> DTS
 }
 
 message UpdatePropertyValueRequest {

--- a/test/ThermalTest/ViewModels/protos/HP3LSThermalTestViewModelService.proto
+++ b/test/ThermalTest/ViewModels/protos/HP3LSThermalTestViewModelService.proto
@@ -39,7 +39,6 @@ message TestSettingsModelState {
   int32 cpu_temperature_threshold = 1; // Original C#: int CpuTemperatureThreshold
   int32 cpu_load_threshold = 2; // Original C#: int CpuLoadThreshold
   int32 cpu_load_time_span = 3; // Original C#: int CpuLoadTimeSpan
-  map<string, int32> dts = 4; // Original C#: System.Collections.Generic.Dictionary<string, int> DTS
 }
 
 message UpdatePropertyValueRequest {


### PR DESCRIPTION
## Summary
- prevent conversion generator from producing assignments for static properties
- skip static members when emitting nested messages in ProtoGenerator
- add regression test ensuring static properties are omitted and update generated samples

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a5cd70a9ac8320aa4de04567722c03