### PR TITLE
Fix TypeScript client generator skipped tests

### DIFF
--- a/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
@@ -45,58 +45,107 @@ public static class TypeScriptClientGenerator
 
         string MapTsType(ITypeSymbol type)
         {
-            if (type is IArrayTypeSymbol arr)
-                return MapTsType(arr.ElementType) + "[]";
+            bool isNullable = false;
+            if (type is INamedTypeSymbol nullable && nullable.IsGenericType &&
+                nullable.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+            {
+                isNullable = true;
+                type = nullable.TypeArguments[0];
+            }
 
-            if (type is INamedTypeSymbol named && named.IsGenericType)
+            string result;
+
+            if (type is IArrayTypeSymbol arr)
+            {
+                result = MapTsType(arr.ElementType) + "[]";
+            }
+            else if (type is INamedTypeSymbol named && named.IsGenericType)
             {
                 if (named.ConstructedFrom.ToDisplayString() == "System.Collections.ObjectModel.ObservableCollection<T>")
                 {
-                    return MapTsType(named.TypeArguments[0]) + "[]";
+                    result = MapTsType(named.TypeArguments[0]) + "[]";
                 }
-                if (GeneratorHelpers.TryGetDictionaryTypeArgs(named, out var key, out var val))
+                else if (GeneratorHelpers.TryGetDictionaryTypeArgs(named, out var key, out var val))
                 {
                     var keyTs = MapKeyType(key!);
                     var valTs = MapTsType(val!);
-                    return $"Record<{keyTs}, {valTs}>";
+                    result = $"Record<{keyTs}, {valTs}>";
                 }
-                if (GeneratorHelpers.TryGetMemoryElementType(named, out var memElem))
+                else if (GeneratorHelpers.TryGetMemoryElementType(named, out var memElem))
                 {
-                    return MapTsType(memElem!) + "[]";
+                    result = MapTsType(memElem!) + "[]";
                 }
-                if (GeneratorHelpers.TryGetEnumerableElementType(named, out var elem))
+                else if (GeneratorHelpers.TryGetEnumerableElementType(named, out var elem))
                 {
-                    return MapTsType(elem!) + "[]";
+                    result = MapTsType(elem!) + "[]";
+                }
+                else
+                {
+                    var wktNamed = GeneratorHelpers.GetProtoWellKnownTypeFor(named);
+                    result = wktNamed switch
+                    {
+                        "StringValue" => "string",
+                        "BoolValue" => "boolean",
+                        "Int32Value" or "Int64Value" or "UInt32Value" or "UInt64Value" or "FloatValue" or "DoubleValue" => "number",
+                        "Timestamp" => "string",
+                        "Duration" => "number",
+                        _ => null
+                    } ?? string.Empty;
+                    if (string.IsNullOrEmpty(result))
+                    {
+                        if (named.TypeKind == TypeKind.Enum)
+                        {
+                            result = "number";
+                        }
+                        else if ((named.TypeKind == TypeKind.Class || named.TypeKind == TypeKind.Struct) &&
+                                 !(named.ContainingNamespace?.ToDisplayString() ?? string.Empty).StartsWith("System"))
+                        {
+                            if (processed.Add(named)) queue.Enqueue(named);
+                            result = GetStateName(named);
+                        }
+                        else
+                        {
+                            result = "any";
+                        }
+                    }
+                }
+            }
+            else
+            {
+                var wkt = GeneratorHelpers.GetProtoWellKnownTypeFor(type);
+                result = wkt switch
+                {
+                    "StringValue" => "string",
+                    "BoolValue" => "boolean",
+                    "Int32Value" or "Int64Value" or "UInt32Value" or "UInt64Value" or "FloatValue" or "DoubleValue" => "number",
+                    "Timestamp" => "string",
+                    "Duration" => "number",
+                    _ => null
+                } ?? string.Empty;
+
+                if (string.IsNullOrEmpty(result))
+                {
+                    if (type.TypeKind == TypeKind.Enum)
+                    {
+                        result = "number";
+                    }
+                    else if (type is INamedTypeSymbol nt &&
+                             (type.TypeKind == TypeKind.Class || type.TypeKind == TypeKind.Struct) &&
+                             !(nt.ContainingNamespace?.ToDisplayString() ?? string.Empty).StartsWith("System"))
+                    {
+                        if (processed.Add(nt)) queue.Enqueue(nt);
+                        result = GetStateName(nt);
+                    }
+                    else
+                    {
+                        result = "any";
+                    }
                 }
             }
 
-            var wkt = GeneratorHelpers.GetProtoWellKnownTypeFor(type);
-            switch (wkt)
-            {
-                case "StringValue": return "string";
-                case "BoolValue": return "boolean";
-                case "Int32Value":
-                case "Int64Value":
-                case "UInt32Value":
-                case "UInt64Value":
-                case "FloatValue":
-                case "DoubleValue": return "number";
-                case "Timestamp": return "string";
-                case "Duration": return "number";
-            }
-
-            if (type.TypeKind == TypeKind.Enum)
-                return "number";
-
-            if (type is INamedTypeSymbol nt &&
-                (type.TypeKind == TypeKind.Class || type.TypeKind == TypeKind.Struct) &&
-                !(nt.ContainingNamespace?.ToDisplayString() ?? string.Empty).StartsWith("System"))
-            {
-                if (processed.Add(nt)) queue.Enqueue(nt);
-                return GetStateName(nt);
-            }
-
-            return "any";
+            if (isNullable)
+                result += " | undefined";
+            return result;
         }
 
         string MapKeyType(ITypeSymbol type)
@@ -148,7 +197,13 @@ public static class TypeScriptClientGenerator
         sb.AppendLine("import * as grpcWeb from 'grpc-web';");
         sb.AppendLine("import { Empty } from 'google-protobuf/google/protobuf/empty_pb';");
         sb.AppendLine("import { Any } from 'google-protobuf/google/protobuf/any_pb';");
-        sb.AppendLine("import { StringValue, Int32Value, BoolValue, DoubleValue } from 'google-protobuf/google/protobuf/wrappers_pb';");
+        var wrapperImports = new HashSet<string> { "StringValue", "Int32Value", "BoolValue", "DoubleValue" };
+        foreach (var p in props)
+        {
+            var w = GeneratorHelpers.GetWrapperType(p.TypeString);
+            if (w != null) wrapperImports.Add(w);
+        }
+        sb.AppendLine($"import {{ {string.Join(", ", wrapperImports.OrderBy(s => s))} }} from 'google-protobuf/google/protobuf/wrappers_pb';");
         sb.AppendLine();
 
         // generate state interfaces for complex types
@@ -185,7 +240,11 @@ public static class TypeScriptClientGenerator
         {
             string expr;
             if (GeneratorHelpers.TryGetDictionaryTypeArgs(p.FullTypeSymbol!, out _, out _))
-                expr = $"(state as any).get{p.Name}()";
+                expr = $"(state as any).get{p.Name}Map()";
+            else if (GeneratorHelpers.TryGetEnumerableElementType(p.FullTypeSymbol!, out _) ||
+                     p.FullTypeSymbol is IArrayTypeSymbol ||
+                     GeneratorHelpers.TryGetMemoryElementType(p.FullTypeSymbol!, out _))
+                expr = $"(state as any).get{p.Name}List()";
             else if (p.FullTypeSymbol is INamedTypeSymbol nt &&
                      (nt.TypeKind == TypeKind.Class || nt.TypeKind == TypeKind.Struct) &&
                      !GeneratorHelpers.IsWellKnownType(p.FullTypeSymbol!) &&
@@ -207,7 +266,11 @@ public static class TypeScriptClientGenerator
         {
             string expr;
             if (GeneratorHelpers.TryGetDictionaryTypeArgs(p.FullTypeSymbol!, out _, out _))
-                expr = $"(state as any).get{p.Name}()";
+                expr = $"(state as any).get{p.Name}Map()";
+            else if (GeneratorHelpers.TryGetEnumerableElementType(p.FullTypeSymbol!, out _) ||
+                     p.FullTypeSymbol is IArrayTypeSymbol ||
+                     GeneratorHelpers.TryGetMemoryElementType(p.FullTypeSymbol!, out _))
+                expr = $"(state as any).get{p.Name}List()";
             else if (p.FullTypeSymbol is INamedTypeSymbol nt &&
                      (nt.TypeKind == TypeKind.Class || nt.TypeKind == TypeKind.Struct) &&
                      !GeneratorHelpers.IsWellKnownType(p.FullTypeSymbol!) &&
@@ -235,9 +298,15 @@ public static class TypeScriptClientGenerator
         sb.AppendLine("            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.StringValue');");
         sb.AppendLine("        } else if (typeof value === 'number') {");
         sb.AppendLine("            if (Number.isInteger(value)) {");
-        sb.AppendLine("                const wrapper = new Int32Value();");
-        sb.AppendLine("                wrapper.setValue(value);");
-        sb.AppendLine("                anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');");
+        sb.AppendLine("                if (value > 2147483647 || value < -2147483648) {");
+        sb.AppendLine("                    const wrapper = new Int64Value();");
+        sb.AppendLine("                    wrapper.setValue(value);");
+        sb.AppendLine("                    anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int64Value');");
+        sb.AppendLine("                } else {");
+        sb.AppendLine("                    const wrapper = new Int32Value();");
+        sb.AppendLine("                    wrapper.setValue(value);");
+        sb.AppendLine("                    anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Int32Value');");
+        sb.AppendLine("                }");
         sb.AppendLine("            } else {");
         sb.AppendLine("                const wrapper = new DoubleValue();");
         sb.AppendLine("                wrapper.setValue(value);");
@@ -303,7 +372,11 @@ public static class TypeScriptClientGenerator
                 {
                     "StringValue" => "StringValue.deserializeBinary",
                     "Int32Value" => "Int32Value.deserializeBinary",
+                    "Int64Value" => "Int64Value.deserializeBinary",
+                    "UInt32Value" => "UInt32Value.deserializeBinary",
+                    "UInt64Value" => "UInt64Value.deserializeBinary",
                     "BoolValue" => "BoolValue.deserializeBinary",
+                    "FloatValue" => "FloatValue.deserializeBinary",
                     "DoubleValue" => "DoubleValue.deserializeBinary",
                     _ => ""
                 };

--- a/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptClientGeneratorBugTests.cs
+++ b/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptClientGeneratorBugTests.cs
@@ -35,7 +35,7 @@ public class TypeScriptClientGeneratorBugTests
         return TypeScriptClientGenerator.Generate(name, "Test.Protos", name + "Service", props, cmds);
     }
 
-    [Fact(Skip="Bug: Nullable properties should generate optional types")]
+    [Fact]
     public async Task Nullable_property_should_generate_optional_type()
     {
         var code = @"\
@@ -51,7 +51,7 @@ public class ObservableObject {}
         Assert.Contains("count: number | undefined;", ts);
     }
 
-    [Fact(Skip="Bug: Array properties should use getXList in initializeRemote")]
+    [Fact]
     public async Task Array_property_should_use_get_list_method()
     {
         var code = @"\
@@ -67,7 +67,7 @@ public class ObservableObject {}
         Assert.Contains("getNumbersList()", ts);
     }
 
-    [Fact(Skip="Bug: Dictionary properties should use getXMap in initializeRemote")]
+    [Fact]
     public async Task Dictionary_property_should_use_get_map_method()
     {
         var code = @"\
@@ -83,7 +83,7 @@ public class ObservableObject {}
         Assert.Contains("getValuesMap()", ts);
     }
 
-    [Fact(Skip="Bug: Long properties require Int64Value wrapper")]
+    [Fact]
     public async Task Long_property_should_import_int64_wrapper()
     {
         var code = @"\
@@ -99,7 +99,7 @@ public class ObservableObject {}
         Assert.Contains("Int64Value", ts);
     }
 
-    [Fact(Skip="Bug: Float properties are missing change notification handling")]
+    [Fact]
     public async Task Float_property_change_should_be_handled()
     {
         var code = @"\


### PR DESCRIPTION
## Summary
- add nullable handling and collection initializers to TypeScript client generator
- extend wrapper imports and change notifications for long and float values
- enable previously skipped TypeScript client generator tests

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj --filter FullyQualifiedName~TypeScriptClientGeneratorBugTests`

------
https://chatgpt.com/codex/tasks/task_e_68a76aa95d7c83208f530c69db2a952c