### PR TITLE
Use options port when configuring Kestrel

### DIFF
--- a/src/RemoteMvvmTool/Generators/ViewModelPartialGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ViewModelPartialGenerator.cs
@@ -87,7 +87,7 @@ public static class ViewModelPartialGenerator
         sb.AppendLine("            // Configure Kestrel to listen on the specified port with HTTP/2 support");
         sb.AppendLine("            builder.WebHost.ConfigureKestrel(kestrelOptions =>");
         sb.AppendLine("            {");
-        sb.AppendLine("                kestrelOptions.ListenLocalhost(NetworkConfig.Port, listenOptions =>");
+        sb.AppendLine("                kestrelOptions.ListenLocalhost(options.Port, listenOptions =>");
         sb.AppendLine("                {");
         sb.AppendLine("                    listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1AndHttp2;");
         sb.AppendLine("                });");

--- a/test/PointerTestModel/expected/PointerViewModel.Remote.g.cs
+++ b/test/PointerTestModel/expected/PointerViewModel.Remote.g.cs
@@ -59,7 +59,7 @@ namespace HPSystemsTools
             // Configure Kestrel to listen on the specified port with HTTP/2 support
             builder.WebHost.ConfigureKestrel(kestrelOptions =>
             {
-                kestrelOptions.ListenLocalhost(NetworkConfig.Port, listenOptions =>
+                kestrelOptions.ListenLocalhost(options.Port, listenOptions =>
                 {
                     listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1AndHttp2;
                 });

--- a/test/RemoteMvvmTool.Tests/RunOptionTests.cs
+++ b/test/RemoteMvvmTool.Tests/RunOptionTests.cs
@@ -147,4 +147,12 @@ public class RunOptionTests
         Assert.DoesNotContain("Control _dispatcher", partial);
         Assert.Contains($"new {name}GrpcServiceImpl(this)", partial);
     }
+
+    [Fact]
+    public void ViewModelPartialGeneration_UsesOptionsPort()
+    {
+        var partial = ViewModelPartialGenerator.Generate("TestViewModel", "Generated.Protos", "TestViewModelService", "Generated.ViewModels", "Generated.Clients", string.Empty, "console");
+        Assert.Contains("kestrelOptions.ListenLocalhost(options.Port", partial);
+        Assert.DoesNotContain("NetworkConfig.Port", partial);
+    }
 }


### PR DESCRIPTION
## Summary
- use `options.Port` instead of `NetworkConfig.Port` when configuring Kestrel in generated view model partials
- update pointer view model expected output
- add regression test ensuring generator uses `options.Port`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a5cebd1cd88320a8ca9917187226a9