### PR TITLE
Handle char in server generator

### DIFF
--- a/src/RemoteMvvmTool/Generators/ServerGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ServerGenerator.cs
@@ -221,12 +221,15 @@ public static class ServerGenerator
                     switch (typeDisplayString)
                     {
                         case "System.Half":
+                        case "Half":
                             sb.AppendLine($"            state.{p.Name} = (float)propValue;");
                             break;
                         case "System.Char":
+                        case "char":
                             sb.AppendLine($"            state.{p.Name} = propValue.ToString();");
                             break;
                         case "System.Guid":
+                        case "Guid":
                             sb.AppendLine($"            state.{p.Name} = propValue.ToString();");
                             break;
                         default:


### PR DESCRIPTION
## Summary
- ensure char properties are converted to strings when mapping view model state

## Testing
- `dotnet test` (fails: Microsoft.NET.Sdk.WindowsDesktop targets not found; TypeScript build missing 'node' typings)

------
https://chatgpt.com/codex/tasks/task_e_68a8fd901a6c8320bc2955c250abfeae