### PR TITLE
Add tests for ViewModel type transfer

### DIFF
--- a/test/ComplexTypes/ComplexTypeTests.cs
+++ b/test/ComplexTypes/ComplexTypeTests.cs
@@ -170,4 +170,17 @@ public class ComplexTypeTests
 
         AssertSecondLevel(serverVm.Layers[1], remoteClient.Layers[1]);
     }
+
+    [Fact]
+    public async Task SupportedTypes_ClientDataTransferredToServer()
+    {
+        var clientServerOptions = new ServerOptions { Port = NetworkConfig.Port };
+        using var clientVm = new SupportedComplexViewModel(clientServerOptions) { Layers = CreateSampleData() };
+
+        var serverClientOptions = new ClientOptions { Address = NetworkConfig.ServerAddress };
+        using var serverVm = new SupportedComplexViewModel(serverClientOptions);
+        using var remoteClient = await serverVm.GetRemoteModel();
+
+        AssertSecondLevel(clientVm.Layers[1], remoteClient.Layers[1]);
+    }
 }


### PR DESCRIPTION
## Summary
- add unit test ensuring SupportedComplexViewModel data flows from client to server

## Testing
- `dotnet test` *(fails: 7 tests failed in RemoteMvvmTool.Tests.dll)*
- `dotnet test test/ComplexTypes/ComplexTypes.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68a61039c37483208cd029d00bf04081