### PR TITLE
Handle error enum keys in generated client dictionaries

### DIFF
--- a/src/RemoteMvvmTool/Generators/ClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ClientGenerator.cs
@@ -126,7 +126,8 @@ public static class ClientGenerator
 
         string KeyFromProto(string expr, ITypeSymbol type)
         {
-            if (type.TypeKind == TypeKind.Enum) return $"({type.ToDisplayString()}){expr}";
+            if (type.TypeKind == TypeKind.Enum || type.TypeKind == TypeKind.Error)
+                return $"({type.ToDisplayString()}){expr}";
             return GeneratorHelpers.GetProtoWellKnownTypeFor(type) switch
             {
                 "Int32Value" => type.SpecialType == SpecialType.System_Int32 ? expr : $"({type.ToDisplayString()}){expr}",


### PR DESCRIPTION
## Summary
- Cast dictionary keys back to their enum types even when Roslyn reports an unresolved symbol

## Testing
- `dotnet test` *(fails: TypeScriptCompilationTests.Generated_TypeScript_Compiles_And_Transfers_Dictionary - missing PowerShell)*
- `dotnet test --filter "Generated_Client_Handles_Dictionary_Property" test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_68a61b57613c83209d232847490a507e