### PR TITLE
test: cover additional dictionary types

### DIFF
--- a/test/ComplexTypes/ComplexTypeTests.cs
+++ b/test/ComplexTypes/ComplexTypeTests.cs
@@ -131,6 +131,8 @@ public class ComplexTypeTests
         Assert.Contains("repeated int32 collection", proto);
         Assert.Contains("repeated string string_list", proto);
         Assert.Contains("map<string, int32> dictionary_interface", proto);
+        Assert.Contains("map<string, int32> read_only_dictionary", proto);
+        Assert.Contains("map<string, int32> read_only_dictionary_interface", proto);
 
         // Thread-safe collections
         Assert.Contains("map<string, int32> concurrent_dictionary", proto);

--- a/test/ComplexTypes/ViewModels/SupportedCollectionsViewModel.cs
+++ b/test/ComplexTypes/ViewModels/SupportedCollectionsViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace ComplexTypes.ViewModels;
@@ -43,6 +44,12 @@ public partial class SupportedCollectionsViewModel : ObservableObject
 
     [ObservableProperty]
     private IDictionary<string, int> dictionaryInterface = new Dictionary<string, int>();
+
+    [ObservableProperty]
+    private ReadOnlyDictionary<string, int> readOnlyDictionary = new(new Dictionary<string, int>());
+
+    [ObservableProperty]
+    private IReadOnlyDictionary<string, int> readOnlyDictionaryInterface = new Dictionary<string, int>();
 
     // Thread-safe collections
     [ObservableProperty]


### PR DESCRIPTION
## Summary
- verify proto generator handles read-only dictionary types
- expose new dictionary properties in test view model

## Testing
- `dotnet test` *(fails: missing `powershell` and ThermalViewModelGenerationTests assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68a61ed6e0f48320b8f8aeeba1459f8b