### PR TITLE
docs: document supported types

### DIFF
--- a/src/RemoteMvvmTool/README.md
+++ b/src/RemoteMvvmTool/README.md
@@ -48,3 +48,35 @@ remotemvvm --generate proto,server,client,ts \
 
 The command above analyzes `MyViewModel.cs` and writes the generated files into `generated/` and `protos/`.
 
+### Supported Types
+
+| C# type | Proto | Server | C# client | TS client | Update direction |
+|---------|-------|:------:|:---------:|:---------:|------------------|
+| `string` | `StringValue` | ✅ | ✅ | ✅ | 2‑way |
+| `bool` | `BoolValue` | ✅ | ✅ | ✅ | 2‑way |
+| `int` | `Int32Value` | ✅ | ✅ | ✅ | 2‑way |
+| `long` | `Int64Value` | ✅ | ✅ | ✅ | 2‑way |
+| `uint` | `UInt32Value` | ✅ | ✅ | ✅ | 2‑way |
+| `float` | `FloatValue` | ✅ | ✅ | ✅ | 2‑way |
+| `double` | `DoubleValue` | ✅ | ✅ | ✅ | 2‑way |
+| `byte` | `UInt32Value` | ✅ | ✅ | ❌ | server → client |
+| `sbyte` | `Int32Value` | ✅ | ✅ | ❌ | server → client |
+| `short` | `Int32Value` | ✅ | ✅ | ❌ | server → client |
+| `ushort` | `UInt32Value` | ✅ | ✅ | ❌ | server → client |
+| `ulong` | `UInt64Value` | ✅ | ✅ | ❌ | server → client |
+| `decimal` | `StringValue` | ✅ | ✅ | ❌ | server → client |
+| `char` | `StringValue` | ✅ | ✅ | ❌ | server → client |
+| `nint` | `Int64Value` | ✅ | ✅ | ❌ | server → client |
+| `nuint` | `UInt64Value` | ✅ | ✅ | ❌ | server → client |
+| `half` | `FloatValue` | ✅ | ✅ | ❌ | server → client |
+| `Guid` | `StringValue` | ✅ | ✅ | ✅ | server → client |
+| `enum` | `Int32Value` | ✅ | ✅ | ✅ | server → client |
+| Arrays & lists (`T[]`, `List<T>`, `ObservableCollection<T>`) | `repeated` | ✅ | ✅ | ✅ | server → client |
+| `Dictionary<TKey,TValue>` (scalar keys) | `map` | ✅ | ✅ | ✅ | server → client |
+| Custom classes/structs | `message` | ✅ | ✅ | ✅ | server → client |
+| `DateTime` | `Timestamp` | ✅ | ❌ | ❌ | n/a |
+| `DateTimeOffset` | `Timestamp` | ✅ | ❌ | ❌ | n/a |
+| `TimeSpan` | `Duration` | ✅ | ❌ | ❌ | n/a |
+| `DateOnly` | `StringValue` | ✅ | ❌ | ❌ | n/a |
+| `TimeOnly` | `StringValue` | ✅ | ❌ | ❌ | n/a |
+| Unsupported numeric types (`IntPtr`, `UIntPtr`, `BigInteger`) | — | ❌ | ❌ | ❌ | n/a |


### PR DESCRIPTION
## Summary
- expand supported type matrix with explicit numeric and date/time rows

## Testing
- `dotnet test` *(fails: Failed: 11, Passed: 105, Skipped: 5)*

------
https://chatgpt.com/codex/tasks/task_e_68a77059e07c832086be08d2fe613cdc