### PR TITLE
Return disconnected status when no clients

### DIFF
--- a/src/RemoteMvvmTool/Generators/ServerGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ServerGenerator.cs
@@ -233,7 +233,8 @@ public static class ServerGenerator
         sb.AppendLine();
         sb.AppendLine("    public override Task<ConnectionStatusResponse> Ping(Google.Protobuf.WellKnownTypes.Empty request, ServerCallContext context)");
         sb.AppendLine("    {");
-        sb.AppendLine("        return Task.FromResult(new ConnectionStatusResponse { Status = ConnectionStatus.Connected });");
+        sb.AppendLine("        var status = ClientCount > 0 ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;");
+        sb.AppendLine("        return Task.FromResult(new ConnectionStatusResponse { Status = status });");
         sb.AppendLine("    }");
         sb.AppendLine();
         foreach (var cmd in cmds)

--- a/src/demo/MonsterClicker/RemoteGenerated/GameViewModelGrpcServiceImpl.cs
+++ b/src/demo/MonsterClicker/RemoteGenerated/GameViewModelGrpcServiceImpl.cs
@@ -156,7 +156,8 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
 
     public override Task<ConnectionStatusResponse> Ping(Google.Protobuf.WellKnownTypes.Empty request, ServerCallContext context)
     {
-        return Task.FromResult(new ConnectionStatusResponse { Status = ConnectionStatus.Connected });
+        var status = ClientCount > 0 ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        return Task.FromResult(new ConnectionStatusResponse { Status = status });
     }
 
     public override async Task<MonsterClicker.ViewModels.Protos.AttackMonsterResponse> AttackMonster(MonsterClicker.ViewModels.Protos.AttackMonsterRequest request, ServerCallContext context)

--- a/test/ComplexTypes/generated/SupportedComplexViewModelGrpcServiceImpl.cs
+++ b/test/ComplexTypes/generated/SupportedComplexViewModelGrpcServiceImpl.cs
@@ -166,7 +166,8 @@ public partial class SupportedComplexViewModelGrpcServiceImpl : SupportedComplex
 
     public override Task<ConnectionStatusResponse> Ping(Google.Protobuf.WellKnownTypes.Empty request, ServerCallContext context)
     {
-        return Task.FromResult(new ConnectionStatusResponse { Status = ConnectionStatus.Connected });
+        var status = ClientCount > 0 ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        return Task.FromResult(new ConnectionStatusResponse { Status = status });
     }
 
     private async void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
+++ b/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
@@ -161,7 +161,8 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
 
     public override Task<ConnectionStatusResponse> Ping(Google.Protobuf.WellKnownTypes.Empty request, ServerCallContext context)
     {
-        return Task.FromResult(new ConnectionStatusResponse { Status = ConnectionStatus.Connected });
+        var status = ClientCount > 0 ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        return Task.FromResult(new ConnectionStatusResponse { Status = status });
     }
 
     public override async Task<MonsterClicker.ViewModels.Protos.AttackMonsterResponse> AttackMonster(MonsterClicker.ViewModels.Protos.AttackMonsterRequest request, ServerCallContext context)

--- a/test/PointerTestModel/RemoteGenerated/PointerViewModelGrpcServiceImpl.cs
+++ b/test/PointerTestModel/RemoteGenerated/PointerViewModelGrpcServiceImpl.cs
@@ -198,7 +198,8 @@ public partial class PointerViewModelGrpcServiceImpl : PointerViewModelService.P
 
     public override Task<ConnectionStatusResponse> Ping(Google.Protobuf.WellKnownTypes.Empty request, ServerCallContext context)
     {
-        return Task.FromResult(new ConnectionStatusResponse { Status = ConnectionStatus.Connected });
+        var status = ClientCount > 0 ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        return Task.FromResult(new ConnectionStatusResponse { Status = status });
     }
 
     public override async Task<Pointer.ViewModels.Protos.InitializeResponse> Initialize(Pointer.ViewModels.Protos.InitializeRequest request, ServerCallContext context)

--- a/test/PointerTestModel/actual/PointerViewModelGrpcServiceImpl.cs
+++ b/test/PointerTestModel/actual/PointerViewModelGrpcServiceImpl.cs
@@ -203,7 +203,8 @@ public partial class PointerViewModelGrpcServiceImpl : PointerViewModelService.P
 
     public override Task<ConnectionStatusResponse> Ping(Google.Protobuf.WellKnownTypes.Empty request, ServerCallContext context)
     {
-        return Task.FromResult(new ConnectionStatusResponse { Status = ConnectionStatus.Connected });
+        var status = ClientCount > 0 ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        return Task.FromResult(new ConnectionStatusResponse { Status = status });
     }
 
     public override async Task<Pointer.ViewModels.Protos.InitializeResponse> Initialize(Pointer.ViewModels.Protos.InitializeRequest request, ServerCallContext context)

