### PR TITLE
Add primitive type end-to-end tests

### DIFF
--- a/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
+++ b/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
@@ -64,56 +64,56 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
             var propValue = _viewModel.MonsterName;
             state.MonsterName = propValue;
         }
-        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property MonsterName to state.MonsterName: " + ex.Message); }
+        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property MonsterName to state.MonsterName: " + ex.ToString()); }
         // Mapping property: MonsterMaxHealth to state.MonsterMaxHealth
         try
         {
             var propValue = _viewModel.MonsterMaxHealth;
             state.MonsterMaxHealth = propValue;
         }
-        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property MonsterMaxHealth to state.MonsterMaxHealth: " + ex.Message); }
+        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property MonsterMaxHealth to state.MonsterMaxHealth: " + ex.ToString()); }
         // Mapping property: MonsterCurrentHealth to state.MonsterCurrentHealth
         try
         {
             var propValue = _viewModel.MonsterCurrentHealth;
             state.MonsterCurrentHealth = propValue;
         }
-        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property MonsterCurrentHealth to state.MonsterCurrentHealth: " + ex.Message); }
+        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property MonsterCurrentHealth to state.MonsterCurrentHealth: " + ex.ToString()); }
         // Mapping property: PlayerDamage to state.PlayerDamage
         try
         {
             var propValue = _viewModel.PlayerDamage;
             state.PlayerDamage = propValue;
         }
-        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property PlayerDamage to state.PlayerDamage: " + ex.Message); }
+        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property PlayerDamage to state.PlayerDamage: " + ex.ToString()); }
         // Mapping property: GameMessage to state.GameMessage
         try
         {
             var propValue = _viewModel.GameMessage;
             state.GameMessage = propValue;
         }
-        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property GameMessage to state.GameMessage: " + ex.Message); }
+        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property GameMessage to state.GameMessage: " + ex.ToString()); }
         // Mapping property: IsMonsterDefeated to state.IsMonsterDefeated
         try
         {
             var propValue = _viewModel.IsMonsterDefeated;
             state.IsMonsterDefeated = propValue;
         }
-        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property IsMonsterDefeated to state.IsMonsterDefeated: " + ex.Message); }
+        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property IsMonsterDefeated to state.IsMonsterDefeated: " + ex.ToString()); }
         // Mapping property: CanUseSpecialAttack to state.CanUseSpecialAttack
         try
         {
             var propValue = _viewModel.CanUseSpecialAttack;
             state.CanUseSpecialAttack = propValue;
         }
-        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property CanUseSpecialAttack to state.CanUseSpecialAttack: " + ex.Message); }
+        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property CanUseSpecialAttack to state.CanUseSpecialAttack: " + ex.ToString()); }
         // Mapping property: IsSpecialAttackOnCooldown to state.IsSpecialAttackOnCooldown
         try
         {
             var propValue = _viewModel.IsSpecialAttackOnCooldown;
             state.IsSpecialAttackOnCooldown = propValue;
         }
-        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property IsSpecialAttackOnCooldown to state.IsSpecialAttackOnCooldown: " + ex.Message); }
+        catch (Exception ex) { Debug.WriteLine("[GrpcService:GameViewModel] Error mapping property IsSpecialAttackOnCooldown to state.IsSpecialAttackOnCooldown: " + ex.ToString()); }
         return Task.FromResult(state);
     }
 

--- a/test/RemoteMvvmTool.Tests/GrpcWebEndToEndTests.cs
+++ b/test/RemoteMvvmTool.Tests/GrpcWebEndToEndTests.cs
@@ -75,7 +75,7 @@ public class GrpcWebEndToEndTests
         await TestEndToEndScenario(modelCode, expectedDataValues);
     }
 
