### PR TITLE
Fix enum ambiguity and list value conversion

### DIFF
--- a/src/RemoteMvvmTool/Generators/ServerGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ServerGenerator.cs
@@ -336,7 +336,7 @@ public static class ServerGenerator
         sb.AppendLine("            case float f: return Any.Pack(new FloatValue { Value = f });");
         sb.AppendLine("            case long l: return Any.Pack(new Int64Value { Value = l });");
         sb.AppendLine("            case DateTime dt: return Any.Pack(Timestamp.FromDateTime(dt.ToUniversalTime()));");
-        sb.AppendLine("            case Enum e: return Any.Pack(new Int32Value { Value = Convert.ToInt32(e) });");
+        sb.AppendLine("            case global::System.Enum e: return Any.Pack(new Int32Value { Value = Convert.ToInt32(e) });");
         sb.AppendLine("        }");
         sb.AppendLine("        if (value is IDictionary dict)");
         sb.AppendLine("        {");
@@ -369,7 +369,7 @@ public static class ServerGenerator
         sb.AppendLine("            case long l: return Value.ForNumber(l);");
         sb.AppendLine("            case double d: return Value.ForNumber(d);");
         sb.AppendLine("            case float f: return Value.ForNumber(f);");
-        sb.AppendLine("            case Enum e: return Value.ForNumber(Convert.ToInt32(e));");
+        sb.AppendLine("            case global::System.Enum e: return Value.ForNumber(Convert.ToInt32(e));");
         sb.AppendLine("            case DateTime dt: return Value.ForString(dt.ToUniversalTime().ToString(\"o\"));");
         sb.AppendLine("        }");
         sb.AppendLine("        if (value is IDictionary dict)");
@@ -384,7 +384,7 @@ public static class ServerGenerator
         sb.AppendLine("            var lv = new ListValue();");
         sb.AppendLine("            foreach (var item in enumerable)");
         sb.AppendLine("                lv.Values.Add(ToValue(item));");
-        sb.AppendLine("            return Value.ForList(lv);");
+        sb.AppendLine("            return Value.ForList(lv.Values.ToArray());");
         sb.AppendLine("        }");
         sb.AppendLine("        var structValue = new Struct();");
         sb.AppendLine("        foreach (var prop in value.GetType().GetProperties())");

--- a/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
+++ b/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
@@ -10,6 +10,7 @@ using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.ComponentModel;
@@ -215,15 +216,7 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
         catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error getting property value for " + e.PropertyName + ": " + ex.Message); return; }
 
         var notification = new MonsterClicker.ViewModels.Protos.PropertyChangeNotification { PropertyName = e.PropertyName };
-        if (newValue == null) notification.NewValue = Any.Pack(new Empty());
-        else if (newValue is string s) notification.NewValue = Any.Pack(new StringValue { Value = s });
-        else if (newValue is int i) notification.NewValue = Any.Pack(new Int32Value { Value = i });
-        else if (newValue is bool b) notification.NewValue = Any.Pack(new BoolValue { Value = b });
-        else if (newValue is double d) notification.NewValue = Any.Pack(new DoubleValue { Value = d });
-        else if (newValue is float f) notification.NewValue = Any.Pack(new FloatValue { Value = f });
-        else if (newValue is long l) notification.NewValue = Any.Pack(new Int64Value { Value = l });
-        else if (newValue is DateTime dt) notification.NewValue = Any.Pack(Timestamp.FromDateTime(dt.ToUniversalTime()));
-        else { Debug.WriteLine($"[GrpcService:GameViewModel] PropertyChanged: Packing not implemented for type {(newValue?.GetType().FullName ?? "null")} of property {e.PropertyName}."); notification.NewValue = Any.Pack(new StringValue { Value = newValue.ToString() }); }
+        notification.NewValue = PackToAny(newValue);
 
         foreach (var channelWriter in _subscriberChannels.Values.Select(c => c.Writer))
         {
@@ -231,5 +224,73 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
             catch (ChannelClosedException) { Debug.WriteLine("[GrpcService:GameViewModel] Channel closed for a subscriber, cannot write notification for '" + e.PropertyName + "'. Subscriber likely disconnected."); }
             catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error writing to subscriber channel for '" + e.PropertyName + "': " + ex.Message); }
         }
