### PR TITLE
Respect read-only ViewModel properties in generated clients

### DIFF
--- a/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
@@ -44,8 +44,14 @@ public static class TsProjectGenerator
             string typeStr = p.TypeString.ToLowerInvariant();
             if (IsPrimitiveType(typeStr))
             {
-                if (typeStr.Contains("bool"))
+                if (p.IsReadOnly)
+                {
+                    sb.AppendLine($"    (document.getElementById('{camel}') as HTMLElement).textContent = String(vm.{camel});");
+                }
+                else if (typeStr.Contains("bool"))
+                {
                     sb.AppendLine($"    (document.getElementById('{camel}') as HTMLInputElement).checked = vm.{camel};");
+                }
                 else
                 {
                     string assignExpr;
@@ -177,7 +183,7 @@ public static class TsProjectGenerator
         {
             string camel = GeneratorHelpers.ToCamelCase(p.Name);
             string typeStr = p.TypeString.ToLowerInvariant();
-            if (!IsPrimitiveType(typeStr)) continue;
+            if (!IsPrimitiveType(typeStr) || p.IsReadOnly) continue;
             sb.AppendLine($"    (document.getElementById('{camel}') as HTMLInputElement).addEventListener('change', async (e) => {{");
             string newValueExpr = typeStr.Contains("bool") ? "(e.target as HTMLInputElement).checked" : "(e.target as HTMLInputElement).value";
             sb.AppendLine($"        const newValue = {newValueExpr};");
@@ -358,12 +364,19 @@ public static class TsProjectGenerator
             string typeStr = p.TypeString.ToLowerInvariant();
             if (IsPrimitiveType(typeStr))
             {
-                string inputType = "text";
-                if (typeStr.Contains("bool"))
-                    inputType = "checkbox";
-                else if (typeStr.Contains("int") || typeStr.Contains("number") || typeStr.Contains("double") || typeStr.Contains("float") || typeStr.Contains("decimal") || typeStr.Contains("long"))
-                    inputType = "number";
-                sb.AppendLine($"        <div class='field'><label for='{camel}'>{p.Name}</label><input id='{camel}' type='{inputType}'/></div>");
+                if (p.IsReadOnly)
+                {
+                    sb.AppendLine($"        <div class='field'><label for='{camel}'>{p.Name}</label><span id='{camel}'></span></div>");
+                }
+                else
+                {
+                    string inputType = "text";
+                    if (typeStr.Contains("bool"))
+                        inputType = "checkbox";
+                    else if (typeStr.Contains("int") || typeStr.Contains("number") || typeStr.Contains("double") || typeStr.Contains("float") || typeStr.Contains("decimal") || typeStr.Contains("long"))
+                        inputType = "number";
+                    sb.AppendLine($"        <div class='field'><label for='{camel}'>{p.Name}</label><input id='{camel}' type='{inputType}'/></div>");
+                }
             }
             else
                 sb.AppendLine($"        <div id='{camel}'></div>");

--- a/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
@@ -290,6 +290,12 @@ public static class TypeScriptClientGenerator
         {
             sb.AppendLine($"    {GeneratorHelpers.ToCamelCase(p.Name)}: {MapTsType(p.FullTypeSymbol)};");
         }
+        bool hasReadOnly = props.Any(p => p.IsReadOnly);
+        if (hasReadOnly)
+        {
+            var roList = string.Join(", ", props.Where(p => p.IsReadOnly).Select(p => $"'{p.Name}'"));
+            sb.AppendLine($"    private readonly readOnlyProps = new Set<string>([{roList}]);");
+        }
         sb.AppendLine("    connectionStatus: string = 'Unknown';");
         sb.AppendLine();
         sb.AppendLine("    addChangeListener(cb: ((isFromServer?: boolean) => void) | (() => void)): void {");
@@ -433,6 +439,15 @@ public static class TypeScriptClientGenerator
         sb.AppendLine("    }");
         sb.AppendLine();
         sb.AppendLine("    async updatePropertyValue(propertyName: string, value: any): Promise<UpdatePropertyValueResponse> {");
+        if (hasReadOnly)
+        {
+            sb.AppendLine("        if (this.readOnlyProps?.has(propertyName)) {");
+            sb.AppendLine("            const res = new UpdatePropertyValueResponse();");
+            sb.AppendLine("            res.setSuccess(false);");
+            sb.AppendLine("            res.setErrorMessage(`Property ${propertyName} is read-only`);");
+            sb.AppendLine("            return res;");
+            sb.AppendLine("        }");
+        }
         sb.AppendLine("        const req = new UpdatePropertyValueRequest();");
         sb.AppendLine("        req.setPropertyName(propertyName);");
         sb.AppendLine("        req.setArrayIndex(-1); // Default to -1 for non-array properties");
@@ -449,6 +464,8 @@ public static class TypeScriptClientGenerator
         sb.AppendLine();
         sb.AppendLine("    // Debounced property update to prevent rapid-fire server calls");
         sb.AppendLine("    updatePropertyValueDebounced(propertyName: string, value: any, delayMs: number = 200): void {");
+        if (hasReadOnly)
+            sb.AppendLine("        if (this.readOnlyProps?.has(propertyName)) return;");
         sb.AppendLine("        // Clear existing timeout for this property");
         sb.AppendLine("        const existingTimeout = this.updateDebounceMap.get(propertyName);");
         sb.AppendLine("        if (existingTimeout) {");

--- a/src/RemoteMvvmTool/ModelTypes.cs
+++ b/src/RemoteMvvmTool/ModelTypes.cs
@@ -9,7 +9,8 @@ namespace GrpcRemoteMvvmModelUtil
     /// <param name="Name">The property name.</param>
     /// <param name="TypeString">The property type as a string.</param>
     /// <param name="FullTypeSymbol">The full type symbol from Roslyn analysis.</param>
-    public record PropertyInfo(string Name, string TypeString, ITypeSymbol FullTypeSymbol);
+    /// <param name="IsReadOnly">Whether the property lacks a public setter.</param>
+    public record PropertyInfo(string Name, string TypeString, ITypeSymbol FullTypeSymbol, bool IsReadOnly = false);
     
     /// <summary>
     /// Represents information about a relay command in a ViewModel.

--- a/src/RemoteMvvmTool/Resources/ServerTemplate.tmpl
+++ b/src/RemoteMvvmTool/Resources/ServerTemplate.tmpl
@@ -230,7 +230,7 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
                 return response;
             }
             
-            if (!propertyInfo.CanWrite)
+            if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
             {
                 response.Success = false;
                 response.ErrorMessage = $"Property '{finalPropertyName}' is read-only";

--- a/src/RemoteMvvmTool/ViewModelAnalyzer.cs
+++ b/src/RemoteMvvmTool/ViewModelAnalyzer.cs
@@ -153,7 +153,8 @@ namespace GrpcRemoteMvvmModelUtil
                     if (obsPropAttribute != null)
                     {
                         var typeName = propertySymbol.Type.ToDisplayString(FullNameFormat).Replace("global::", "");
-                        props.Add(new PropertyInfo(propertySymbol.Name, typeName, propertySymbol.Type));
+                        bool isReadOnly = propertySymbol.SetMethod == null || propertySymbol.SetMethod.DeclaredAccessibility != Accessibility.Public;
+                        props.Add(new PropertyInfo(propertySymbol.Name, typeName, propertySymbol.Type, isReadOnly));
                     }
                 }
             }

--- a/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
+++ b/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
@@ -288,7 +288,7 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
                 return response;
             }
             
