### PR TITLE
Resolve dictionary generation compile warnings

### DIFF
--- a/src/RemoteMvvmTool/Generators/ServerGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ServerGenerator.cs
@@ -256,7 +256,10 @@ public static class ServerGenerator
                         sb.AppendLine("                command.ExecuteAsync(null).GetAwaiter().GetResult();");
                 }
                 else
+                {
                     sb.AppendLine("                command.Execute(null);");
+                    if (runType == "wpf") sb.AppendLine("                await Task.CompletedTask;");
+                }
             }
                 else if (cmd.Parameters.Count == 1)
             {
@@ -277,7 +280,10 @@ public static class ServerGenerator
                         sb.AppendLine($"                if (typedCommand != null) typedCommand.ExecuteAsync({paramConv}).GetAwaiter().GetResult(); else command.ExecuteAsync(request).GetAwaiter().GetResult();");
                 }
                 else
+                {
                     sb.AppendLine($"                if (typedCommand != null) typedCommand.Execute({paramConv}); else command.Execute(request);");
+                    if (runType == "wpf") sb.AppendLine("                await Task.CompletedTask;");
+                }
             }
             else
             {
@@ -289,7 +295,10 @@ public static class ServerGenerator
                         sb.AppendLine("                command.ExecuteAsync(request).GetAwaiter().GetResult();");
                 }
                 else
+                {
                     sb.AppendLine("                command.Execute(request);");
+                    if (runType == "wpf") sb.AppendLine("                await Task.CompletedTask;");
+                }
             }
             sb.AppendLine("            }");
             sb.AppendLine($"            else {{ Debug.WriteLine(\"[GrpcService:{vmName}] Command {cmd.CommandPropertyName} not found or not {relayTypeShort}.\"); }}");
@@ -383,8 +392,8 @@ public static class ServerGenerator
         sb.AppendLine("        {");
         sb.AppendLine("            var lv = new List<Value>();");
         sb.AppendLine("            foreach (var item in enumerable)");
-        sb.AppendLine("                lv.Values.Add(ToValue(item));");
-        sb.AppendLine("            return Value.ForList(lv.Values.ToArray());");
+        sb.AppendLine("                lv.Add(ToValue(item));");
+        sb.AppendLine("            return Value.ForList(lv.ToArray());");
         sb.AppendLine("        }");
         sb.AppendLine("        var structValue = new Struct();");
         sb.AppendLine("        foreach (var prop in value.GetType().GetProperties())");

--- a/src/RemoteMvvmTool/Generators/ViewModelPartialGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ViewModelPartialGenerator.cs
@@ -82,7 +82,7 @@ public static class ViewModelPartialGenerator
         sb.AppendLine("            }));");
         sb.AppendLine();
         sb.AppendLine("            // Register the gRPC service implementation with ASP.NET Core DI");
-        sb.AppendLine("            builder.Services.AddSingleton(_grpcService);");
+        sb.AppendLine("            builder.Services.AddSingleton(_grpcService!);");
         sb.AppendLine();
         sb.AppendLine("            // Configure Kestrel to listen on the specified port with HTTP/2 support");
         sb.AppendLine("            builder.WebHost.ConfigureKestrel(kestrelOptions =>");
@@ -118,6 +118,7 @@ public static class ViewModelPartialGenerator
         sb.AppendLine($"        public {vmName}(ClientOptions options)");
         sb.AppendLine("        {");
         sb.AppendLine("            if (options == null) throw new ArgumentNullException(nameof(options));");
+        if (runType == "wpf" || runType == "winforms") sb.AppendLine("            _dispatcher = null!;");
         sb.AppendLine("            _channel = GrpcChannel.ForAddress(options.Address);");
         sb.AppendLine($"            var client = new {serviceName}.{serviceName}Client(_channel);");
         sb.AppendLine($"            _remoteClient = new {vmName}RemoteClient(client);");

--- a/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
+++ b/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
@@ -167,6 +167,7 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
             if (command != null)
             {
                 command.Execute(null);
+                await Task.CompletedTask;
             }
             else { Debug.WriteLine("[GrpcService:GameViewModel] Command AttackMonsterCommand not found or not IRelayCommand."); }
         }); } catch (Exception ex) {
@@ -199,6 +200,7 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
             if (command != null)
             {
                 command.Execute(null);
+                await Task.CompletedTask;
             }
             else { Debug.WriteLine("[GrpcService:GameViewModel] Command ResetGameCommand not found or not IRelayCommand."); }
         }); } catch (Exception ex) {
@@ -283,10 +285,10 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
         }
         if (value is IEnumerable enumerable && value is not string)
         {
-            var lv = new ListValue();
+            var lv = new List<Value>();
             foreach (var item in enumerable)
-                lv.Values.Add(ToValue(item));
-            return Value.ForList(lv.Values.ToArray());
+                lv.Add(ToValue(item));
+            return Value.ForList(lv.ToArray());
         }
         var structValue = new Struct();
         foreach (var prop in value.GetType().GetProperties())


### PR DESCRIPTION
## Summary
- ensure synchronous dispatcher invocations await a Task to avoid CS1998
- fix generated dictionary conversions to use List<Value>
- initialize dispatcher in partial view models and register gRPC service with null-forgiving operator

## Testing
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj -v minimal`
- `dotnet test` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fe7322848320b1554a521c92649d