+    }
+
+    private static Any PackToAny(object? value)
+    {
+        if (value == null) return Any.Pack(new Empty());
+        switch (value)
+        {
+            case string s: return Any.Pack(new StringValue { Value = s });
+            case int i: return Any.Pack(new Int32Value { Value = i });
+            case bool b: return Any.Pack(new BoolValue { Value = b });
+            case double d: return Any.Pack(new DoubleValue { Value = d });
+            case float f: return Any.Pack(new FloatValue { Value = f });
+            case long l: return Any.Pack(new Int64Value { Value = l });
+            case DateTime dt: return Any.Pack(Timestamp.FromDateTime(dt.ToUniversalTime()));
+            case global::System.Enum e: return Any.Pack(new Int32Value { Value = Convert.ToInt32(e) });
+        }
+        if (value is IDictionary dict)
+        {
+            var sv = new Struct();
+            foreach (DictionaryEntry entry in dict)
+                sv.Fields[entry.Key?.ToString() ?? string.Empty] = ToValue(entry.Value);
+            return Any.Pack(sv);
+        }
+        if (value is IEnumerable enumerable && value is not string)
+        {
+            var lv = new ListValue();
+            foreach (var item in enumerable)
+                lv.Values.Add(ToValue(item));
+            return Any.Pack(lv);
+        }
+        var structValue = new Struct();
+        foreach (var prop in value.GetType().GetProperties())
+            structValue.Fields[prop.Name] = ToValue(prop.GetValue(value));
+        return Any.Pack(structValue);
+    }
+
+    private static Value ToValue(object? value)
+    {
+        if (value == null) return Value.ForNull();
+        switch (value)
+        {
+            case string s: return Value.ForString(s);
+            case bool b: return Value.ForBool(b);
+            case int i: return Value.ForNumber(i);
+            case long l: return Value.ForNumber(l);
+            case double d: return Value.ForNumber(d);
+            case float f: return Value.ForNumber(f);
+            case global::System.Enum e: return Value.ForNumber(Convert.ToInt32(e));
+            case DateTime dt: return Value.ForString(dt.ToUniversalTime().ToString("o"));
+        }
+        if (value is IDictionary dict)
+        {
+            var sv = new Struct();
+            foreach (DictionaryEntry entry in dict)
+                sv.Fields[entry.Key?.ToString() ?? string.Empty] = ToValue(entry.Value);
+            return Value.ForStruct(sv);
+        }
+        if (value is IEnumerable enumerable && value is not string)
+        {
+            var lv = new ListValue();
+            foreach (var item in enumerable)
+                lv.Values.Add(ToValue(item));
+            return Value.ForList(lv.Values.ToArray());
+        }
+        var structValue = new Struct();
+        foreach (var prop in value.GetType().GetProperties())
+            structValue.Fields[prop.Name] = ToValue(prop.GetValue(value));
+        return Value.ForStruct(structValue);
     }
 }

--- a/test/PointerTestModel/expected/PointerViewModelGrpcServiceImpl.cs
+++ b/test/PointerTestModel/expected/PointerViewModelGrpcServiceImpl.cs
@@ -10,6 +10,7 @@ using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.ComponentModel;
@@ -357,15 +358,7 @@ public partial class PointerViewModelGrpcServiceImpl : PointerViewModelService.P
         catch (Exception ex) { Debug.WriteLine("[GrpcService:PointerViewModel] Error getting property value for " + e.PropertyName + ": " + ex.Message); return; }
 
         var notification = new Pointer.ViewModels.Protos.PropertyChangeNotification { PropertyName = e.PropertyName };
-        if (newValue == null) notification.NewValue = Any.Pack(new Empty());
-        else if (newValue is string s) notification.NewValue = Any.Pack(new StringValue { Value = s });
-        else if (newValue is int i) notification.NewValue = Any.Pack(new Int32Value { Value = i });
-        else if (newValue is bool b) notification.NewValue = Any.Pack(new BoolValue { Value = b });
-        else if (newValue is double d) notification.NewValue = Any.Pack(new DoubleValue { Value = d });
-        else if (newValue is float f) notification.NewValue = Any.Pack(new FloatValue { Value = f });
-        else if (newValue is long l) notification.NewValue = Any.Pack(new Int64Value { Value = l });
-        else if (newValue is DateTime dt) notification.NewValue = Any.Pack(Timestamp.FromDateTime(dt.ToUniversalTime()));
-        else { Debug.WriteLine($"[GrpcService:PointerViewModel] PropertyChanged: Packing not implemented for type {(newValue?.GetType().FullName ?? "null")} of property {e.PropertyName}."); notification.NewValue = Any.Pack(new StringValue { Value = newValue.ToString() }); }
+        notification.NewValue = PackToAny(newValue);
 
         foreach (var channelWriter in _subscriberChannels.Values.Select(c => c.Writer))
         {
@@ -373,5 +366,73 @@ public partial class PointerViewModelGrpcServiceImpl : PointerViewModelService.P
             catch (ChannelClosedException) { Debug.WriteLine("[GrpcService:PointerViewModel] Channel closed for a subscriber, cannot write notification for '" + e.PropertyName + "'. Subscriber likely disconnected."); }
             catch (Exception ex) { Debug.WriteLine("[GrpcService:PointerViewModel] Error writing to subscriber channel for '" + e.PropertyName + "': " + ex.Message); }
         }
