### PR TITLE
Generate TypeScript enum maps for nested view model types

### DIFF
--- a/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptGenerationTests.cs
+++ b/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptGenerationTests.cs
@@ -165,4 +165,23 @@ public class ObservableObject {}
         var ts = await GenerateTsAsync(code);
         Assert.Contains("when: Date;", ts);
     }
+
+    [Fact]
+    public async Task Generates_Enum_Map_For_Nested_Types()
+    {
+        var code = """
+public class ObservablePropertyAttribute : System.Attribute {}
+namespace HP.Telemetry { public enum Zone { CPUZ_0, CPUZ_1 } }
+public class ThermalZoneComponentViewModel { public HP.Telemetry.Zone Zone { get; set; } }
+public partial class TestViewModel : ObservableObject
+{
+    [ObservableProperty]
+    public ThermalZoneComponentViewModel ZoneVm { get; set; } = new ThermalZoneComponentViewModel();
+}
+public class ObservableObject {}
+""";
+        var ts = await GenerateTsAsync(code);
+        Assert.Contains("// Enum mapping for HP.Telemetry.Zone", ts);
+        Assert.Contains("export const ZoneMap", ts);
+    }
 }


### PR DESCRIPTION
## Summary
- recurse through nested property types so enums like HP.Telemetry.Zone produce TS maps
- add regression test ensuring nested enums are mapped

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ae31517d2c832092696b220e6f9612