-            if (!propertyInfo.CanWrite)
+            if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
             {
                 response.Success = false;
                 response.ErrorMessage = $"Property '{finalPropertyName}' is read-only";

--- a/test/PointerTestModel/RemoteGenerated/PointerViewModelGrpcServiceImpl.cs
+++ b/test/PointerTestModel/RemoteGenerated/PointerViewModelGrpcServiceImpl.cs
@@ -330,7 +330,7 @@ public partial class PointerViewModelGrpcServiceImpl : PointerViewModelService.P
                 return response;
             }
             
-            if (!propertyInfo.CanWrite)
+            if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
             {
                 response.Success = false;
                 response.ErrorMessage = $"Property '{finalPropertyName}' is read-only";

--- a/test/PointerTestModel/expected/PointerViewModelGrpcServiceImpl.cs
+++ b/test/PointerTestModel/expected/PointerViewModelGrpcServiceImpl.cs
@@ -330,7 +330,7 @@ public partial class PointerViewModelGrpcServiceImpl : PointerViewModelService.P
                 return response;
             }
             
-            if (!propertyInfo.CanWrite)
+            if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
             {
                 response.Success = false;
                 response.ErrorMessage = $"Property '{finalPropertyName}' is read-only";

--- a/test/RemoteMvvmTool.Tests/TsProjectGeneratorTests.cs
+++ b/test/RemoteMvvmTool.Tests/TsProjectGeneratorTests.cs
@@ -116,5 +116,29 @@ public class TsProjectGeneratorTests
         Assert.Contains("<style>", html);
         Assert.DoesNotContain("<input id='zoneList'", html);
     }