+    }
+
+    private static Any PackToAny(object? value)
+    {
+        if (value == null) return Any.Pack(new Empty());
+        switch (value)
+        {
+            case string s: return Any.Pack(new StringValue { Value = s });
+            case int i: return Any.Pack(new Int32Value { Value = i });
+            case bool b: return Any.Pack(new BoolValue { Value = b });
+            case double d: return Any.Pack(new DoubleValue { Value = d });
+            case float f: return Any.Pack(new FloatValue { Value = f });
+            case long l: return Any.Pack(new Int64Value { Value = l });
+            case DateTime dt: return Any.Pack(Timestamp.FromDateTime(dt.ToUniversalTime()));
+            case global::System.Enum e: return Any.Pack(new Int32Value { Value = Convert.ToInt32(e) });
+        }
+        if (value is IDictionary dict)
+        {
+            var sv = new Struct();
+            foreach (DictionaryEntry entry in dict)
+                sv.Fields[entry.Key?.ToString() ?? string.Empty] = ToValue(entry.Value);
+            return Any.Pack(sv);
+        }
+        if (value is IEnumerable enumerable && value is not string)
+        {
+            var lv = new ListValue();
+            foreach (var item in enumerable)
+                lv.Values.Add(ToValue(item));
+            return Any.Pack(lv);
+        }
+        var structValue = new Struct();
+        foreach (var prop in value.GetType().GetProperties())
+            structValue.Fields[prop.Name] = ToValue(prop.GetValue(value));
+        return Any.Pack(structValue);
+    }
+
+    private static Value ToValue(object? value)
+    {
+        if (value == null) return Value.ForNull();
+        switch (value)
+        {
+            case string s: return Value.ForString(s);
+            case bool b: return Value.ForBool(b);
+            case int i: return Value.ForNumber(i);
+            case long l: return Value.ForNumber(l);
+            case double d: return Value.ForNumber(d);
+            case float f: return Value.ForNumber(f);
+            case global::System.Enum e: return Value.ForNumber(Convert.ToInt32(e));
+            case DateTime dt: return Value.ForString(dt.ToUniversalTime().ToString("o"));
+        }
+        if (value is IDictionary dict)
+        {
+            var sv = new Struct();
+            foreach (DictionaryEntry entry in dict)
+                sv.Fields[entry.Key?.ToString() ?? string.Empty] = ToValue(entry.Value);
+            return Value.ForStruct(sv);
+        }
+        if (value is IEnumerable enumerable && value is not string)
+        {
+            var lv = new ListValue();
+            foreach (var item in enumerable)
+                lv.Values.Add(ToValue(item));
+            return Value.ForList(lv.Values.ToArray());
+        }
+        var structValue = new Struct();
+        foreach (var prop in value.GetType().GetProperties())
+            structValue.Fields[prop.Name] = ToValue(prop.GetValue(value));
+        return Value.ForStruct(structValue);
     }
 }

