### PR TITLE
Add end-to-end test for property change subscriptions

### DIFF
--- a/test/RemoteMvvmTool.Tests/TestData/GrpcWebEndToEnd/test-subscribe.js
+++ b/test/RemoteMvvmTool.Tests/TestData/GrpcWebEndToEnd/test-subscribe.js
@@ -1,0 +1,51 @@
+// gRPC-Web client test for SubscribeToPropertyChanges
+// Subscribes to property changes and logs the first notification
+
+global.XMLHttpRequest = require('xhr2');
+
+function loadGenerated(modulePathLower, modulePathUpper) {
+  try {
+    return require(modulePathLower);
+  } catch {
+    return require(modulePathUpper);
+  }
+}
+
+const svc = loadGenerated('./testviewmodelservice_grpc_web_pb.js', './TestViewModelService_grpc_web_pb.js');
+const pb = loadGenerated('./testviewmodelservice_pb.js', './TestViewModelService_pb.js');
+const { TestViewModelServiceClient } = svc;
+const { SubscribeRequest } = pb;
+const { StringValue } = require('google-protobuf/google/protobuf/wrappers_pb.js');
+const process = require('process');
+
+const port = process.argv[2] || '5000';
+const client = new TestViewModelServiceClient(`http://localhost:${port}`, null, null);
+
+console.log('Starting SubscribeToPropertyChanges test using generated client...');
+
+const req = new SubscribeRequest();
+req.setClientId('test-client');
+
+const stream = client.subscribeToPropertyChanges(req, {});
+stream.on('data', update => {
+  const anyVal = update.getNewValue();
+  let value = '';
+  if (anyVal) {
+    const str = anyVal.unpack(StringValue.deserializeBinary, 'google.protobuf.StringValue');
+    if (str) {
+      value = str.getValue();
+    }
+  }
+  console.log(`PROPERTY_CHANGE:${update.getPropertyName()}=${value}`);
+  console.log('✅ Test passed');
+  process.exit(0);
+});
+stream.on('error', err => {
+  console.error('Stream error:', err);
+  process.exit(1);
+});
+
+setTimeout(() => {
+  console.error('Test timed out after 10 seconds');
+  process.exit(1);
+}, 10000);


### PR DESCRIPTION
## Summary
- add SubscribeToPropertyChanges end-to-end test using a delayed status update
- extend Node.js test harness to validate property change notifications
- include JS client for property change subscription in test data

## Testing
- `dotnet test` *(fails: Could not find npm executable or npm install failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8febccf3c832097bd3b346acae959