### PR TITLE
Add tests exposing ServerGenerator bugs

### DIFF
--- a/test/RemoteMvvmTool.Tests/ServerGeneratorBugTests.cs
+++ b/test/RemoteMvvmTool.Tests/ServerGeneratorBugTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using GrpcRemoteMvvmModelUtil;
+using RemoteMvvmTool.Generators;
+using Xunit;
+
+namespace ToolExecution;
+
+public class ServerGeneratorBugTests
+{
+    static string GenerateServer()
+    {
+        return ServerGenerator.Generate(
+            "SampleViewModel",
+            "Generated.Protos",
+            "SampleViewModelService",
+            new List<PropertyInfo>(),
+            new List<CommandInfo>(),
+            "Generated.ViewModels");
+    }
+
+    [Fact]
+    public void UpdatePropertyValue_ShouldHandle_Double()
+    {
+        var server = GenerateServer();
+        Assert.Contains("request.NewValue.Is(DoubleValue.Descriptor)", server);
+    }
+
+    [Fact]
+    public void UpdatePropertyValue_ShouldHandle_Float()
+    {
+        var server = GenerateServer();
+        Assert.Contains("request.NewValue.Is(FloatValue.Descriptor)", server);
+    }
+
+    [Fact]
+    public void UpdatePropertyValue_ShouldHandle_Long()
+    {
+        var server = GenerateServer();
+        Assert.Contains("request.NewValue.Is(Int64Value.Descriptor)", server);
+    }
+
+    [Fact]
+    public void PackToAny_ShouldHandle_UInt()
+    {
+        var server = GenerateServer();
+        Assert.Contains("case uint", server);
+    }
+
+    [Fact]
+    public void ToValue_ShouldHandle_UInt()
+    {
+        var server = GenerateServer();
+        Assert.Contains("case uint", server);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add failing tests revealing missing numeric type support in ServerGenerator

## Testing
- `dotnet test` *(fails: UpdatePropertyValue_ShouldHandle_Double, UpdatePropertyValue_ShouldHandle_Long, PackToAny_ShouldHandle_UInt, UpdatePropertyValue_ShouldHandle_Float, ToValue_ShouldHandle_UInt, Generated_TypeScript_Compiles_With_Bool_Property, Generated_TypeScript_Compiles_With_Double_Property, Generated_TypeScript_Compiles_And_Transfers_ObservableCollection, Generated_TypeScript_Compiles_With_String_Property, Generated_TypeScript_Compiles_With_Int_Property, Generated_TypeScript_Compiles_And_Transfers_Dictionary, Generated_TypeScript_Compiles_With_Enum_Property)*

------
https://chatgpt.com/codex/tasks/task_e_68a75c574c7c83208317f5ccc2278c78