### PR TITLE
Support double values in TS client generator

### DIFF
--- a/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
@@ -144,7 +144,7 @@ public static class TypeScriptClientGenerator
         sb.AppendLine("import * as grpcWeb from 'grpc-web';");
         sb.AppendLine("import { Empty } from 'google-protobuf/google/protobuf/empty_pb';");
         sb.AppendLine("import { Any } from 'google-protobuf/google/protobuf/any_pb';");
-        sb.AppendLine("import { StringValue, Int32Value, BoolValue } from 'google-protobuf/google/protobuf/wrappers_pb';");
+        sb.AppendLine("import { StringValue, Int32Value, BoolValue, DoubleValue } from 'google-protobuf/google/protobuf/wrappers_pb';");
         sb.AppendLine();
 
         // generate state interfaces for complex types
@@ -229,10 +229,16 @@ public static class TypeScriptClientGenerator
         sb.AppendLine("            const wrapper = new StringValue();");
         sb.AppendLine("            wrapper.setValue(value);");
         sb.AppendLine("            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.StringValue');");
-        sb.AppendLine("        } else if (typeof value === 'number' && Number.isInteger(value)) {");
-        sb.AppendLine("            const wrapper = new Int32Value();");
-        sb.AppendLine("            wrapper.setValue(value);");
-        sb.AppendLine("            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');");
+        sb.AppendLine("        } else if (typeof value === 'number') {");
+        sb.AppendLine("            if (Number.isInteger(value)) {");
+        sb.AppendLine("                const wrapper = new Int32Value();");
+        sb.AppendLine("                wrapper.setValue(value);");
+        sb.AppendLine("                anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');");
+        sb.AppendLine("            } else {");
+        sb.AppendLine("                const wrapper = new DoubleValue();");
+        sb.AppendLine("                wrapper.setValue(value);");
+        sb.AppendLine("                anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.DoubleValue');");
+        sb.AppendLine("            }");
         sb.AppendLine("        } else if (typeof value === 'boolean') {");
         sb.AppendLine("            const wrapper = new BoolValue();");
         sb.AppendLine("            wrapper.setValue(value);");
@@ -294,6 +300,7 @@ public static class TypeScriptClientGenerator
                     "StringValue" => "StringValue.deserializeBinary",
                     "Int32Value" => "Int32Value.deserializeBinary",
                     "BoolValue" => "BoolValue.deserializeBinary",
+                    "DoubleValue" => "DoubleValue.deserializeBinary",
                     _ => ""
                 };
                 sb.AppendLine($"                case '{p.Name}':");