-    [Fact] 
+    [Fact]
     public async Task SimpleStringProperty_EndToEnd_Test()
     {
         var modelCode = """
@@ -111,6 +111,110 @@ public class GrpcWebEndToEndTests
 
         // Expected data: Counter (42), number from Message string (44), bool as int (1 for true)
         var expectedDataValues = "1,42,44";
+
+        await TestEndToEndScenario(modelCode, expectedDataValues);
+    }
+
+    [Fact]
+    public async Task TwoWayPrimitiveTypes_EndToEnd_Test()
+    {
+        var modelCode = """
+            using System;
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace Generated.ViewModels
+            {
+                public partial class TestViewModel : ObservableObject
+                {
+                    public TestViewModel()
+                    {
+                        Message = "123";
+                        IsEnabled = true;
+                        Counter = 9876543210;
+                        PlayerLevel = 4000000000;
+                        HasBonus = 3.14f;
+                        BonusMultiplier = 6.28;
+                    }
+
+                    [ObservableProperty]
+                    private string _message = "";
+
+                    [ObservableProperty]
+                    private bool _isEnabled = false;
+
+                    [ObservableProperty]
+                    private long _counter = 0;
+
+                    [ObservableProperty]
+                    private uint _playerLevel = 0;
+
+                    [ObservableProperty]
+                    private float _hasBonus = 0;
+
+                    [ObservableProperty]
+                    private double _bonusMultiplier = 0;
+                }
+            }
+            """;
+
+        var expectedDataValues = "1,3.14,6.28,123,4000000000,9876543210";
+
+        await TestEndToEndScenario(modelCode, expectedDataValues);
+    }
+
+    [Fact]
+    public async Task ServerOnlyPrimitiveTypes_EndToEnd_Test()
+    {
+        var modelCode = """
+            using System;
+            using CommunityToolkit.Mvvm.ComponentModel;
+
+            namespace Generated.ViewModels
+            {
+                public enum Mode { Idle = 1, Done = 2 }
+
+                public partial class TestViewModel : ObservableObject
+                {
+                    public TestViewModel()
+                    {
+                        Counter = (byte)1;
+                        PlayerLevel = (ushort)4;
+                        HasBonus = (sbyte)(-2);
+                        BonusMultiplier = (Half)1.5;
+                        IsEnabled = (nint)9;
+                        Status = '8';
+                        Message = new Guid("00000000-0000-0000-0000-000000000020");
+                        CurrentStatus = Mode.Done;
+                    }
+
+                    [ObservableProperty]
+                    private byte _counter;
+
+                    [ObservableProperty]
+                    private ushort _playerLevel;
+
+                    [ObservableProperty]
+                    private sbyte _hasBonus;
+
+                    [ObservableProperty]
+                    private Half _bonusMultiplier;
+
+                    [ObservableProperty]
+                    private nint _isEnabled;
+
+                    [ObservableProperty]
+                    private char _status;
+
+                    [ObservableProperty]
+                    private Guid _message = Guid.Empty;
+
+                    [ObservableProperty]
+                    private Mode _currentStatus = Mode.Idle;
+                }
+            }
+            """;
+
+        var expectedDataValues = "-2,0,0,0,0,1,1.5,2,4,8,9,20";
 
         await TestEndToEndScenario(modelCode, expectedDataValues);
     }

--- a/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
@@ -64,14 +64,14 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             var propValue = _viewModel.Name;
             state.Name = propValue;
         }
-        catch (Exception ex) { Debug.WriteLine("[GrpcService:SampleViewModel] Error mapping property Name to state.Name: " + ex.Message); }
+        catch (Exception ex) { Debug.WriteLine("[GrpcService:SampleViewModel] Error mapping property Name to state.Name: " + ex.ToString()); }
         // Mapping property: Count to state.Count
         try
         {
             var propValue = _viewModel.Count;
             state.Count = propValue;
         }
-        catch (Exception ex) { Debug.WriteLine("[GrpcService:SampleViewModel] Error mapping property Count to state.Count: " + ex.Message); }
+        catch (Exception ex) { Debug.WriteLine("[GrpcService:SampleViewModel] Error mapping property Count to state.Count: " + ex.ToString()); }
         return Task.FromResult(state);
     }
 


### PR DESCRIPTION
## Summary
- add end-to-end test covering two-way primitive value types
- add end-to-end test for server-only primitive value types
- update expected gRPC service implementations to log full exception details

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f382ca4483208266cd130f174b5c