### PR TITLE
Respect readonly complex properties in generated TS UI

### DIFF
--- a/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TsProjectGenerator.cs
@@ -85,29 +85,39 @@ public static class TsProjectGenerator
                 sb.AppendLine($"            field.className = 'field';");
                 sb.AppendLine($"            const label = document.createElement('span');");
                 sb.AppendLine("            label.textContent = key;");
-                sb.AppendLine($"            const input = document.createElement('input');");
-                sb.AppendLine($"            if (typeof value === 'boolean') {{");
-                sb.AppendLine($"                input.type = 'checkbox';");
-                sb.AppendLine($"                input.checked = Boolean(value);");
-                sb.AppendLine($"            }} else {{");
-                sb.AppendLine($"                input.type = typeof value === 'number' ? 'number' : 'text';");
-                sb.AppendLine($"                input.value = typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);");
-                sb.AppendLine($"            }}");
-                sb.AppendLine($"            input.addEventListener('change', async (e) => {{");
-                sb.AppendLine($"                const tgt = e.target as HTMLInputElement;");
-                sb.AppendLine($"                let parsed: any;");
-                sb.AppendLine($"                if (typeof value === 'number') parsed = tgt.valueAsNumber;");
-                sb.AppendLine($"                else if (typeof value === 'boolean') parsed = tgt.checked;");
-                sb.AppendLine($"                else {{ try {{ parsed = JSON.parse(tgt.value); }} catch {{ parsed = tgt.value; }} }}");
-                sb.AppendLine($"                const newCollection = vm.{camel}.map((z: any) => Object.assign({{}}, z));");
-                sb.AppendLine($"                if (JSON.stringify(newCollection[index][key]) !== JSON.stringify(parsed)) {{");
-                sb.AppendLine($"                    (newCollection[index] as any)[key] = parsed;");
-                sb.AppendLine($"                    try {{ await vm.updatePropertyValueDebounced('{p.Name}', newCollection); }}");
-                sb.AppendLine($"                    catch (err) {{ handleError(err, 'Update {p.Name}'); }}");
-                sb.AppendLine($"                }}");
-                sb.AppendLine($"            }});");
-                sb.AppendLine($"            field.appendChild(label);");
-                sb.AppendLine($"            field.appendChild(input);");
+                if (p.IsReadOnly)
+                {
+                    sb.AppendLine($"            const valueEl = document.createElement('span');");
+                    sb.AppendLine($"            valueEl.textContent = typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);");
+                    sb.AppendLine($"            field.appendChild(label);");
+                    sb.AppendLine($"            field.appendChild(valueEl);");
+                }
+                else
+                {
+                    sb.AppendLine($"            const input = document.createElement('input');");
+                    sb.AppendLine($"            if (typeof value === 'boolean') {{");
+                    sb.AppendLine($"                input.type = 'checkbox';");
+                    sb.AppendLine($"                input.checked = Boolean(value);");
+                    sb.AppendLine($"            }} else {{");
+                    sb.AppendLine($"                input.type = typeof value === 'number' ? 'number' : 'text';");
+                    sb.AppendLine($"                input.value = typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);");
+                    sb.AppendLine($"            }}");
+                    sb.AppendLine($"            input.addEventListener('change', async (e) => {{");
+                    sb.AppendLine($"                const tgt = e.target as HTMLInputElement;");
+                    sb.AppendLine($"                let parsed: any;");
+                    sb.AppendLine($"                if (typeof value === 'number') parsed = tgt.valueAsNumber;");
+                    sb.AppendLine($"                else if (typeof value === 'boolean') parsed = tgt.checked;");
+                    sb.AppendLine($"                else {{ try {{ parsed = JSON.parse(tgt.value); }} catch {{ parsed = tgt.value; }} }}");
+                    sb.AppendLine($"                const newCollection = vm.{camel}.map((z: any) => Object.assign({{}}, z));");
+                    sb.AppendLine($"                if (JSON.stringify(newCollection[index][key]) !== JSON.stringify(parsed)) {{");
+                    sb.AppendLine($"                    (newCollection[index] as any)[key] = parsed;");
+                    sb.AppendLine($"                    try {{ await vm.updatePropertyValueDebounced('{p.Name}', newCollection); }}");
+                    sb.AppendLine($"                    catch (err) {{ handleError(err, 'Update {p.Name}'); }}");
+                    sb.AppendLine($"                }}");
+                    sb.AppendLine($"            }});");
+                    sb.AppendLine($"            field.appendChild(label);");
+                    sb.AppendLine($"            field.appendChild(input);");
+                }
                 sb.AppendLine($"            container.appendChild(field);");
                 sb.AppendLine($"        }});");
                 sb.AppendLine($"        itemDetails.appendChild(container);");
@@ -132,29 +142,39 @@ public static class TsProjectGenerator
                 sb.AppendLine($"        field.className = 'field';");
                 sb.AppendLine($"        const label = document.createElement('span');");
                 sb.AppendLine("        label.textContent = key;");