--- a/test/PointerTestModel/expected/PointerViewModelGrpcServiceImpl.cs
+++ b/test/PointerTestModel/expected/PointerViewModelGrpcServiceImpl.cs
@@ -203,7 +203,8 @@ public partial class PointerViewModelGrpcServiceImpl : PointerViewModelService.P
 
     public override Task<ConnectionStatusResponse> Ping(Google.Protobuf.WellKnownTypes.Empty request, ServerCallContext context)
     {
-        return Task.FromResult(new ConnectionStatusResponse { Status = ConnectionStatus.Connected });
+        var status = ClientCount > 0 ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        return Task.FromResult(new ConnectionStatusResponse { Status = status });
     }
 
     public override async Task<Pointer.ViewModels.Protos.InitializeResponse> Initialize(Pointer.ViewModels.Protos.InitializeRequest request, ServerCallContext context)

--- a/test/SampleViewModel/actual/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/actual/SampleViewModelGrpcServiceImpl.cs
@@ -119,7 +119,8 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
 
     public override Task<ConnectionStatusResponse> Ping(Google.Protobuf.WellKnownTypes.Empty request, ServerCallContext context)
     {
-        return Task.FromResult(new ConnectionStatusResponse { Status = ConnectionStatus.Connected });
+        var status = ClientCount > 0 ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        return Task.FromResult(new ConnectionStatusResponse { Status = status });
     }
 
     public override async Task<SampleApp.ViewModels.Protos.IncrementCountResponse> IncrementCount(SampleApp.ViewModels.Protos.IncrementCountRequest request, ServerCallContext context)

--- a/test/SampleViewModel/actual2/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/actual2/SampleViewModelGrpcServiceImpl.cs
@@ -119,7 +119,8 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
 
     public override Task<ConnectionStatusResponse> Ping(Google.Protobuf.WellKnownTypes.Empty request, ServerCallContext context)
     {
-        return Task.FromResult(new ConnectionStatusResponse { Status = ConnectionStatus.Connected });
+        var status = ClientCount > 0 ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        return Task.FromResult(new ConnectionStatusResponse { Status = status });
     }
 
     public override async Task<SampleApp.ViewModels.Protos.IncrementCountResponse> IncrementCount(SampleApp.ViewModels.Protos.IncrementCountRequest request, ServerCallContext context)

--- a/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
@@ -119,7 +119,8 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
 
     public override Task<ConnectionStatusResponse> Ping(Google.Protobuf.WellKnownTypes.Empty request, ServerCallContext context)
     {
-        return Task.FromResult(new ConnectionStatusResponse { Status = ConnectionStatus.Connected });
+        var status = ClientCount > 0 ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        return Task.FromResult(new ConnectionStatusResponse { Status = status });
     }
 
     public override async Task<SampleApp.ViewModels.Protos.IncrementCountResponse> IncrementCount(SampleApp.ViewModels.Protos.IncrementCountRequest request, ServerCallContext context)

--- a/test/SimpleViewModelTest/ViewModels/generated/MainViewModelGrpcServiceImpl.cs
+++ b/test/SimpleViewModelTest/ViewModels/generated/MainViewModelGrpcServiceImpl.cs
@@ -112,7 +112,8 @@ public partial class MainViewModelGrpcServiceImpl : MainViewModelService.MainVie
 
     public override Task<ConnectionStatusResponse> Ping(Google.Protobuf.WellKnownTypes.Empty request, ServerCallContext context)
     {
-        return Task.FromResult(new ConnectionStatusResponse { Status = ConnectionStatus.Connected });
+        var status = ClientCount > 0 ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        return Task.FromResult(new ConnectionStatusResponse { Status = status });
     }
 
     public override async Task<Generated.Protos.UpdateStatusResponse> UpdateStatus(Generated.Protos.UpdateStatusRequest request, ServerCallContext context)

--- a/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelGrpcServiceImpl.cs
+++ b/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelGrpcServiceImpl.cs
@@ -154,7 +154,8 @@ public partial class HP3LSThermalTestViewModelGrpcServiceImpl : HP3LSThermalTest
 
     public override Task<ConnectionStatusResponse> Ping(Google.Protobuf.WellKnownTypes.Empty request, ServerCallContext context)
     {
-        return Task.FromResult(new ConnectionStatusResponse { Status = ConnectionStatus.Connected });
+        var status = ClientCount > 0 ? ConnectionStatus.Connected : ConnectionStatus.Disconnected;
+        return Task.FromResult(new ConnectionStatusResponse { Status = status });
     }
 
     public override async Task<Generated.Protos.StateChangedResponse> StateChanged(Generated.Protos.StateChangedRequest request, ServerCallContext context)


### PR DESCRIPTION
## Summary
- Report disconnected status when no clients are subscribed by checking ClientCount in Ping
- Update generated service implementations accordingly

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a7b46cfda083209fe22c975e79f388