### PR TITLE
Handle ObservableCollection in generated clients and tests

### DIFF
--- a/src/RemoteMvvmTool/Generators/ClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ClientGenerator.cs
@@ -156,6 +156,8 @@ public static class ClientGenerator
                             sel = ".Select(ProtoStateConverters.FromProto)";
                         if (named.TypeKind == TypeKind.Interface)
                             psb.AppendLine($"{ind}this.{prop.Name} = state.{protoStateFieldName}{sel}.ToList();");
+                        else if (named.ConstructedFrom.ToDisplayString() == "System.Collections.ObjectModel.ObservableCollection<T>")
+                            psb.AppendLine($"{ind}this.{prop.Name} = new System.Collections.ObjectModel.ObservableCollection<{elem.ToDisplayString()}>(state.{protoStateFieldName}{sel});");
                         else
                             psb.AppendLine($"{ind}this.{prop.Name} = new {prop.TypeString}(state.{protoStateFieldName}{sel});");
                     }

--- a/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
@@ -50,6 +50,10 @@ public static class TypeScriptClientGenerator
 
             if (type is INamedTypeSymbol named && named.IsGenericType)
             {
+                if (named.ConstructedFrom.ToDisplayString() == "System.Collections.ObjectModel.ObservableCollection<T>")
+                {
+                    return MapTsType(named.TypeArguments[0]) + "[]";
+                }
                 if (GeneratorHelpers.TryGetDictionaryTypeArgs(named, out var key, out var val))
                 {
                     var keyTs = MapKeyType(key!);


### PR DESCRIPTION
## Summary
- revert HP3LSThermalTestViewModel to dictionary-only zones
- add explicit ObservableCollection handling in C# and TypeScript client generators
- extend generation test to validate ObservableCollection support without altering view model source

## Testing
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj --filter Generated_Code_Handles_ObservableCollection_Property`
- `dotnet test` *(fails: RemoteMvvmTool.Tests.TypeScript.TypeScriptCompilationTests.Generated_TypeScript_Compiles_With_Bool_Property, Generated_TypeScript_Compiles_With_Double_Property, Generated_TypeScript_Compiles_With_String_Property, Generated_TypeScript_Compiles_With_Int_Property, Generated_TypeScript_Compiles_And_Transfers_Dictionary, Generated_TypeScript_Compiles_With_Enum_Property)*

------
https://chatgpt.com/codex/tasks/task_e_68a748a556488320857b77d4fc1819f8