### PR TITLE
Parse Guid parameters in server commands

### DIFF
--- a/src/RemoteMvvmTool/Generators/ServerGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ServerGenerator.cs
@@ -295,6 +295,10 @@ public static class ServerGenerator
                     {
                         sb.AppendLine($"            var {paramName} = ({p.TypeString})request.{GeneratorHelpers.ToPascalCase(p.Name)};");
                     }
+                    else if (p.FullTypeSymbol.ToDisplayString() == "System.Guid")
+                    {
+                        sb.AppendLine($"            var {paramName} = Guid.Parse(request.{GeneratorHelpers.ToPascalCase(p.Name)});");
+                    }
                     else
                     {
                         sb.AppendLine($"            var {paramName} = request.{GeneratorHelpers.ToPascalCase(p.Name)};");


### PR DESCRIPTION
## Summary
- parse Guid parameters in server command generator using `Guid.Parse`
- add test ensuring Guid parameters are parsed before command execution

## Testing
- `dotnet test`
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj --filter FullyQualifiedName~CommandWithGuidParameter_ParsesGuid`


------
https://chatgpt.com/codex/tasks/task_e_68ae2eedb19c83208aed569c991a78f7