### PR TITLE
Adjust generated constructors and fix test code

### DIFF
--- a/src/RemoteMvvmTool/Generators/ViewModelPartialGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ViewModelPartialGenerator.cs
@@ -41,7 +41,7 @@ public static class ViewModelPartialGenerator
         sb.AppendLine("        private GrpcChannel? _channel;");
         sb.AppendLine($"        private {clientNamespace}.{vmName}RemoteClient? _remoteClient;");
         sb.AppendLine();
-        sb.AppendLine($"        public {vmName}(ServerOptions options) : this()");
+        sb.AppendLine($"        public {vmName}(ServerOptions options)");
         sb.AppendLine("        {");
         sb.AppendLine("            if (options == null) throw new ArgumentNullException(nameof(options));");
         if (runType == "wpf")
@@ -115,7 +115,7 @@ public static class ViewModelPartialGenerator
         sb.AppendLine("            Task.Run(() => app.RunAsync()); // Run the server in a background thread");
         sb.AppendLine("        }");
         sb.AppendLine();
-        sb.AppendLine($"        public {vmName}(ClientOptions options) : this()");
+        sb.AppendLine($"        public {vmName}(ClientOptions options)");
         sb.AppendLine("        {");
         sb.AppendLine("            if (options == null) throw new ArgumentNullException(nameof(options));");
         sb.AppendLine("            _channel = GrpcChannel.ForAddress(options.Address);");

--- a/test/RemoteMvvmTool.Tests/GeneratedCodeCompilationTests.cs
+++ b/test/RemoteMvvmTool.Tests/GeneratedCodeCompilationTests.cs
@@ -40,7 +40,7 @@ public class GeneratedCodeCompilationTests
         Directory.CreateDirectory(tempDir);
         var vmDir = tempDir;
         var vmFile = Path.Combine(vmDir, "TestViewModel.cs");
-        var viewModelCode = @$"using System;\nusing System.Collections.Generic;\nusing CommunityToolkit.Mvvm.ComponentModel;\nusing CommunityToolkit.Mvvm.Input;\n\nnamespace GeneratedTests;\n\npublic partial class TestViewModel : ObservableObject\n{{\n    [ObservableProperty]\n    private Dictionary<{keyType}, {valueType}> map;\n\n    [RelayCommand]\n    void DoThing() {{ }}\n\n    public enum SampleEnum {{ A, B, C }}\n    public class NestedType {{ public int Value {{ get; set; }} }}\n}}";
+        var viewModelCode = @$"using System;\nusing System.Collections.Generic;\nusing CommunityToolkit.Mvvm.ComponentModel;\nusing CommunityToolkit.Mvvm.Input;\n\nnamespace GeneratedTests;\n\npublic partial class TestViewModel : ObservableObject\n{{\n    [ObservableProperty]\n    private Dictionary<{keyType}, {valueType}> map;\n\n    [RelayCommand]\n    void DoThing() {{ }}\n\n    public enum SampleEnum {{ A, B, C }}\n    public class NestedType {{ public int Value {{ get; set; }} }}\n}}".Replace("\\n", "\n");
         File.WriteAllText(vmFile, viewModelCode);
 
         var generatedDir = Path.Combine(vmDir, "generated");
@@ -63,7 +63,7 @@ public class GeneratedCodeCompilationTests
             .Concat(Directory.GetFiles(grpcOut, "*.cs"))
             .ToList();
 
-        var stubCode = @$"using System;\nusing System.Collections.Generic;\nusing CommunityToolkit.Mvvm.ComponentModel;\nusing CommunityToolkit.Mvvm.Input;\n\nnamespace GeneratedTests;\n\npublic partial class TestViewModel : ObservableObject\n{{\n    public Dictionary<{keyType}, {valueType}> Map {{ get; set; }} = new();\n    public IRelayCommand DoThingCommand {{ get; }} = new RelayCommand(() => {{ }});\n    public enum SampleEnum {{ A, B, C }}\n    public class NestedType {{ public int Value {{ get; set; }} }}\n}}";
+        var stubCode = @$"using System;\nusing System.Collections.Generic;\nusing CommunityToolkit.Mvvm.ComponentModel;\nusing CommunityToolkit.Mvvm.Input;\n\nnamespace GeneratedTests;\n\npublic partial class TestViewModel : ObservableObject\n{{\n    public Dictionary<{keyType}, {valueType}> Map {{ get; set; }} = new();\n    public IRelayCommand DoThingCommand {{ get; }} = new RelayCommand(() => {{ }});\n    public enum SampleEnum {{ A, B, C }}\n    public class NestedType {{ public int Value {{ get; set; }} }}\n}}".Replace("\\n", "\n");
         var stubFile = Path.Combine(vmDir, "TestViewModelStub.cs");
         File.WriteAllText(stubFile, stubCode);
         sourceFiles.Add(stubFile);


### PR DESCRIPTION
## Summary
- ensure test-generated view model sources use real newlines
- remove constructor chaining from generated view model partials to avoid needing an explicit default constructor

## Testing
- `dotnet test` *(fails: 7 Failed, 64 Passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fdcc2834832097a2af51c85da4d4