### PR TITLE
Add TypeScript generation tests

### DIFF
--- a/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptGenerationTests.cs
+++ b/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptGenerationTests.cs
@@ -22,6 +22,19 @@ public class TypeScriptGenerationTests
         return list;
     }
 
+    static async Task<string> GenerateTsAsync(string code)
+    {
+        var tmp = Path.GetTempFileName();
+        File.WriteAllText(tmp, code);
+        var refs = LoadDefaultRefs();
+        var (_, name, props, cmds, _) = await ViewModelAnalyzer.AnalyzeAsync(new[] { tmp },
+            "ObservablePropertyAttribute",
+            "RelayCommandAttribute",
+            refs,
+            "ObservableObject");
+        return TypeScriptClientGenerator.Generate(name, "Test.Protos", name + "Service", props, cmds);
+    }
+
     [Fact]
     public async Task GeneratesInterfacesForDependentTypes()
     {
@@ -38,15 +51,102 @@ public partial class ParentViewModel : ObservableObject
 }
 public class ObservableObject {}
 ";
-        var tmp = Path.GetTempFileName();
-        File.WriteAllText(tmp, code);
-        var refs = LoadDefaultRefs();
-        var (_, name, props, cmds, _) = await ViewModelAnalyzer.AnalyzeAsync(new[] { tmp },
-            "ObservablePropertyAttribute",
-            "RelayCommandAttribute",
-            refs,
-            "ObservableObject");
-        var ts = TypeScriptClientGenerator.Generate(name, "Test.Protos", name + "Service", props, cmds);
+        var ts = await GenerateTsAsync(code);
         Assert.Contains("export interface ChildState", ts);
+    }
+
+    [Fact]
+    public async Task Maps_Primitive_Types_To_TS_Primitives()
+    {
+        var code = @"\
+public class ObservablePropertyAttribute : System.Attribute {}
+public partial class PrimitiveViewModel : ObservableObject
+{
+    [ObservableProperty]
+    public string Name { get; set; }
+    [ObservableProperty]
+    public bool IsActive { get; set; }
+    [ObservableProperty]
+    public int Age { get; set; }
+}
+public class ObservableObject {}
+";
+        var ts = await GenerateTsAsync(code);
+        Assert.Contains("name: string;", ts);
+        Assert.Contains("isActive: boolean;", ts);
+        Assert.Contains("age: number;", ts);
+    }
+
+    [Fact]
+    public async Task Maps_Array_Types_To_TS_Arrays()
+    {
+        var code = @"\
+public class ObservablePropertyAttribute : System.Attribute {}
+public partial class ArrayViewModel : ObservableObject
+{
+    [ObservableProperty]
+    public int[] Numbers { get; set; }
+    [ObservableProperty]
+    public System.Collections.Generic.List<string> Names { get; set; }
+}
+public class ObservableObject {}
+";
+        var ts = await GenerateTsAsync(code);
+        Assert.Contains("numbers: number[];", ts);
+        Assert.Contains("names: string[];", ts);
+    }
+
+    [Fact]
+    public async Task Maps_Dictionary_To_Record()
+    {
+        var code = @"\
+public class ObservablePropertyAttribute : System.Attribute {}
+public partial class DictViewModel : ObservableObject
+{
+    [ObservableProperty]
+    public System.Collections.Generic.Dictionary<string, int> Values { get; set; }
+}
+public class ObservableObject {}
+";
+        var ts = await GenerateTsAsync(code);
+        Assert.Contains("values: Record<string, number>;", ts);
+    }
+
+    [Fact]
+    public async Task Maps_Enum_To_Number()
+    {
+        var code = @"\
+public class ObservablePropertyAttribute : System.Attribute {}
+public enum Status { Active, Inactive }
+public partial class EnumViewModel : ObservableObject
+{
+    [ObservableProperty]
+    public Status CurrentStatus { get; set; }
+}
+public class ObservableObject {}
+";
+        var ts = await GenerateTsAsync(code);
+        Assert.Contains("currentStatus: number;", ts);
+    }
+
+    [Fact]
+    public async Task Generates_Command_Methods()
+    {
+        var code = @"\
+public class ObservablePropertyAttribute : System.Attribute {}
+public class RelayCommandAttribute : System.Attribute {}
+public partial class CommandViewModel : ObservableObject
+{
+    [ObservableProperty]
+    public int Count { get; set; }
+
+    [RelayCommand]
+    public void DoStuff(int value) {}
+}
+public class ObservableObject {}
+";
+        var ts = await GenerateTsAsync(code);
+        Assert.Contains("DoStuffRequest", ts);
+        Assert.Contains("async doStuff(value: any): Promise<void>", ts);
     }
 }


### PR DESCRIPTION
## Summary
- expand TypeScript generation coverage with helper and five new tests

## Testing
- `dotnet test` *(fails: An error occurred trying to start process 'code' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f787096c8320859c34ade76372fe