### PR TITLE
Fix TypeScript dictionary state retrieval

### DIFF
--- a/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
@@ -181,7 +181,7 @@ public static class TypeScriptClientGenerator
         {
             string expr;
             if (GeneratorHelpers.TryGetDictionaryTypeArgs(p.FullTypeSymbol!, out _, out _))
-                expr = $"(state as any).get{p.Name}Map().toObject()";
+                expr = $"(state as any).get{p.Name}()";
             else if (p.FullTypeSymbol is INamedTypeSymbol nt &&
                      (nt.TypeKind == TypeKind.Class || nt.TypeKind == TypeKind.Struct) &&
                      !GeneratorHelpers.IsWellKnownType(p.FullTypeSymbol!) &&
@@ -203,7 +203,7 @@ public static class TypeScriptClientGenerator
         {
             string expr;
             if (GeneratorHelpers.TryGetDictionaryTypeArgs(p.FullTypeSymbol!, out _, out _))
-                expr = $"(state as any).get{p.Name}Map().toObject()";
+                expr = $"(state as any).get{p.Name}()";
             else if (p.FullTypeSymbol is INamedTypeSymbol nt &&
                      (nt.TypeKind == TypeKind.Class || nt.TypeKind == TypeKind.Struct) &&
                      !GeneratorHelpers.IsWellKnownType(p.FullTypeSymbol!) &&


### PR DESCRIPTION
## Summary
- use simple getter for dictionary properties when initializing or refreshing TypeScript client state

## Testing
- `dotnet test` *(fails: System.ComponentModel.Win32Exception : An error occurred trying to start process 'powershell' ... No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7121e36048320bd2ba54678d068ea