### PR TITLE
Use npm protoc for grpc-web end-to-end test

### DIFF
--- a/test/RemoteMvvmTool.Tests/GrpcWebEndToEndTests.cs
+++ b/test/RemoteMvvmTool.Tests/GrpcWebEndToEndTests.cs
@@ -334,9 +334,12 @@ module.exports = protobuf;");
             var protoFile = Path.Combine(protoDir, name + "Service.proto");
             File.WriteAllText(protoFile, proto);
 
-            // Generate JavaScript protobuf files using protoc
-            Console.WriteLine("Generating JavaScript protobuf files with protoc...");
-            GenerateJavaScriptProtos(protoFile, testProjectDir);
+            // Install npm dependencies and generate JavaScript protobuf files
+            Console.WriteLine("Installing npm packages for gRPC-Web...");
+            RunCmd("npm", "install", testProjectDir);
+
+            Console.WriteLine("Generating JavaScript protobuf files with npm run protoc...");
+            RunCmd("npm", "run protoc", testProjectDir);
 
             var grpcOut = Path.Combine(testProjectDir, "grpc");
             Directory.CreateDirectory(grpcOut);

--- a/test/RemoteMvvmTool.Tests/TestData/GrpcWebEndToEnd/package.json
+++ b/test/RemoteMvvmTool.Tests/TestData/GrpcWebEndToEnd/package.json
@@ -4,6 +4,14 @@
   "dependencies": {
     "grpc-web": "^1.4.2",
     "google-protobuf": "^3.21.2",
-    "@types/google-protobuf": "^3.15.5"
+    "@types/google-protobuf": "^3.15.5",
+    "xhr2": "^0.2.1"
+  },
+  "devDependencies": {
+    "grpc-tools": "^1.12.4",
+    "protoc-gen-grpc-web": "^1.4.2"
+  },
+  "scripts": {
+    "protoc": "grpc_tools_node_protoc --js_out=import_style=commonjs,binary:./ --grpc-web_out=import_style=commonjs,mode=grpcwebtext:./ -I protos protos/TestViewModelService.proto"
   }
 }

--- a/test/RemoteMvvmTool.Tests/TestData/GrpcWebEndToEnd/test-protoc.js
+++ b/test/RemoteMvvmTool.Tests/TestData/GrpcWebEndToEnd/test-protoc.js
@@ -1,92 +1,53 @@
+// gRPC-Web client test using protoc generated stubs
+// This script is executed from the C# test to verify that the generated
+// protobuf and service files can communicate with the running server.
+
+global.XMLHttpRequest = require('xhr2');
+
+function loadGenerated(modulePathLower, modulePathUpper) {
+  try {
+    return require(modulePathLower);
+  } catch {
+    return require(modulePathUpper);
+  }
+}
+
+const svc = loadGenerated('./testviewmodelservice_grpc_web_pb.js', './TestViewModelService_grpc_web_pb.js');
+loadGenerated('./testviewmodelservice_pb.js', './TestViewModelService_pb.js');
+const { TestViewModelServiceClient } = svc;
+const { Empty } = require('google-protobuf/google/protobuf/empty_pb.js');
 const process = require('process');
 
