### PR TITLE
Ensure RemoteMvvmTool always regenerates outputs

### DIFF
--- a/src/RemoteMvvmTool/Program.cs
+++ b/src/RemoteMvvmTool/Program.cs
@@ -58,18 +58,7 @@ namespace RemoteMvvmTool
             root.AddOption(clientNsOption);
             root.AddOption(runOption);
 
-            bool NeedsGeneration(string outputFile, IEnumerable<string> inputs)
-            {
-                if (!File.Exists(outputFile))
-                    return true;
-                var outTime = File.GetLastWriteTimeUtc(outputFile);
-                foreach (var inp in inputs)
-                {
-                    if (File.Exists(inp) && File.GetLastWriteTimeUtc(inp) > outTime)
-                        return true;
-                }
-                return false;
-            }
+            bool NeedsGeneration(string outputFile, IEnumerable<string> inputs) => true;
 
             root.SetHandler(async (generate, output, protoOutput, vms, protoNs, serviceNameOpt, clientNsOpt, runType) =>
             {


### PR DESCRIPTION
## Summary
- Remove timestamp-based up-to-date check so RemoteMvvmTool always regenerates code

## Testing
- `dotnet test` *(fails: tsc : error TS2688: Build:Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68ae4b66f5c4832096036b3cc5a49ce6