### PR TITLE
Remove redundant casts in client property updates

### DIFF
--- a/src/RemoteMvvmTool/Generators/ClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ClientGenerator.cs
@@ -379,13 +379,29 @@ public static class ClientGenerator
                 }
             }
             else if (wkt == "Int32Value")
-                propertyUpdateCases.AppendLine($"                     if (update.NewValue!.Is(Int32Value.Descriptor)) this.{csharpPropName} = ({prop.TypeString})update.NewValue.Unpack<Int32Value>().Value; break;");
+            {
+                bool needsCast = prop.FullTypeSymbol.SpecialType != SpecialType.System_Int32;
+                string cast = needsCast ? $"({prop.TypeString})" : string.Empty;
+                propertyUpdateCases.AppendLine($"                     if (update.NewValue!.Is(Int32Value.Descriptor)) this.{csharpPropName} = {cast}update.NewValue.Unpack<Int32Value>().Value; break;");
+            }
             else if (wkt == "Int64Value")
-                propertyUpdateCases.AppendLine($"                     if (update.NewValue!.Is(Int64Value.Descriptor)) this.{csharpPropName} = ({prop.TypeString})update.NewValue.Unpack<Int64Value>().Value; break;");
+            {
+                bool needsCast = prop.FullTypeSymbol.SpecialType != SpecialType.System_Int64;
+                string cast = needsCast ? $"({prop.TypeString})" : string.Empty;
+                propertyUpdateCases.AppendLine($"                     if (update.NewValue!.Is(Int64Value.Descriptor)) this.{csharpPropName} = {cast}update.NewValue.Unpack<Int64Value>().Value; break;");
+            }
             else if (wkt == "UInt32Value")
-                propertyUpdateCases.AppendLine($"                    if (update.NewValue!.Is(UInt32Value.Descriptor)) this.{csharpPropName} = ({prop.TypeString})update.NewValue.Unpack<UInt32Value>().Value; break;");
+            {
+                bool needsCast = prop.FullTypeSymbol.SpecialType != SpecialType.System_UInt32;
+                string cast = needsCast ? $"({prop.TypeString})" : string.Empty;
+                propertyUpdateCases.AppendLine($"                    if (update.NewValue!.Is(UInt32Value.Descriptor)) this.{csharpPropName} = {cast}update.NewValue.Unpack<UInt32Value>().Value; break;");
+            }
             else if (wkt == "UInt64Value")
-                propertyUpdateCases.AppendLine($"                    if (update.NewValue!.Is(UInt64Value.Descriptor)) this.{csharpPropName} = ({prop.TypeString})update.NewValue.Unpack<UInt64Value>().Value; break;");
+            {
+                bool needsCast = prop.FullTypeSymbol.SpecialType != SpecialType.System_UInt64;
+                string cast = needsCast ? $"({prop.TypeString})" : string.Empty;
+                propertyUpdateCases.AppendLine($"                    if (update.NewValue!.Is(UInt64Value.Descriptor)) this.{csharpPropName} = {cast}update.NewValue.Unpack<UInt64Value>().Value; break;");
+            }
             else if (wkt == "DoubleValue")
                 propertyUpdateCases.AppendLine($"                    if (update.NewValue!.Is(DoubleValue.Descriptor)) this.{csharpPropName} = update.NewValue.Unpack<DoubleValue>().Value; break;");
             else if (wkt == "FloatValue")


### PR DESCRIPTION
## Summary
- conditionally cast numeric property updates to avoid unnecessary casts when types match

## Testing
- `dotnet test test/GameViewModel/GameViewModelTests.csproj -nologo`
- `dotnet test test/SampleViewModel/SampleViewModel.Tests.csproj -nologo`
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj --filter FullyQualifiedName~Generated_Code_Compiles_For_EdgeCase_Types -nologo`
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found; multiple RemoteMvvmTool.Tests.*)


------
https://chatgpt.com/codex/tasks/task_e_68ab65d5109c8320a79b44e7be984bea