### PR TITLE
fix: avoid container variable clashes in ts generator

### DIFF
--- a/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
@@ -129,7 +129,7 @@ public static class TsProjectGenerator
                 sb.AppendLine($"    const {camel}Summary = document.createElement('summary');");
                 sb.AppendLine($"    {camel}Summary.textContent = '{p.Name}';");
                 sb.AppendLine($"    {camel}Details.appendChild({camel}Summary);");
-                sb.AppendLine($"    const container = document.createElement('div');");
+                sb.AppendLine($"    const {camel}Container = document.createElement('div');");
                 sb.AppendLine($"    Object.entries(vm.{camel} as any).forEach(([key, value]) => {{");
                 sb.AppendLine($"        const field = document.createElement('div');");
                 sb.AppendLine($"        field.className = 'field';");
@@ -158,9 +158,9 @@ public static class TsProjectGenerator
                 sb.AppendLine($"        }});");
                 sb.AppendLine($"        field.appendChild(label);");
                 sb.AppendLine($"        field.appendChild(input);");
-                sb.AppendLine($"        container.appendChild(field);");
+                sb.AppendLine($"        {camel}Container.appendChild(field);");
                 sb.AppendLine($"    }});");
-                sb.AppendLine($"    {camel}Details.appendChild(container);");
+                sb.AppendLine($"    {camel}Details.appendChild({camel}Container);");
                 sb.AppendLine($"    {camel}El.appendChild({camel}Details);");
             }
         }

--- a/test/RemoteMvvmTool.Tests/TsProjectGeneratorTests.cs
+++ b/test/RemoteMvvmTool.Tests/TsProjectGeneratorTests.cs
@@ -95,6 +95,7 @@ public class TsProjectGeneratorTests
         Assert.Contains("vm.zoneList.forEach", ts);
         Assert.Contains("document.createElement('details')", ts);
         Assert.Contains("Object.entries(vm.testSettings", ts);
+        Assert.Contains("const testSettingsContainer = document.createElement('div');", ts);
         Assert.Contains("await vm.updatePropertyValueDebounced('ZoneList'", ts);
         Assert.Contains("await vm.updatePropertyValueDebounced('TestSettings'", ts);
         Assert.Contains("await vm.doWork", ts);

--- a/test/ThermalTest/ViewModels/generated/tsProject/src/app.ts
+++ b/test/ThermalTest/ViewModels/generated/tsProject/src/app.ts
@@ -36,7 +36,7 @@ async function render() {
     const zonesSummary = document.createElement('summary');
     zonesSummary.textContent = 'Zones';
     zonesDetails.appendChild(zonesSummary);
-    const container = document.createElement('div');
+    const zonesContainer = document.createElement('div');
     Object.entries(vm.zones as any).forEach(([key, value]) => {
         const field = document.createElement('div');
         field.className = 'field';
@@ -65,9 +65,9 @@ async function render() {
         });
         field.appendChild(label);
         field.appendChild(input);
-        container.appendChild(field);
+        zonesContainer.appendChild(field);
     });
-    zonesDetails.appendChild(container);
+    zonesDetails.appendChild(zonesContainer);
     zonesEl.appendChild(zonesDetails);
     const testSettingsEl = document.getElementById('testSettings') as HTMLElement;
     const testSettingsRootOpen = (testSettingsEl.querySelector('details[data-root]') as HTMLDetailsElement)?.open ?? true;
@@ -78,7 +78,7 @@ async function render() {
     const testSettingsSummary = document.createElement('summary');
     testSettingsSummary.textContent = 'TestSettings';
     testSettingsDetails.appendChild(testSettingsSummary);
-    const container = document.createElement('div');
+    const testSettingsContainer = document.createElement('div');
     Object.entries(vm.testSettings as any).forEach(([key, value]) => {
         const field = document.createElement('div');
         field.className = 'field';
@@ -107,9 +107,9 @@ async function render() {
         });
         field.appendChild(label);
         field.appendChild(input);
-        container.appendChild(field);
+        testSettingsContainer.appendChild(field);
     });
-    testSettingsDetails.appendChild(container);
+    testSettingsDetails.appendChild(testSettingsContainer);
     testSettingsEl.appendChild(testSettingsDetails);
     (document.getElementById('showDescription') as HTMLInputElement).checked = vm.showDescription;
     (document.getElementById('showReadme') as HTMLInputElement).checked = vm.showReadme;


### PR DESCRIPTION
## Summary
- ensure TsProjectGenerator uses property-specific container variables
- add regression test for complex type container naming
- update generated ThermalTest app.ts with unique container variables

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj` *(fails: Cannot find type definition file for 'node')*
- `npm run build` in `test/ThermalTest/ViewModels/generated/tsProject` *(fails: enhanced-resolve TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68afcd08116c8320b1fa1fa06f2f7200