### PR TITLE
Add analyzer and TypeScript project generator tests

### DIFF
--- a/test/RemoteMvvmTool.Tests/TsProjectGeneratorTests.cs
+++ b/test/RemoteMvvmTool.Tests/TsProjectGeneratorTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using RemoteMvvmTool.Generators;
+using GrpcRemoteMvvmModelUtil;
+using System.Collections.Generic;
+
+namespace ToolExecution;
+
+public class TsProjectGeneratorTests
+{
+    static List<string> LoadDefaultRefs()
+    {
+        var list = new List<string>();
+        string? tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (tpa != null)
+        {
+            foreach (var p in tpa.Split(Path.PathSeparator))
+                if (!string.IsNullOrEmpty(p) && File.Exists(p)) list.Add(p);
+        }
+        return list;
+    }
+
+    static async Task<(string VmName, List<PropertyInfo> Props, List<CommandInfo> Cmds)> AnalyzeAsync()
+    {
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
+        var vmFile = Path.Combine(root, "test", "SimpleViewModelTest", "ViewModels", "MainViewModel.cs");
+        var references = LoadDefaultRefs();
+        var (sym, name, props, cmds, _) = await ViewModelAnalyzer.AnalyzeAsync(new[] { vmFile },
+            "CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute",
+            "CommunityToolkit.Mvvm.Input.RelayCommandAttribute",
+            references);
+        return (name, props, cmds);
+    }
+
+    [Fact]
+    public async Task GenerateAppTs_ImportsServiceClient()
+    {
+        var (name, props, cmds) = await AnalyzeAsync();
+        string ts = TsProjectGenerator.GenerateAppTs(name, name + "Service", props, cmds);
+        Assert.Contains("ServiceClientPb", ts);
+        Assert.Contains($"{name}RemoteClient", ts);
+    }
+
+    [Fact]
+    public async Task GenerateIndexHtml_IncludesConnectionStatusDiv()
+    {
+        var (name, props, cmds) = await AnalyzeAsync();
+        string html = TsProjectGenerator.GenerateIndexHtml(name, props, cmds);
+        Assert.Contains("id='connection-status'", html);
+    }
+
+    [Fact]
+    public void GeneratePackageJson_IncludesGrpcWebDependency()
+    {
+        string pkg = TsProjectGenerator.GeneratePackageJson("TestProject");
+        Assert.Contains("\"grpc-web\"", pkg);
+    }
+
+    [Fact]
+    public void GenerateTsConfig_SetsEs2020Target()
+    {
+        string cfg = TsProjectGenerator.GenerateTsConfig();
+        Assert.Contains("\"target\": \"es2020\"", cfg);
+    }
+
+    [Fact]
+    public void GenerateWebpackConfig_SpecifiesEntryPoint()
+    {
+        string cfg = TsProjectGenerator.GenerateWebpackConfig();
+        Assert.Contains("entry: './src/app.ts'", cfg);
+    }
+
+    [Fact]
+    public void GenerateReadme_ContainsSetupInstructions()
+    {
+        string readme = TsProjectGenerator.GenerateReadme("TestProject");
+        Assert.Contains("npm run build", readme);
+    }
+}
+

--- a/test/RemoteMvvmTool.Tests/ViewModelAnalyzerTests.cs
+++ b/test/RemoteMvvmTool.Tests/ViewModelAnalyzerTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using GrpcRemoteMvvmModelUtil;
+using System.Collections.Generic;
+
+namespace ToolExecution;
+
+public class ViewModelAnalyzerTests
+{
+    static List<string> LoadDefaultRefs()
+    {
+        var list = new List<string>();
+        string? tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (tpa != null)
+        {
+            foreach (var p in tpa.Split(Path.PathSeparator))
+                if (!string.IsNullOrEmpty(p) && File.Exists(p)) list.Add(p);
+        }
+        return list;
+    }
+
+    static async Task<(string Name, List<PropertyInfo> Props, List<CommandInfo> Cmds)> AnalyzeAsync()
+    {
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../.."));
+        var vmFile = Path.Combine(root, "test", "SimpleViewModelTest", "ViewModels", "MainViewModel.cs");
+        var references = LoadDefaultRefs();
+        var (sym, name, props, cmds, _) = await ViewModelAnalyzer.AnalyzeAsync(new[] { vmFile },
+            "CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute",
+            "CommunityToolkit.Mvvm.Input.RelayCommandAttribute",
+            references);
+        return (name, props, cmds);
+    }
+
+    [Fact]
+    public async Task AnalyzerReturnsViewModelName()
+    {
+        var (name, _, _) = await AnalyzeAsync();
+        Assert.Equal("MainViewModel", name);
+    }
+
+    [Fact]
+    public async Task AnalyzerDetectsObservableProperties()
+    {
+        var (_, props, _) = await AnalyzeAsync();
+        Assert.Single(props);
+        Assert.Equal("Devices", props[0].Name);
+    }
+
+    [Fact]
+    public async Task AnalyzerDetectsRelayCommands()
+    {
+        var (_, _, cmds) = await AnalyzeAsync();
+        Assert.Single(cmds);
+        Assert.Equal("UpdateStatus", cmds[0].MethodName);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add coverage for TsProjectGenerator outputs
- verify ViewModelAnalyzer finds expected properties and commands

## Testing
- `dotnet test` (errors building Windows-specific projects; 95 tests passed)


------
https://chatgpt.com/codex/tasks/task_e_68a6806b1d5c8320ba4c85815747d46d