### PR TITLE
Generate one-way bindings and numeric parsing from CsProjectGenerator

### DIFF
--- a/test/RemoteMvvmTool.Tests/CsProjectGeneratorTests.cs
+++ b/test/RemoteMvvmTool.Tests/CsProjectGeneratorTests.cs
@@ -53,4 +53,28 @@ public class CsProjectGeneratorTests
         Assert.Contains("UpdatePropertyValueRequest", prog);
         Assert.Contains("DoWorkCommand", prog);
     }
+
+    [Fact]
+    public void GenerateProgramCs_WpfHandlesReadOnlyAndInt()
+    {
+        var props = new List<PropertyInfo>
+        {
+            new("Instructions", "string", null!, true),
+            new("Threshold", "int", null!)
+        };
+        string prog = CsProjectGenerator.GenerateProgramCs("Vm", "wpf", "Proto.Ns", "Svc", "Client.Ns", props, new List<CommandInfo>());
+        Assert.Contains("IsReadOnly = true", prog);
+        Assert.Contains("Mode = BindingMode.OneWay", prog);
+        Assert.Contains("int.TryParse(thresholdBox.Text, out var value)", prog);
+        Assert.Contains("Any.Pack(new Int32Value", prog);
+    }
+
+    [Fact]
+    public void GenerateProgramCs_WinFormsUsesOneWayBinding()
+    {
+        var props = new List<PropertyInfo> { new("Count", "int", null!) };
+        string prog = CsProjectGenerator.GenerateProgramCs("Vm", "winforms", "Proto.Ns", "Svc", "Client.Ns", props, new List<CommandInfo>());
+        Assert.Contains("DataSourceUpdateMode.Never", prog);
+        Assert.Contains("int.TryParse(countBox.Text, out var value)", prog);
+    }
 }


### PR DESCRIPTION
## Summary
- generate one-way bindings and read-only text boxes for RemoteMvvm clients
- parse numeric text input and send typed gRPC values
- add tests for read-only and numeric binding generation

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0da086b688320a0c099fefcb0f5a9