-(async () => {
-  console.log('Starting gRPC-Web test with protoc-generated protobuf parsing...');
-  
-  try {
-    // Try to require the generated protobuf files
-    let TestViewModelState;
-    let ThermalZoneComponentViewModelState;
-    
-    try {
-      // Import generated protobuf classes
-      const pb = require('./testviewmodelservice_pb.js');
-      TestViewModelState = pb.TestViewModelState;
-      ThermalZoneComponentViewModelState = pb.ThermalZoneComponentViewModelState;
-      console.log('Successfully loaded protoc-generated protobuf classes');
-    } catch (importError) {
-      console.warn('Could not load generated protobuf classes:', importError.message);
-      throw importError;
-    }
-    
-    console.log('Making gRPC-web call...');
-    
-    const port = process.argv[2] || '5000';
-    const response = await fetch(`http://localhost:${port}/test_protos.TestViewModelService/GetState`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/grpc-web+proto' },
-      body: new Uint8Array([0,0,0,0,0]) // Empty protobuf message for GetState
-    });
-    
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-    }
-    
-    const buffer = await response.arrayBuffer();
-    const bytes = new Uint8Array(buffer);
-    
-    console.log('Response received:', bytes.length, 'bytes');
-    console.log('First 20 bytes:', Array.from(bytes.slice(0, 20)));
-    
-    if (bytes.length < 5) {
-      throw new Error('Response too short');
-    }
-    
-    // Parse gRPC-web response format: [compressed_flag][message_length][message_data]
-    const messageLength = (bytes[1] << 24) | (bytes[2] << 16) | (bytes[3] << 8) | bytes[4];
-    console.log('Message length from header:', messageLength);
-    
-    if (messageLength === 0) {
-      console.error('Server returned empty message - this suggests a server-side issue');
-      console.log('Full response bytes:', Array.from(bytes.slice(0, 100)));
-      throw new Error('Empty message returned from server');
-    }
-    
-    const messageBytes = bytes.slice(5, 5 + messageLength);
-    console.log('Protobuf message bytes:', messageBytes.length, 'bytes');
-    
-    // Use the protoc-generated classes to deserialize
-    const state = TestViewModelState.deserializeBinary(messageBytes);
-    console.log('Deserialized state using protoc-generated protobuf:', state);
-    
-    const zoneList = state.getZoneListList ? state.getZoneListList() : [];
-    console.log('Zone list from protobuf:', zoneList.length, 'items');
-    
-    const zones = zoneList.map((zone, index) => ({
-      zone: zone.getZone ? zone.getZone() : index,
-      temperature: zone.getTemperature ? zone.getTemperature() : 0
-    }));
-    
-    console.log('Final parsed zones:', zones);
-    
-    if (zones.length < 2) {
-      throw new Error(`Expected at least 2 zones, got ${zones.length}`);
-    }
-    
-    if (zones[0].temperature !== 42 || zones[1].temperature !== 43) {
-      throw new Error(`Expected temperatures [42, 43], got [${zones[0].temperature}, ${zones[1].temperature}]`);
-    }
-    
-    console.log('? Test passed! Successfully retrieved collection from server using protoc-generated protobuf parsing');
-    console.log(`Zone 1: Zone=${zones[0].zone}, Temperature=${zones[0].temperature}`);
-    console.log(`Zone 2: Zone=${zones[1].zone}, Temperature=${zones[1].temperature}`);
-    
-  } catch (error) {
-    console.error('? Test failed:', error);
-    throw error;
+const port = process.argv[2] || '5000';
+
+const client = new TestViewModelServiceClient(`http://localhost:${port}`, null, null);
+
+console.log('Starting gRPC-Web test using generated client...');
+
+client.getState(new Empty(), {}, (err, response) => {
+  if (err) {
+    console.error('gRPC error:', err);
+    process.exit(1);
   }
-})().catch(e => { 
-  console.error('Unhandled error:', e); 
-  process.exit(1); 
+
+  const zones = response.getZoneListList();
+  console.log('Received zones:', zones.length);
+
+  if (zones.length < 2) {
+    console.error('Expected at least 2 zones, got', zones.length);
+    process.exit(1);
+  }
+
+  const t0 = zones[0].getTemperature();
+  const t1 = zones[1].getTemperature();
+  console.log('Temperatures:', t0, t1);
+
+  if (t0 !== 42 || t1 !== 43) {
+    console.error(`Unexpected temperatures [${t0}, ${t1}]`);
+    process.exit(1);
+  }
+
+  console.log('✅ Test passed! Successfully retrieved collection from server using grpc-web client');
+  process.exit(0);
 });
 


### PR DESCRIPTION
## Summary
- install npm packages and generate grpc-web stubs via `npm run protoc`
- add grpc-web protoc script and dev dependencies to test package.json
- exercise generated grpc-web client in test-protoc.js

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a86886d5648320a11a34481f4b9a0e