-                sb.AppendLine($"        const input = document.createElement('input');");
-                sb.AppendLine($"        if (typeof value === 'boolean') {{");
-                sb.AppendLine($"            input.type = 'checkbox';");
-                sb.AppendLine($"            input.checked = Boolean(value);");
-                sb.AppendLine($"        }} else {{");
-                sb.AppendLine($"            input.type = typeof value === 'number' ? 'number' : 'text';");
-                sb.AppendLine($"            input.value = typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);");
-                sb.AppendLine($"        }}");
-        sb.AppendLine($"        input.addEventListener('change', async (e) => {{");
-                sb.AppendLine($"            const tgt = e.target as HTMLInputElement;");
-                sb.AppendLine($"            let parsed: any;");
-                sb.AppendLine($"            if (typeof value === 'number') parsed = tgt.valueAsNumber;");
-                sb.AppendLine($"            else if (typeof value === 'boolean') parsed = tgt.checked;");
-                sb.AppendLine($"            else {{ try {{ parsed = JSON.parse(tgt.value); }} catch {{ parsed = tgt.value; }} }}");
-                sb.AppendLine($"            const newObj = Object.assign({{}}, vm.{camel});");
-                sb.AppendLine($"            if (JSON.stringify((newObj as any)[key]) !== JSON.stringify(parsed)) {{");
-                sb.AppendLine($"                (newObj as any)[key] = parsed;");
-                sb.AppendLine($"                try {{ await vm.updatePropertyValueDebounced('{p.Name}', newObj); }}");
-                sb.AppendLine($"                catch (err) {{ handleError(err, 'Update {p.Name}'); }}");
-                sb.AppendLine($"            }}");
-                sb.AppendLine($"        }});");
-                sb.AppendLine($"        field.appendChild(label);");
-                sb.AppendLine($"        field.appendChild(input);");
+                if (p.IsReadOnly)
+                {
+                    sb.AppendLine($"        const valueEl = document.createElement('span');");
+                    sb.AppendLine($"        valueEl.textContent = typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);");
+                    sb.AppendLine($"        field.appendChild(label);");
+                    sb.AppendLine($"        field.appendChild(valueEl);");
+                }
+                else
+                {
+                    sb.AppendLine($"        const input = document.createElement('input');");
+                    sb.AppendLine($"        if (typeof value === 'boolean') {{");
+                    sb.AppendLine($"            input.type = 'checkbox';");
+                    sb.AppendLine($"            input.checked = Boolean(value);");
+                    sb.AppendLine($"        }} else {{");
+                    sb.AppendLine($"            input.type = typeof value === 'number' ? 'number' : 'text';");
+                    sb.AppendLine($"            input.value = typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);");
+                    sb.AppendLine($"        }}");
+            sb.AppendLine($"        input.addEventListener('change', async (e) => {{");
+                    sb.AppendLine($"            const tgt = e.target as HTMLInputElement;");
+                    sb.AppendLine($"            let parsed: any;");
+                    sb.AppendLine($"            if (typeof value === 'number') parsed = tgt.valueAsNumber;");
+                    sb.AppendLine($"            else if (typeof value === 'boolean') parsed = tgt.checked;");
+                    sb.AppendLine($"            else {{ try {{ parsed = JSON.parse(tgt.value); }} catch {{ parsed = tgt.value; }} }}");
+                    sb.AppendLine($"            const newObj = Object.assign({{}}, vm.{camel});");
+                    sb.AppendLine($"            if (JSON.stringify((newObj as any)[key]) !== JSON.stringify(parsed)) {{");
+                    sb.AppendLine($"                (newObj as any)[key] = parsed;");
+                    sb.AppendLine($"                try {{ await vm.updatePropertyValueDebounced('{p.Name}', newObj); }}");
+                    sb.AppendLine($"                catch (err) {{ handleError(err, 'Update {p.Name}'); }}");
+                    sb.AppendLine($"            }}");
+                    sb.AppendLine($"        }});");
+                    sb.AppendLine($"        field.appendChild(label);");
+                    sb.AppendLine($"        field.appendChild(input);");
+                }
                 sb.AppendLine($"        {camel}Container.appendChild(field);");
                 sb.AppendLine($"    }});");
                 sb.AppendLine($"    {camel}Details.appendChild({camel}Container);");

--- a/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
@@ -195,7 +195,10 @@ public static class TypeScriptClientGenerator
                     .Where(p => p.GetMethod != null && p.Parameters.Length == 0);
                 foreach (var m in members)
                 {
-                    ifaceSb.AppendLine($"  {GeneratorHelpers.ToCamelCase(m.Name)}: {MapTsType(m.Type)};");
+                    var ro = m.SetMethod == null || m.SetMethod.DeclaredAccessibility != Accessibility.Public
+                        ? "readonly "
+                        : string.Empty;
+                    ifaceSb.AppendLine($"  {ro}{GeneratorHelpers.ToCamelCase(m.Name)}: {MapTsType(m.Type)};");
                 }
                 ifaceSb.AppendLine("}");
                 ifaceSb.AppendLine();

--- a/test/RemoteMvvmTool.Tests/TsProjectGeneratorTests.cs
+++ b/test/RemoteMvvmTool.Tests/TsProjectGeneratorTests.cs
@@ -147,5 +147,17 @@ public class TsProjectGeneratorTests
         Assert.Contains("<span id='name'></span>", html);
         Assert.DoesNotContain("<input id='name'", html);
     }
+
+    [Fact]
+    public void GenerateAppTs_ReadOnlyComplexPropertyIsNotEditable()
+    {
+        var props = new List<PropertyInfo>
+        {
+            new("Zones", "ZoneCollection", null!, true)
+        };
+        string ts = TsProjectGenerator.GenerateAppTs("Vm", "VmService", props, new List<CommandInfo>());
+        Assert.DoesNotContain("updatePropertyValueDebounced('Zones'", ts);
+        Assert.Contains("valueEl.textContent", ts);
+    }
 }
 


### PR DESCRIPTION
## Summary
- Render readonly collection and object properties as static text in generated app.ts
- Mark interface members without public setters as `readonly`
- Cover readonly complex properties with new TsProjectGenerator test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68afd5d47d308320a00320627731c491