### PR TITLE
feat: add DateTime support to TypeScript client

### DIFF
--- a/test/GameViewModel/expected/GameViewModelRemoteClient.ts
+++ b/test/GameViewModel/expected/GameViewModelRemoteClient.ts
@@ -8,6 +8,7 @@ import * as grpcWeb from 'grpc-web';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { Any } from 'google-protobuf/google/protobuf/any_pb';
 import { BoolValue, DoubleValue, Int32Value, StringValue } from 'google-protobuf/google/protobuf/wrappers_pb';
+import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
 
 export class GameViewModelRemoteClient {
     private readonly grpcClient: GameViewModelServiceClient;
@@ -99,6 +100,9 @@ export class GameViewModelRemoteClient {
             const wrapper = new BoolValue();
             wrapper.setValue(value);
             anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.BoolValue');
+        } else if (value instanceof Date) {
+            const wrapper = Timestamp.fromDate(value);
+            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Timestamp');
         } else {
             throw new Error('Unsupported value type');
         }

--- a/test/PointerTestModel/RemoteGenerated/tsProject/src/PointerViewModelRemoteClient.ts
+++ b/test/PointerTestModel/RemoteGenerated/tsProject/src/PointerViewModelRemoteClient.ts
@@ -7,7 +7,7 @@ import { PointerViewModelState, UpdatePropertyValueRequest, SubscribeRequest, Pr
 import * as grpcWeb from 'grpc-web';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { Any } from 'google-protobuf/google/protobuf/any_pb';
-import { BoolValue, DoubleValue, Int32Value, StringValue } from 'google-protobuf/google/protobuf/wrappers_pb';
+import { BoolValue, DoubleValue, Int32Value, Int64Value, StringValue } from 'google-protobuf/google/protobuf/wrappers_pb';
 
 export class PointerViewModelRemoteClient {
     private readonly grpcClient: PointerViewModelServiceClient;

--- a/test/PointerTestModel/expected/PointerViewModelRemoteClient.ts
+++ b/test/PointerTestModel/expected/PointerViewModelRemoteClient.ts
@@ -8,6 +8,7 @@ import * as grpcWeb from 'grpc-web';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { Any } from 'google-protobuf/google/protobuf/any_pb';
 import { BoolValue, DoubleValue, Int32Value, StringValue } from 'google-protobuf/google/protobuf/wrappers_pb';
+import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
 
 export class PointerViewModelRemoteClient {
     private readonly grpcClient: PointerViewModelServiceClient;
@@ -117,6 +118,9 @@ export class PointerViewModelRemoteClient {
             const wrapper = new BoolValue();
             wrapper.setValue(value);
             anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.BoolValue');
+        } else if (value instanceof Date) {
+            const wrapper = Timestamp.fromDate(value);
+            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Timestamp');
         } else {
             throw new Error('Unsupported value type');
         }

--- a/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptClientGeneratorBugTests.cs
+++ b/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptClientGeneratorBugTests.cs
@@ -114,4 +114,20 @@ public class ObservableObject {}
         var ts = await GenerateTsAsync(code);
         Assert.Contains("FloatValue.deserializeBinary", ts);
     }
+
+    [Fact]
+    public async Task DateTime_property_change_should_be_handled()
+    {
+        var code = @"\
+public class ObservablePropertyAttribute : System.Attribute {}
+public partial class DateViewModel : ObservableObject
+{
+    [ObservableProperty]
+    public System.DateTime When { get; set; }
+}
+public class ObservableObject {}
+";
+        var ts = await GenerateTsAsync(code);
+        Assert.Contains("Timestamp.deserializeBinary", ts);
+    }
 }

--- a/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptGenerationTests.cs
+++ b/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptGenerationTests.cs
@@ -149,4 +149,20 @@ public class ObservableObject {}
         Assert.Contains("DoStuffRequest", ts);
         Assert.Contains("async doStuff(value: any): Promise<void>", ts);
     }
+
+    [Fact]
+    public async Task Maps_DateTime_To_Date()
+    {
+        var code = @"\
+public class ObservablePropertyAttribute : System.Attribute {}
+public partial class DateViewModel : ObservableObject
+{
+    [ObservableProperty]
+    public System.DateTime When { get; set; }
+}
+public class ObservableObject {}
+";
+        var ts = await GenerateTsAsync(code);
+        Assert.Contains("when: Date;", ts);
+    }
 }

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
@@ -8,6 +8,7 @@ import * as grpcWeb from 'grpc-web';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
 import { Any } from 'google-protobuf/google/protobuf/any_pb';
 import { BoolValue, DoubleValue, Int32Value, StringValue } from 'google-protobuf/google/protobuf/wrappers_pb';
+import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
 
 export class SampleViewModelRemoteClient {
     private readonly grpcClient: CounterServiceClient;
@@ -81,6 +82,9 @@ export class SampleViewModelRemoteClient {
             const wrapper = new BoolValue();
             wrapper.setValue(value);
             anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.BoolValue');
+        } else if (value instanceof Date) {
+            const wrapper = Timestamp.fromDate(value);
+            anyVal.pack(wrapper.serializeBinary(), 'google.protobuf.Timestamp');
         } else {
             throw new Error('Unsupported value type');
         }


### PR DESCRIPTION
## Summary
- support `DateTime` fields in TypeScript client generation
- cover `Timestamp` packing/unpacking for updates, commands, and change notifications
- add tests and fixtures for new Date/`Timestamp` handling

## Testing
- `dotnet test` *(fails: Generated_TypeScript_Compiles_With_Bool_Property [FAIL]; environment missing Node/tsc)*

------
https://chatgpt.com/codex/tasks/task_e_68a7776156b48320b996f588e0e7361d