### PR TITLE
Fix WinForms generators to produce populated UI

### DIFF
--- a/src/RemoteMvvmTool/Generators/WinFormsClientUIGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/WinFormsClientUIGenerator.cs
@@ -84,12 +84,10 @@ public class WinFormsClientUIGenerator : UIGeneratorBase
         sb.AppendLine();
         
         var uiTranslator = new WinFormsUITranslator();
-        var uiRoot = new ContainerComponent("StackPanel");
-        uiRoot.Children.Add(GenerateTreeViewStructure());
-        uiRoot.Children.Add(GeneratePropertyDetailsPanel());
-        uiRoot.Children.Add(GenerateCommandButtons());
-        uiRoot.Children.Add(GeneratePropertyChangeMonitoring());
-        sb.Append(uiTranslator.Translate(uiRoot));
+        sb.Append(uiTranslator.Translate(GenerateTreeViewStructure(), "                ", "split.Panel1"));
+        sb.Append(uiTranslator.Translate(GenerateCommandButtons(), "                ", "split.Panel2"));
+        sb.Append(uiTranslator.Translate(GeneratePropertyDetailsPanel(), "                ", "split.Panel2"));
+        sb.Append(uiTranslator.Translate(GeneratePropertyChangeMonitoring(), "                "));
         sb.AppendLine();
         sb.AppendLine("                refreshBtn.Click += (_, __) => LoadTree();");
         sb.AppendLine("                expandBtn.Click += (_, __) => tree.ExpandAll();");

--- a/src/RemoteMvvmTool/Generators/WinFormsServerUIGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/WinFormsServerUIGenerator.cs
@@ -79,12 +79,10 @@ public class WinFormsServerUIGenerator : UIGeneratorBase
         sb.AppendLine();
         
         var uiTranslator = new WinFormsUITranslator();
-        var uiRoot = new ContainerComponent("StackPanel");
-        uiRoot.Children.Add(GenerateTreeViewStructure());
-        uiRoot.Children.Add(GeneratePropertyDetailsPanel());
-        uiRoot.Children.Add(GenerateCommandButtons());
-        uiRoot.Children.Add(GeneratePropertyChangeMonitoring());
-        sb.Append(uiTranslator.Translate(uiRoot));
+        sb.Append(uiTranslator.Translate(GenerateTreeViewStructure(), "                ", "split.Panel1"));
+        sb.Append(uiTranslator.Translate(GenerateCommandButtons(), "                ", "split.Panel2"));
+        sb.Append(uiTranslator.Translate(GeneratePropertyDetailsPanel(), "                ", "split.Panel2"));
+        sb.Append(uiTranslator.Translate(GeneratePropertyChangeMonitoring(), "                "));
         sb.AppendLine();
         sb.AppendLine("                refreshBtn.Click += (_, __) => LoadTree();");
         sb.AppendLine("                expandBtn.Click += (_, __) => tree.ExpandAll();");


### PR DESCRIPTION
## Summary
- add docking and parent support to WinForms UI translator
- wire WinForms client and server generators to populate split panels with tree, commands and details

## Testing
- `dotnet test` *(fails: MSB4019 The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c36bc8113c8320a4f21a99dd0e0c56