+
+    [Fact]
+    public void GenerateAppTs_ReadOnlyPropertyIsNotEditable()
+    {
+        var props = new List<PropertyInfo>
+        {
+            new("Name", "string", null!, true)
+        };
+        string ts = TsProjectGenerator.GenerateAppTs("Vm", "VmService", props, new List<CommandInfo>());
+        Assert.Contains("textContent = String(vm.name);", ts);
+        Assert.DoesNotContain("updatePropertyValueDebounced('Name'", ts);
+    }
+
+    [Fact]
+    public void GenerateIndexHtml_ReadOnlyPropertyUsesSpan()
+    {
+        var props = new List<PropertyInfo>
+        {
+            new("Name", "string", null!, true)
+        };
+        string html = TsProjectGenerator.GenerateIndexHtml("Vm", props, new List<CommandInfo>());
+        Assert.Contains("<span id='name'></span>", html);
+        Assert.DoesNotContain("<input id='name'", html);
+    }
 }
 

--- a/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptGenerationTests.cs
+++ b/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptGenerationTests.cs
@@ -184,4 +184,16 @@ public class ObservableObject {}
         Assert.Contains("// Enum mapping for HP.Telemetry.Zone", ts);
         Assert.Contains("export const ZoneMap", ts);
     }
+
+    [Fact]
+    public void Generates_ReadOnly_Property_Guard()
+    {
+        var props = new List<PropertyInfo>
+        {
+            new("Name", "string", null!, true)
+        };
+        string ts = TypeScriptClientGenerator.Generate("Vm", "Ns", "VmService", props, new List<CommandInfo>());
+        Assert.Contains("readOnlyProps = new Set", ts);
+        Assert.Contains("this.readOnlyProps?.has(propertyName)", ts);
+    }
 }

--- a/test/SampleViewModel/actual2/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/actual2/SampleViewModelGrpcServiceImpl.cs
@@ -246,7 +246,7 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                 return response;
             }
             
-            if (!propertyInfo.CanWrite)
+            if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
             {
                 response.Success = false;
                 response.ErrorMessage = $"Property '{finalPropertyName}' is read-only";

--- a/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
@@ -246,7 +246,7 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                 return response;
             }
             
-            if (!propertyInfo.CanWrite)
+            if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
             {
                 response.Success = false;
                 response.ErrorMessage = $"Property '{finalPropertyName}' is read-only";

--- a/test/SimpleViewModelTest/ViewModels/generated/MainViewModelGrpcServiceImpl.cs
+++ b/test/SimpleViewModelTest/ViewModels/generated/MainViewModelGrpcServiceImpl.cs
@@ -239,7 +239,7 @@ public partial class MainViewModelGrpcServiceImpl : MainViewModelService.MainVie
                 return response;
             }
             
-            if (!propertyInfo.CanWrite)
+            if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
             {
                 response.Success = false;
                 response.ErrorMessage = $"Property '{finalPropertyName}' is read-only";

--- a/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelGrpcServiceImpl.cs
+++ b/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelGrpcServiceImpl.cs
@@ -288,7 +288,7 @@ public partial class HP3LSThermalTestViewModelGrpcServiceImpl : HP3LSThermalTest
                 return response;
             }
             
-            if (!propertyInfo.CanWrite)
+            if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
             {
                 response.Success = false;
                 response.ErrorMessage = $"Property '{finalPropertyName}' is read-only";


### PR DESCRIPTION
## Summary
- track whether ViewModel properties have public setters
- omit editing UI for read-only properties in generated TypeScript project
- guard TypeScript client and server against updates to read-only properties

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68afc48ba8d883208c87ec05e21d20b2