### PR TITLE
fix: update ts dictionary test stub

### DIFF
--- a/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptCompilationTests.cs
+++ b/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptCompilationTests.cs
@@ -145,8 +145,8 @@ import {{ {name}ServiceClient }} from './generated/{name}ServiceServiceClientPb'
 class FakeClient extends {name}ServiceClient {{
   async getState(_req:any) {{
     return {{
-      getZones: () => ({{ 0: {{ zone: 0, temperature: 42 }} }}),
-      getTestSettings: () => ({{ cpuTemperatureThreshold:0, cpuLoadThreshold:0, cpuLoadTimeSpan:0, dTS:{{}} }}),
+      getZonesMap: () => ({{ toObject: () => ({{ 0: {{ zone: 0, temperature: 42 }} }}) }}),
+      getTestSettings: () => ({{ toObject: () => ({{ cpuTemperatureThreshold:0, cpuLoadThreshold:0, cpuLoadTimeSpan:0, dTS:{{}} }}) }}),
       getShowDescription: () => true,
       getShowReadme: () => false
     }};


### PR DESCRIPTION
## Summary
- update TypeScriptCompilationTests stub to use getZonesMap and toObject

## Testing
- `dotnet test` *(fails: An error occurred trying to start process 'code' ...)*
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj --filter "FullyQualifiedName~Generated_TypeScript_Compiles_And_Transfers_Dictionary"`

------
https://chatgpt.com/codex/tasks/task_e_68a6f672d3b883209154ca4f05910658