--- a/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptCompilationTests.cs
+++ b/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptCompilationTests.cs
@@ -145,7 +145,7 @@ import {{ {name}ServiceClient }} from './generated/{name}ServiceServiceClientPb'
 class FakeClient extends {name}ServiceClient {{
   async getState(_req:any) {{
     return {{
-      getZones: () => ({{ 0: {{ zone: 0, temperature: 42 }} }}),
+      getZonesMap: () => ({{ toObject: () => ({{ 0: {{ zone: 0, temperature: 42 }} }}) }}),
       getTestSettings: () => ({{ cpuTemperatureThreshold:0, cpuLoadThreshold:0, cpuLoadTimeSpan:0, dTS:{{}} }}),
       getShowDescription: () => true,
       getShowReadme: () => false

--- a/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
@@ -10,6 +10,7 @@ using Google.Protobuf.WellKnownTypes;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.ComponentModel;
@@ -175,15 +176,7 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
         catch (Exception ex) { Debug.WriteLine("[GrpcService:SampleViewModel] Error getting property value for " + e.PropertyName + ": " + ex.Message); return; }
 
         var notification = new SampleApp.ViewModels.Protos.PropertyChangeNotification { PropertyName = e.PropertyName };
-        if (newValue == null) notification.NewValue = Any.Pack(new Empty());
-        else if (newValue is string s) notification.NewValue = Any.Pack(new StringValue { Value = s });
-        else if (newValue is int i) notification.NewValue = Any.Pack(new Int32Value { Value = i });
-        else if (newValue is bool b) notification.NewValue = Any.Pack(new BoolValue { Value = b });
-        else if (newValue is double d) notification.NewValue = Any.Pack(new DoubleValue { Value = d });
-        else if (newValue is float f) notification.NewValue = Any.Pack(new FloatValue { Value = f });
-        else if (newValue is long l) notification.NewValue = Any.Pack(new Int64Value { Value = l });
-        else if (newValue is DateTime dt) notification.NewValue = Any.Pack(Timestamp.FromDateTime(dt.ToUniversalTime()));
-        else { Debug.WriteLine($"[GrpcService:SampleViewModel] PropertyChanged: Packing not implemented for type {(newValue?.GetType().FullName ?? "null")} of property {e.PropertyName}."); notification.NewValue = Any.Pack(new StringValue { Value = newValue.ToString() }); }
+        notification.NewValue = PackToAny(newValue);
 
         foreach (var channelWriter in _subscriberChannels.Values.Select(c => c.Writer))
         {
@@ -191,5 +184,73 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             catch (ChannelClosedException) { Debug.WriteLine("[GrpcService:SampleViewModel] Channel closed for a subscriber, cannot write notification for '" + e.PropertyName + "'. Subscriber likely disconnected."); }
             catch (Exception ex) { Debug.WriteLine("[GrpcService:SampleViewModel] Error writing to subscriber channel for '" + e.PropertyName + "': " + ex.Message); }
         }
+    }
+
+    private static Any PackToAny(object? value)
+    {
+        if (value == null) return Any.Pack(new Empty());
+        switch (value)
+        {
+            case string s: return Any.Pack(new StringValue { Value = s });
+            case int i: return Any.Pack(new Int32Value { Value = i });
+            case bool b: return Any.Pack(new BoolValue { Value = b });
+            case double d: return Any.Pack(new DoubleValue { Value = d });
+            case float f: return Any.Pack(new FloatValue { Value = f });
+            case long l: return Any.Pack(new Int64Value { Value = l });
+            case DateTime dt: return Any.Pack(Timestamp.FromDateTime(dt.ToUniversalTime()));
+            case global::System.Enum e: return Any.Pack(new Int32Value { Value = Convert.ToInt32(e) });
+        }
+        if (value is IDictionary dict)
+        {
+            var sv = new Struct();
+            foreach (DictionaryEntry entry in dict)
+                sv.Fields[entry.Key?.ToString() ?? string.Empty] = ToValue(entry.Value);
+            return Any.Pack(sv);
+        }
+        if (value is IEnumerable enumerable && value is not string)
+        {
+            var lv = new ListValue();
+            foreach (var item in enumerable)
+                lv.Values.Add(ToValue(item));
+            return Any.Pack(lv);
+        }
+        var structValue = new Struct();
+        foreach (var prop in value.GetType().GetProperties())
+            structValue.Fields[prop.Name] = ToValue(prop.GetValue(value));
+        return Any.Pack(structValue);
+    }
+
+    private static Value ToValue(object? value)
+    {
+        if (value == null) return Value.ForNull();
+        switch (value)
+        {
+            case string s: return Value.ForString(s);
+            case bool b: return Value.ForBool(b);
+            case int i: return Value.ForNumber(i);
+            case long l: return Value.ForNumber(l);
+            case double d: return Value.ForNumber(d);
+            case float f: return Value.ForNumber(f);
+            case global::System.Enum e: return Value.ForNumber(Convert.ToInt32(e));
+            case DateTime dt: return Value.ForString(dt.ToUniversalTime().ToString("o"));
+        }
+        if (value is IDictionary dict)
+        {
+            var sv = new Struct();
+            foreach (DictionaryEntry entry in dict)
+                sv.Fields[entry.Key?.ToString() ?? string.Empty] = ToValue(entry.Value);
+            return Value.ForStruct(sv);
+        }
+        if (value is IEnumerable enumerable && value is not string)
+        {
+            var lv = new ListValue();
+            foreach (var item in enumerable)
+                lv.Values.Add(ToValue(item));
+            return Value.ForList(lv.Values.ToArray());
+        }
+        var structValue = new Struct();
+        foreach (var prop in value.GetType().GetProperties())
+            structValue.Fields[prop.Name] = ToValue(prop.GetValue(value));
+        return Value.ForStruct(structValue);
     }
 }


### PR DESCRIPTION
## Summary
- fully qualify `Enum` in server generator to avoid namespace conflicts
- convert list values with `Value.ForList(lv.Values.ToArray())`
- adjust TypeScript dictionary test stub for map access
- refresh expected gRPC server implementations

## Testing
- `dotnet test` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop for MonsterClicker and PointerViewModelTests)*
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj --filter FullyQualifiedName~Generated_Code_Compiles_For_Dictionary_Types`
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj --filter FullyQualifiedName~TypeScriptCompilationTests.Generated_TypeScript_Compiles_And_Transfers_Dictionary`


------
https://chatgpt.com/codex/tasks/task_e_68a6f714a3008320878721f8e2691ac8