### PR TITLE
Ensure generated Program runs on STA thread

### DIFF
--- a/src/RemoteMvvmTool/Generators/CsProjectGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/CsProjectGenerator.cs
@@ -62,12 +62,12 @@ public static class CsProjectGenerator
         sb.AppendLine("public class Program");
         sb.AppendLine("{");
         sb.AppendLine("    [STAThread]");
-        sb.AppendLine("    public static async Task Main()");
+        sb.AppendLine("    public static void Main()");
         sb.AppendLine("    {");
         sb.AppendLine("        var channel = GrpcChannel.ForAddress(\"http://localhost:50052\");");
         sb.AppendLine($"        var grpcClient = new {serviceName}.{serviceName}Client(channel);");
         sb.AppendLine($"        var vm = new {projectName}RemoteClient(grpcClient);");
-        sb.AppendLine("        await vm.InitializeRemoteAsync();");
+        sb.AppendLine("        vm.InitializeRemoteAsync().GetAwaiter().GetResult();");
         sb.AppendLine();
 
         if (isWpf)


### PR DESCRIPTION
## Summary
- Run generated Program entry point synchronously so STAThread attribute is honored

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b0e26296dc83209d49bbafc2a0a97b