### PR TITLE
Fix Guid and DateTime mapping in server generator

### DIFF
--- a/src/RemoteMvvmTool/Generators/ServerGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ServerGenerator.cs
@@ -189,12 +189,25 @@ public static class ServerGenerator
                 }
                 else
                 {
+                    var typeDisplayString = p.FullTypeSymbol.ToDisplayString();
+                    var assignment = typeDisplayString switch
+                    {
+                        "System.DateTime" => $"Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(propValue.ToUniversalTime())",
+                        "System.Half" => $"(float)propValue",
+                        "System.Char" or "char" => $"propValue.ToString()",
+                        "System.Guid" => $"propValue.ToString()",
+                        "System.Decimal" or "decimal" => $"propValue.ToString()",
+                        "System.DateOnly" => $"propValue.ToString()",
+                        "System.TimeOnly" => $"propValue.ToString()",
+                        _ => "propValue",
+                    };
+
                     if (p.FullTypeSymbol.TypeKind == TypeKind.Enum)
                         sb.AppendLine($"            state.{p.Name} = (int)propValue;");
                     else if (!GeneratorHelpers.IsWellKnownType(p.FullTypeSymbol))
                         sb.AppendLine($"            state.{p.Name} = {viewModelNamespace}.ProtoStateConverters.ToProto(propValue);");
                     else
-                        sb.AppendLine($"            state.{p.Name} = propValue;");
+                        sb.AppendLine($"            state.{p.Name} = {assignment};");
                 }
             }
             else if (p.FullTypeSymbol is IArrayTypeSymbol arr)


### PR DESCRIPTION
## Summary
- handle Guid and DateTime properties when generating server mappings to convert to string or timestamp as appropriate

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj --filter MixedComplexTypesWithCommands_EndToEnd_Test` *(fails: npm install failed to download grpc-web plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68b0408eb9208320b64d707217b573ff