### PR TITLE
Avoid assigning to read-only Background property

### DIFF
--- a/test/ThermalTest/ViewModels/ThermalZoneComponentViewModel.cs
+++ b/test/ThermalTest/ViewModels/ThermalZoneComponentViewModel.cs
@@ -39,7 +39,7 @@ namespace HPSystemsTools.ViewModels
         [ObservableProperty]
         public partial int Progress { get; private set; }
         [ObservableProperty]
-        public partial string Background { get; set; }
+        public partial string Background { get; private set; }
         [ObservableProperty]
         public partial ThermalStateEnum Status { get; private set; }
         [ObservableProperty]

--- a/test/ThermalTest/ViewModels/generated/ProtoStateConverters.cs
+++ b/test/ThermalTest/ViewModels/generated/ProtoStateConverters.cs
@@ -36,7 +36,6 @@ public static class ProtoStateConverters
     {
         var model = new HPSystemsTools.ViewModels.ThermalZoneComponentViewModel();
         model.Zone = (HP.Telemetry.Zone)state.Zone;
-        model.Background = state.Background;
         return model;
     }
 

--- a/test/ThermalTest/ViewModels/generated/csProject/ProtoStateConverters.cs
+++ b/test/ThermalTest/ViewModels/generated/csProject/ProtoStateConverters.cs
@@ -36,7 +36,6 @@ public static class ProtoStateConverters
     {
         var model = new HPSystemsTools.ViewModels.ThermalZoneComponentViewModel();
         model.Zone = (HP.Telemetry.Zone)state.Zone;
-        model.Background = state.Background;
         return model;
     }
 


### PR DESCRIPTION
## Summary
- Mark `ThermalZoneComponentViewModel.Background` with a private setter so it's read-only externally
- Regenerate converters to stop assigning to `Background` in `FromProto`

## Testing
- `dotnet test` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop and Node type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c7a621f88320befb60d0fcc27270