### PR TITLE
Skip indexer properties when wiring nested property change handlers

### DIFF
--- a/src/RemoteMvvmTool/Resources/ServerTemplate.tmpl
+++ b/src/RemoteMvvmTool/Resources/ServerTemplate.tmpl
@@ -533,7 +533,7 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
             ViewModel_PropertyChanged(s, new PropertyChangedEventArgs(path));
 
             var prop = s?.GetType().GetProperty(e.PropertyName);
-            var val = prop?.GetValue(s);
+            var val = prop != null && prop.GetIndexParameters().Length == 0 ? prop.GetValue(s) : null;
             if (val is INotifyPropertyChanged child)
             {
                 var childPrefix = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
@@ -551,7 +551,7 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
             }
         };
 
-        foreach (var p in obj.GetType().GetProperties())
+        foreach (var p in obj.GetType().GetProperties().Where(p => p.GetIndexParameters().Length == 0))
         {
             var val = p.GetValue(obj);
             if (val is INotifyPropertyChanged child)

--- a/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
+++ b/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
@@ -591,7 +591,7 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
             ViewModel_PropertyChanged(s, new PropertyChangedEventArgs(path));
 
             var prop = s?.GetType().GetProperty(e.PropertyName);
-            var val = prop?.GetValue(s);
+            var val = prop != null && prop.GetIndexParameters().Length == 0 ? prop.GetValue(s) : null;
             if (val is INotifyPropertyChanged child)
             {
                 var childPrefix = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
@@ -609,7 +609,7 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
             }
         };
 
-        foreach (var p in obj.GetType().GetProperties())
+        foreach (var p in obj.GetType().GetProperties().Where(p => p.GetIndexParameters().Length == 0))
         {
             var val = p.GetValue(obj);
             if (val is INotifyPropertyChanged child)

--- a/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
@@ -549,7 +549,7 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             ViewModel_PropertyChanged(s, new PropertyChangedEventArgs(path));
 
             var prop = s?.GetType().GetProperty(e.PropertyName);
-            var val = prop?.GetValue(s);
+            var val = prop != null && prop.GetIndexParameters().Length == 0 ? prop.GetValue(s) : null;
             if (val is INotifyPropertyChanged child)
             {
                 var childPrefix = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
@@ -567,7 +567,7 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             }
         };
 
-        foreach (var p in obj.GetType().GetProperties())
+        foreach (var p in obj.GetType().GetProperties().Where(p => p.GetIndexParameters().Length == 0))
         {
             var val = p.GetValue(obj);
             if (val is INotifyPropertyChanged child)


### PR DESCRIPTION
## Summary
- avoid `TargetParameterCountException` by checking for indexer parameters before reading nested property values
- filter `GetProperties()` results to exclude indexer properties
- update expected service implementations for tests

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c560bfa9c48320a2fb701d7472171c