--- a/test/GameViewModel/expected/GameViewModelRemoteClient.ts
+++ b/test/GameViewModel/expected/GameViewModelRemoteClient.ts
@@ -7,7 +7,7 @@ import { GameViewModelState, UpdatePropertyValueRequest, SubscribeRequest, Prope
 import * as grpcWeb from 'grpc-web';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { Any } from 'google-protobuf/google/protobuf/any_pb';
-import { StringValue, Int32Value, BoolValue } from 'google-protobuf/google/protobuf/wrappers_pb';
+import { StringValue, Int32Value, BoolValue, DoubleValue } from 'google-protobuf/google/protobuf/wrappers_pb';
 
 export class GameViewModelRemoteClient {
     private readonly grpcClient: GameViewModelServiceClient;
@@ -79,10 +79,16 @@ export class GameViewModelRemoteClient {
             const wrapper = new StringValue();
             wrapper.setValue(value);
             anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.StringValue');
-        } else if (typeof value === 'number' && Number.isInteger(value)) {
-            const wrapper = new Int32Value();
-            wrapper.setValue(value);
-            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');
+        } else if (typeof value === 'number') {
+            if (Number.isInteger(value)) {
+                const wrapper = new Int32Value();
+                wrapper.setValue(value);
+                anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');
+            } else {
+                const wrapper = new DoubleValue();
+                wrapper.setValue(value);
+                anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.DoubleValue');
+            }
         } else if (typeof value === 'boolean') {
             const wrapper = new BoolValue();
             wrapper.setValue(value);

--- a/test/PointerTestModel/RemoteGenerated/PointerViewModelRemoteClient.ts
+++ b/test/PointerTestModel/RemoteGenerated/PointerViewModelRemoteClient.ts
@@ -4,7 +4,7 @@ import { PointerViewModelState, UpdatePropertyValueRequest, SubscribeRequest, Pr
 import * as grpcWeb from 'grpc-web';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { Any } from 'google-protobuf/google/protobuf/any_pb';
-import { StringValue, Int32Value, BoolValue } from 'google-protobuf/google/protobuf/wrappers_pb';
+import { StringValue, Int32Value, BoolValue, DoubleValue } from 'google-protobuf/google/protobuf/wrappers_pb';
 
 export class PointerViewModelRemoteClient {
     private readonly grpcClient: PointerViewModelServiceClient;
@@ -94,10 +94,16 @@ export class PointerViewModelRemoteClient {
             const wrapper = new StringValue();
             wrapper.setValue(value);
             anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.StringValue');
-        } else if (typeof value === 'number' && Number.isInteger(value)) {
-            const wrapper = new Int32Value();
-            wrapper.setValue(value);
-            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');
+        } else if (typeof value === 'number') {
+            if (Number.isInteger(value)) {
+                const wrapper = new Int32Value();
+                wrapper.setValue(value);
+                anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');
+            } else {
+                const wrapper = new DoubleValue();
+                wrapper.setValue(value);
+                anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.DoubleValue');
+            }
         } else if (typeof value === 'boolean') {
             const wrapper = new BoolValue();
             wrapper.setValue(value);

--- a/test/PointerTestModel/RemoteGenerated/tsProject/src/PointerViewModelRemoteClient.ts
+++ b/test/PointerTestModel/RemoteGenerated/tsProject/src/PointerViewModelRemoteClient.ts
@@ -7,7 +7,7 @@ import { PointerViewModelState, UpdatePropertyValueRequest, SubscribeRequest, Pr
 import * as grpcWeb from 'grpc-web';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { Any } from 'google-protobuf/google/protobuf/any_pb';
-import { StringValue, Int32Value, BoolValue } from 'google-protobuf/google/protobuf/wrappers_pb';
+import { StringValue, Int32Value, BoolValue, DoubleValue } from 'google-protobuf/google/protobuf/wrappers_pb';
 
 export class PointerViewModelRemoteClient {
     private readonly grpcClient: PointerViewModelServiceClient;
@@ -97,10 +97,16 @@ export class PointerViewModelRemoteClient {
             const wrapper = new StringValue();
             wrapper.setValue(value);
             anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.StringValue');
-        } else if (typeof value === 'number' && Number.isInteger(value)) {
-            const wrapper = new Int32Value();
-            wrapper.setValue(value);
-            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');
+        } else if (typeof value === 'number') {
+            if (Number.isInteger(value)) {
+                const wrapper = new Int32Value();
+                wrapper.setValue(value);
+                anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');
+            } else {
+                const wrapper = new DoubleValue();
+                wrapper.setValue(value);
+                anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.DoubleValue');
+            }
         } else if (typeof value === 'boolean') {
             const wrapper = new BoolValue();
             wrapper.setValue(value);

--- a/test/PointerTestModel/expected/PointerViewModelRemoteClient.ts
+++ b/test/PointerTestModel/expected/PointerViewModelRemoteClient.ts
@@ -7,7 +7,7 @@ import { PointerViewModelState, UpdatePropertyValueRequest, SubscribeRequest, Pr
 import * as grpcWeb from 'grpc-web';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { Any } from 'google-protobuf/google/protobuf/any_pb';
-import { StringValue, Int32Value, BoolValue } from 'google-protobuf/google/protobuf/wrappers_pb';
+import { StringValue, Int32Value, BoolValue, DoubleValue } from 'google-protobuf/google/protobuf/wrappers_pb';
 
 export class PointerViewModelRemoteClient {
     private readonly grpcClient: PointerViewModelServiceClient;
@@ -97,10 +97,16 @@ export class PointerViewModelRemoteClient {
             const wrapper = new StringValue();
             wrapper.setValue(value);
             anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.StringValue');
-        } else if (typeof value === 'number' && Number.isInteger(value)) {
-            const wrapper = new Int32Value();
-            wrapper.setValue(value);
-            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');
+        } else if (typeof value === 'number') {
+            if (Number.isInteger(value)) {
+                const wrapper = new Int32Value();
+                wrapper.setValue(value);
+                anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');
+            } else {
+                const wrapper = new DoubleValue();
+                wrapper.setValue(value);
+                anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.DoubleValue');
+            }
         } else if (typeof value === 'boolean') {
             const wrapper = new BoolValue();
             wrapper.setValue(value);

--- a/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptCompilationTests.cs
+++ b/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptCompilationTests.cs
@@ -90,9 +90,10 @@ public class TypeScriptCompilationTests
         File.WriteAllText(Path.Combine(gp, "wrappers_pb.d.ts"),
             "export class StringValue { setValue(v:string):void; getValue():string; serializeBinary():Uint8Array; static deserializeBinary(b:Uint8Array):StringValue; }\n" +
             "export class Int32Value { setValue(v:number):void; getValue():number; serializeBinary():Uint8Array; static deserializeBinary(b:Uint8Array):Int32Value; }\n" +
-            "export class BoolValue { setValue(v:boolean):void; getValue():boolean; serializeBinary():Uint8Array; static deserializeBinary(b:Uint8Array):BoolValue; }");
+            "export class BoolValue { setValue(v:boolean):void; getValue():boolean; serializeBinary():Uint8Array; static deserializeBinary(b:Uint8Array):BoolValue; }\n" +
+            "export class DoubleValue { setValue(v:number):void; getValue():number; serializeBinary():Uint8Array; static deserializeBinary(b:Uint8Array):DoubleValue; }");
         File.WriteAllText(Path.Combine(gp, "wrappers_pb.js"),
-            "class W{ constructor(){this.value=0;} setValue(v){this.value=v;} getValue(){return this.value;} serializeBinary(){return new Uint8Array();} } exports.StringValue=W; exports.Int32Value=W; exports.BoolValue=W;");
+            "class W{ constructor(){this.value=0;} setValue(v){this.value=v;} getValue(){return this.value;} serializeBinary(){return new Uint8Array();} } exports.StringValue=W; exports.Int32Value=W; exports.BoolValue=W; exports.DoubleValue=W;");
 
         var gen = Path.Combine(dir, "generated");
         Directory.CreateDirectory(gen);

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
@@ -7,7 +7,7 @@ import { SampleViewModelState, UpdatePropertyValueRequest, SubscribeRequest, Pro
 import * as grpcWeb from 'grpc-web';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { Any } from 'google-protobuf/google/protobuf/any_pb';
-import { StringValue, Int32Value, BoolValue } from 'google-protobuf/google/protobuf/wrappers_pb';
+import { StringValue, Int32Value, BoolValue, DoubleValue } from 'google-protobuf/google/protobuf/wrappers_pb';
 
 export class SampleViewModelRemoteClient {
     private readonly grpcClient: CounterServiceClient;
@@ -61,10 +61,16 @@ export class SampleViewModelRemoteClient {
             const wrapper = new StringValue();
             wrapper.setValue(value);
             anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.StringValue');
-        } else if (typeof value === 'number' && Number.isInteger(value)) {
-            const wrapper = new Int32Value();
-            wrapper.setValue(value);
-            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');
+        } else if (typeof value === 'number') {
+            if (Number.isInteger(value)) {
+                const wrapper = new Int32Value();
+                wrapper.setValue(value);
+                anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');
+            } else {
+                const wrapper = new DoubleValue();
+                wrapper.setValue(value);
+                anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.DoubleValue');
+            }
         } else if (typeof value === 'boolean') {
             const wrapper = new BoolValue();
             wrapper.setValue(value);


### PR DESCRIPTION
## Summary
- handle double numbers when generating TypeScript clients
- include DoubleValue stub in TypeScript compilation tests
- update expected TypeScript clients to import and emit DoubleValue wrappers

## Testing
- `dotnet test` *(fails: An error occurred trying to start process 'powershell' - No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a71233bf008320acf7adf1284946ea