### PR TITLE
Ensure generated remote viewmodels invoke default ctor

### DIFF
--- a/src/RemoteMvvmTool/Generators/ViewModelPartialGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ViewModelPartialGenerator.cs
@@ -41,7 +41,7 @@ public static class ViewModelPartialGenerator
         sb.AppendLine("        private GrpcChannel? _channel;");
         sb.AppendLine($"        private {clientNamespace}.{vmName}RemoteClient? _remoteClient;");
         sb.AppendLine();
-        sb.AppendLine($"        public {vmName}(ServerOptions options)");
+        sb.AppendLine($"        public {vmName}(ServerOptions options) : this()");
         sb.AppendLine("        {");
         sb.AppendLine("            if (options == null) throw new ArgumentNullException(nameof(options));");
         if (runType == "wpf")

--- a/src/demo/BlazorMonsterClicker/BlazorMonsterClicker/RemoteGenerated/GameViewModel.Remote.g.cs
+++ b/src/demo/BlazorMonsterClicker/BlazorMonsterClicker/RemoteGenerated/GameViewModel.Remote.g.cs
@@ -27,7 +27,7 @@ namespace MonsterClicker.ViewModels
         private GrpcChannel? _channel;
         private MonsterClicker.ViewModels.RemoteClients.GameViewModelRemoteClient? _remoteClient;
 
-        public GameViewModel(ServerOptions options)
+        public GameViewModel(ServerOptions options) : this()
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
             _dispatcher = Dispatcher.CurrentDispatcher;

--- a/test/SimpleViewModelTest/ViewModels/generated/MainViewModel.Remote.g.cs
+++ b/test/SimpleViewModelTest/ViewModels/generated/MainViewModel.Remote.g.cs
@@ -27,7 +27,7 @@ namespace SimpleViewModelTest.ViewModels
         private GrpcChannel? _channel;
         private SimpleViewModelTest.ViewModels.RemoteClients.MainViewModelRemoteClient? _remoteClient;
 
-        public MainViewModel(ServerOptions options)
+        public MainViewModel(ServerOptions options) : this()
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
             _dispatcher = Dispatcher.CurrentDispatcher;

--- a/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModel.Remote.g.cs
+++ b/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModel.Remote.g.cs
@@ -27,7 +27,7 @@ namespace HPSystemsTools.ViewModels
         private GrpcChannel? _channel;
         private HPSystemsTools.ViewModels.RemoteClients.HP3LSThermalTestViewModelRemoteClient? _remoteClient;
 
-        public HP3LSThermalTestViewModel(ServerOptions options)
+        public HP3LSThermalTestViewModel(ServerOptions options) : this()
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
             _dispatcher = Dispatcher.CurrentDispatcher;


### PR DESCRIPTION
## Summary
- call default constructor when generating ServerOptions constructor
- update generated remote viewmodel files to forward ServerOptions constructor to parameterless ctor

## Testing
- `dotnet test` *(fails: CS1729 and 12 failing tests)*


------
https://chatgpt.com/codex/tasks/task_e_68a7b55adc9483209ac6834cdab79229