### PR TITLE
Fix nested timestamp array Date conversion

### DIFF
--- a/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
@@ -197,9 +197,9 @@ public static class TypeScriptClientGenerator
                             GeneratorHelpers.GetProtoWellKnownTypeFor(m.Type) == "Timestamp")
                 .ToList();
             if (members.Count == 0)
-                return $"typeof {varName}.toObject === 'function' ? {varName}.toObject() : {varName}";
+                return $"{varName}.toObject()";
             var sbLocal = new StringBuilder();
-            sbLocal.Append("{ const obj = typeof " + varName + ".toObject === 'function' ? " + varName + ".toObject() : " + varName + ";");
+            sbLocal.Append("{ const obj = " + varName + ".toObject();");
             foreach (var m in members)
             {
                 sbLocal.Append($" obj.{GeneratorHelpers.ToCamelCase(m.Name)} = {varName}.get{m.Name}()?.toDate();");


### PR DESCRIPTION
## Summary
- ensure nested timestamp fields in arrays are converted to `Date` objects in the generated TypeScript client

## Testing
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj` *(fails: 23 Failed, 157 Passed)*
- `dotnet test test/RemoteMvvmTool.Tests/RemoteMvvmTool.Tests.csproj --filter Nested_timestamp_fields_are_converted_to_dates -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68b0a817d74c83209a35c6bc17882051