### PR TITLE
Handle zones map in thermal test client

### DIFF
--- a/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelRemoteClient.ts
+++ b/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelRemoteClient.ts
@@ -57,8 +57,8 @@ export class HP3LSThermalTestViewModelRemoteClient {
 
     async initializeRemote(): Promise<void> {
         const state = await this.grpcClient.getState(new Empty());
-        this.zones = (state as any).getZones();
-        this.testSettings = (state as any).getTestSettings();
+        this.zones = (state as any).getZonesMap().toObject();
+        this.testSettings = (state as any).getTestSettings()?.toObject();
         this.showDescription = (state as any).getShowDescription();
         this.showReadme = (state as any).getShowReadme();
         this.connectionStatus = 'Connected';
@@ -69,8 +69,8 @@ export class HP3LSThermalTestViewModelRemoteClient {
 
     async refreshState(): Promise<void> {
         const state = await this.grpcClient.getState(new Empty());
-        this.zones = (state as any).getZones();
-        this.testSettings = (state as any).getTestSettings();
+        this.zones = (state as any).getZonesMap().toObject();
+        this.testSettings = (state as any).getTestSettings()?.toObject();
         this.showDescription = (state as any).getShowDescription();
         this.showReadme = (state as any).getShowReadme();
         this.notifyChange();

--- a/test/ThermalTest/ViewModels/generated/tsProject/src/HP3LSThermalTestViewModelRemoteClient.ts
+++ b/test/ThermalTest/ViewModels/generated/tsProject/src/HP3LSThermalTestViewModelRemoteClient.ts
@@ -57,8 +57,8 @@ export class HP3LSThermalTestViewModelRemoteClient {
 
     async initializeRemote(): Promise<void> {
         const state = await this.grpcClient.getState(new Empty());
-        this.zones = (state as any).getZones();
-        this.testSettings = (state as any).getTestSettings();
+        this.zones = (state as any).getZonesMap().toObject();
+        this.testSettings = (state as any).getTestSettings()?.toObject();
         this.showDescription = (state as any).getShowDescription();
         this.showReadme = (state as any).getShowReadme();
         this.connectionStatus = 'Connected';
@@ -69,8 +69,8 @@ export class HP3LSThermalTestViewModelRemoteClient {
 
     async refreshState(): Promise<void> {
         const state = await this.grpcClient.getState(new Empty());
-        this.zones = (state as any).getZones();
-        this.testSettings = (state as any).getTestSettings();
+        this.zones = (state as any).getZonesMap().toObject();
+        this.testSettings = (state as any).getTestSettings()?.toObject();
         this.showDescription = (state as any).getShowDescription();
         this.showReadme = (state as any).getShowReadme();
         this.notifyChange();


### PR DESCRIPTION
## Summary
- fix remote client to extract zone state from map and unwrap test settings

## Testing
- `dotnet test` *(fails: An error occurred trying to start process 'code'...)*

------
https://chatgpt.com/codex/tasks/task_e_68a691ee0d948320a069895f91a06d9d