### PR TITLE
Handle derived ObservableCollection in client generator

### DIFF
--- a/test/RemoteMvvmTool.Tests/ThermalViewModelGenerationTests.cs
+++ b/test/RemoteMvvmTool.Tests/ThermalViewModelGenerationTests.cs
@@ -165,7 +165,8 @@ public class ObservableObject {}
         Assert.Contains("repeated ThermalZoneComponentViewModelState zones", proto);
 
         var client = ClientGenerator.Generate(name, "Test.Protos", name + "Service", props, cmds, string.Empty);
-        Assert.Contains("new ZoneCollection(state.Zones", client);
+        Assert.Contains("this.Zones = new ZoneCollection();", client);
+        Assert.Contains("foreach (var e in state.Zones.Select(ProtoStateConverters.FromProto)) this.Zones.Add(e);", client);
 
         var server = ServerGenerator.Generate(name, "Test.Protos", name + "Service", props, cmds, string.Empty);
         Assert.Contains("state.Zones.AddRange(propValue.Where", server);

--- a/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelRemoteClient.cs
+++ b/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelRemoteClient.cs
@@ -120,7 +120,8 @@ namespace HPSystemsTools.ViewModels.RemoteClients
                                 this.CpuTemperatureThreshold = state.CpuTemperatureThreshold;
                                 this.CpuLoadThreshold = state.CpuLoadThreshold;
                                 this.CpuLoadTimeSpan = state.CpuLoadTimeSpan;
-                                this.Zones = new HPSystemsTools.ViewModels.ZoneCollection(state.Zones.Select(ProtoStateConverters.FromProto));
+                                this.Zones = new HPSystemsTools.ViewModels.ZoneCollection();
+                                foreach (var e in state.Zones.Select(ProtoStateConverters.FromProto)) this.Zones.Add(e);
                                 this.TestSettings = ProtoStateConverters.FromProto(state.TestSettings);
                                 this.ShowDescription = state.ShowDescription;
                                 this.ShowReadme = state.ShowReadme;
@@ -163,7 +164,8 @@ namespace HPSystemsTools.ViewModels.RemoteClients
                 this.CpuTemperatureThreshold = state.CpuTemperatureThreshold;
                 this.CpuLoadThreshold = state.CpuLoadThreshold;
                 this.CpuLoadTimeSpan = state.CpuLoadTimeSpan;
-                this.Zones = new HPSystemsTools.ViewModels.ZoneCollection(state.Zones.Select(ProtoStateConverters.FromProto));
+                this.Zones = new HPSystemsTools.ViewModels.ZoneCollection();
+                foreach (var e in state.Zones.Select(ProtoStateConverters.FromProto)) this.Zones.Add(e);
                 this.TestSettings = ProtoStateConverters.FromProto(state.TestSettings);
                 this.ShowDescription = state.ShowDescription;
                 this.ShowReadme = state.ShowReadme;

--- a/test/ThermalTest/ViewModels/generated/csProject/HP3LSThermalTestViewModel.csproj
+++ b/test/ThermalTest/ViewModels/generated/csProject/HP3LSThermalTestViewModel.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <LangVersion>preview</LangVersion>
     <UseWPF>true</UseWPF>
-	<LangVersion>preview</LangVersion>
     
   </PropertyGroup>
   <ItemGroup>

--- a/test/ThermalTest/ViewModels/generated/csProject/HP3LSThermalTestViewModelRemoteClient.cs
+++ b/test/ThermalTest/ViewModels/generated/csProject/HP3LSThermalTestViewModelRemoteClient.cs
@@ -120,7 +120,8 @@ namespace HPSystemsTools.ViewModels.RemoteClients
                                 this.CpuTemperatureThreshold = state.CpuTemperatureThreshold;
                                 this.CpuLoadThreshold = state.CpuLoadThreshold;
                                 this.CpuLoadTimeSpan = state.CpuLoadTimeSpan;
-                                this.Zones = new HPSystemsTools.ViewModels.ZoneCollection(state.Zones.Select(ProtoStateConverters.FromProto));
+                                this.Zones = new HPSystemsTools.ViewModels.ZoneCollection();
+                                foreach (var e in state.Zones.Select(ProtoStateConverters.FromProto)) this.Zones.Add(e);
                                 this.TestSettings = ProtoStateConverters.FromProto(state.TestSettings);
                                 this.ShowDescription = state.ShowDescription;
                                 this.ShowReadme = state.ShowReadme;
@@ -163,7 +164,8 @@ namespace HPSystemsTools.ViewModels.RemoteClients
                 this.CpuTemperatureThreshold = state.CpuTemperatureThreshold;
                 this.CpuLoadThreshold = state.CpuLoadThreshold;
                 this.CpuLoadTimeSpan = state.CpuLoadTimeSpan;
-                this.Zones = new HPSystemsTools.ViewModels.ZoneCollection(state.Zones.Select(ProtoStateConverters.FromProto));
+                this.Zones = new HPSystemsTools.ViewModels.ZoneCollection();
+                foreach (var e in state.Zones.Select(ProtoStateConverters.FromProto)) this.Zones.Add(e);
                 this.TestSettings = ProtoStateConverters.FromProto(state.TestSettings);
                 this.ShowDescription = state.ShowDescription;
                 this.ShowReadme = state.ShowReadme;


### PR DESCRIPTION
## Summary
- support types derived from ObservableCollection in C# client generator
- update unit tests
- regenerate thermal test client code

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found; tsc cannot find type definitions for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68b0c7260d8c83209749563265d32025