### PR TITLE
Handle DateTime command parameters

### DIFF
--- a/src/RemoteMvvmTool/Generators/ServerGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ServerGenerator.cs
@@ -291,13 +291,23 @@ public static class ServerGenerator
                 foreach (var p in cmd.Parameters)
                 {
                     var paramName = GeneratorHelpers.ToCamelCase(p.Name);
-                    if (p.FullTypeSymbol!.TypeKind == TypeKind.Enum)
+                    var paramProp = GeneratorHelpers.ToPascalCase(p.Name);
+                    var typeDisplay = p.FullTypeSymbol!.ToDisplayString();
+                    if (p.FullTypeSymbol.TypeKind == TypeKind.Enum)
                     {
-                        sb.AppendLine($"            var {paramName} = ({p.TypeString})request.{GeneratorHelpers.ToPascalCase(p.Name)};");
+                        sb.AppendLine($"            var {paramName} = ({p.TypeString})request.{paramProp};");
+                    }
+                    else if (typeDisplay == "System.DateTime")
+                    {
+                        sb.AppendLine($"            var {paramName} = request.{paramProp}.ToDateTime();");
+                    }
+                    else if (typeDisplay == "System.DateTime?")
+                    {
+                        sb.AppendLine($"            var {paramName} = request.{paramProp}?.ToDateTime();");
                     }
                     else
                     {
-                        sb.AppendLine($"            var {paramName} = request.{GeneratorHelpers.ToPascalCase(p.Name)};");
+                        sb.AppendLine($"            var {paramName} = request.{paramProp};");
                     }
                 }
                 


### PR DESCRIPTION
## Summary
- convert DateTime command parameters from gRPC Timestamp using `ToDateTime()`
- test server generator for DateTime parameter handling

## Testing
- `dotnet test` *(errors: Microsoft.NET.Sdk.WindowsDesktop targets missing; TypeScript tsc TS2688 cannot find type definition for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68ae2eef47488320bf1892345a478ff9