### PR TITLE
feat: preserve collection expansion state in generated TypeScript app

### DIFF
--- a/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
@@ -54,14 +54,20 @@ public static class TsProjectGenerator
             else if (IsCollectionType(typeStr))
             {
                 sb.AppendLine($"    const {camel}El = document.getElementById('{camel}') as HTMLElement;");
+                sb.AppendLine($"    const {camel}RootOpen = ({camel}El.querySelector('details[data-root]') as HTMLDetailsElement)?.open ?? true;");
+                sb.AppendLine($"    const {camel}ItemOpen: boolean[] = Array.from({camel}El.querySelectorAll('details[data-index]')).map(d => (d as HTMLDetailsElement).open);");
                 sb.AppendLine($"    {camel}El.innerHTML = '';");
                 sb.AppendLine($"    const {camel}Details = document.createElement('details');");
-                sb.AppendLine($"    {camel}Details.open = true;");
+                sb.AppendLine($"    {camel}Details.setAttribute('data-root', '');");
+                sb.AppendLine($"    {camel}Details.open = {camel}RootOpen;");
                 sb.AppendLine($"    const {camel}Summary = document.createElement('summary');");
                 sb.AppendLine($"    {camel}Summary.textContent = '{p.Name}';");
                 sb.AppendLine($"    {camel}Details.appendChild({camel}Summary);");
                 sb.AppendLine($"    vm.{camel}.forEach((item: any, index: number) => {{");
                 sb.AppendLine($"        const itemDetails = document.createElement('details');");
+        
+                sb.AppendLine($"        itemDetails.setAttribute('data-index', String(index));");
+                sb.AppendLine($"        itemDetails.open = {camel}ItemOpen[index] ?? false;");
                 sb.AppendLine($"        const itemSummary = document.createElement('summary');");
                 sb.AppendLine($"        itemSummary.textContent = `{p.Name}[${{index}}]`;");
                 sb.AppendLine($"        itemDetails.appendChild(itemSummary);");
@@ -98,9 +104,11 @@ public static class TsProjectGenerator
             else
             {
                 sb.AppendLine($"    const {camel}El = document.getElementById('{camel}') as HTMLElement;");
+                sb.AppendLine($"    const {camel}RootOpen = ({camel}El.querySelector('details[data-root]') as HTMLDetailsElement)?.open ?? true;");
                 sb.AppendLine($"    {camel}El.innerHTML = '';");
                 sb.AppendLine($"    const {camel}Details = document.createElement('details');");
-                sb.AppendLine($"    {camel}Details.open = true;");
+                sb.AppendLine($"    {camel}Details.setAttribute('data-root', '');");
+                sb.AppendLine($"    {camel}Details.open = {camel}RootOpen;");
                 sb.AppendLine($"    const {camel}Summary = document.createElement('summary');");
                 sb.AppendLine($"    {camel}Summary.textContent = '{p.Name}';");
                 sb.AppendLine($"    {camel}Details.appendChild({camel}Summary);");

--- a/test/RemoteMvvmTool.Tests/TsProjectGeneratorTests.cs
+++ b/test/RemoteMvvmTool.Tests/TsProjectGeneratorTests.cs
@@ -98,6 +98,8 @@ public class TsProjectGeneratorTests
         Assert.Contains("await vm.updatePropertyValueDebounced('ZoneList'", ts);
         Assert.Contains("await vm.updatePropertyValueDebounced('TestSettings'", ts);
         Assert.Contains("await vm.doWork", ts);
+        Assert.Contains("querySelector('details[data-root]')", ts);
+        Assert.Contains("querySelectorAll('details[data-index]')", ts);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- maintain open/closed state of `details` elements when regenerating collection and object markup in TypeScript app generator
- cover expansion preservation in tests

## Testing
- `dotnet test` *(fails: Could not find npm executable or npm install failed)*

------
https://chatgpt.com/codex/tasks/task_e_68af84f933f08320a8baa74984b62d5e