### PR TITLE
Remove array index field and rely on property paths

### DIFF
--- a/ENHANCED_UPDATE_PROPERTY_SUMMARY.md
+++ b/ENHANCED_UPDATE_PROPERTY_SUMMARY.md
@@ -13,8 +13,7 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   string property_path = 3;          // For nested properties like "User.Address.Street"
   string collection_key = 4;         // For dictionary keys
-  int32 array_index = 5;             // For array indices
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
 }
 
 message UpdatePropertyValueResponse {
@@ -58,8 +57,8 @@ var response = await UpdatePropertyValue(new() {
 
 // Array element update
 var response = await UpdatePropertyValue(new() {
-    PropertyName = "Scores", 
-    ArrayIndex = 3,
+    PropertyName = "Scores",
+    PropertyPath = "Scores[3]",
     NewValue = Any.Pack(new Int32Value { Value = 9500 })
 });
 ```
@@ -137,7 +136,7 @@ var response = await grpcService.UpdatePropertyValue(request);
 var request = new UpdatePropertyValueRequest
 {
     PropertyName = "PlayerScores",
-    ArrayIndex = 2,
+    PropertyPath = "PlayerScores[2]",
     NewValue = Any.Pack(new Int32Value { Value = 5000 })
 };
 var response = await grpcService.UpdatePropertyValue(request);

--- a/docs/UpdatePropertyValueExamples.md
+++ b/docs/UpdatePropertyValueExamples.md
@@ -43,7 +43,7 @@ if (response.getSuccess()) {
 
 // Advanced update with options
 const response = await client.updatePropertyValueAdvanced("items", newValue, {
-    arrayIndex: 2,
+    propertyPath: "items[2]",
     operationType: 'set'
 });
 ```
@@ -76,7 +76,7 @@ var request = new UpdatePropertyValueRequest
 var request = new UpdatePropertyValueRequest
 {
     PropertyName = "Scores",
-    ArrayIndex = 5,                  // Update element at index 5
+    PropertyPath = "Scores[5]",      // Update element at index 5
     NewValue = Any.Pack(new Int32Value { Value = 1500 })
 };
 ```

--- a/src/RemoteMvvmTool/Generators/ProtoGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ProtoGenerator.cs
@@ -263,10 +263,9 @@ public static class ProtoGenerator
         body.AppendLine("  google.protobuf.Any new_value = 2;");
         body.AppendLine("  // Optional fields for complex property updates");
         body.AppendLine("  string property_path = 3;          // For nested properties like \"User.Address.Street\"");
-        body.AppendLine("  string collection_key = 4;         // For dictionary keys or array indices");
-        body.AppendLine("  int32 array_index = 5;             // For updating specific array elements");
-        body.AppendLine("  string operation_type = 6;         // \"set\", \"add\", \"remove\", \"clear\", \"insert\"");
-        body.AppendLine("  string client_id = 7;             // Originating client identifier");
+        body.AppendLine("  string collection_key = 4;         // For dictionary keys");
+        body.AppendLine("  string operation_type = 5;         // \"set\", \"add\", \"remove\", \"clear\", \"insert\"");
+        body.AppendLine("  string client_id = 6;             // Originating client identifier");
         body.AppendLine("}");
         body.AppendLine();
         body.AppendLine("message UpdatePropertyValueResponse {");

--- a/src/RemoteMvvmTool/Generators/StronglyTypedTestClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/StronglyTypedTestClientGenerator.cs
@@ -137,7 +137,6 @@ public static class StronglyTypedTestClientGenerator
         sb.AppendLine("        var request = new UpdatePropertyValueRequest");
         sb.AppendLine("        {");
         sb.AppendLine("            PropertyName = propertyName,");
-        sb.AppendLine("            ArrayIndex = -1,");
         sb.AppendLine("            NewValue = Any.Pack(CreateValueFromObject(value))");
         sb.AppendLine("        };");
         sb.AppendLine("        await _grpcClient.UpdatePropertyValueAsync(request);");
@@ -149,7 +148,6 @@ public static class StronglyTypedTestClientGenerator
         sb.AppendLine("        {");
         sb.AppendLine("            PropertyName = propertyName,");
         sb.AppendLine("            PropertyPath = $\"{collectionName}[{index}].{propertyName}\",");
-        sb.AppendLine("            ArrayIndex = index,");
         sb.AppendLine("            NewValue = Any.Pack(CreateValueFromObject(value))");
         sb.AppendLine("        };");
         sb.AppendLine("        await _grpcClient.UpdatePropertyValueAsync(request);");
@@ -184,7 +182,6 @@ public static class StronglyTypedTestClientGenerator
             sb.AppendLine("        var request = new UpdatePropertyValueRequest");
             sb.AppendLine("        {");
             sb.AppendLine($"            PropertyName = \"{prop.Name}\",");
-            sb.AppendLine("            ArrayIndex = -1,");
             if (prop.TypeString == "System.String") sb.AppendLine("            NewValue = Any.Pack(new StringValue { Value = value })");
             else if (prop.TypeString == "System.Int32") sb.AppendLine("            NewValue = Any.Pack(new Int32Value { Value = value })");
             else if (prop.TypeString == "System.Boolean") sb.AppendLine("            NewValue = Any.Pack(new BoolValue { Value = value })");
@@ -296,7 +293,6 @@ public static class StronglyTypedTestClientGenerator
                 sb.AppendLine("            var request = new UpdatePropertyValueRequest { ");
                 sb.AppendLine("                PropertyName = propertyName,");
                 sb.AppendLine("                PropertyPath = $\"{_collectionName}[{_index}].{propertyName}\",");
-                sb.AppendLine("                ArrayIndex = _index,");
                 sb.AppendLine("                NewValue = Any.Pack(protoValue) ");
                 sb.AppendLine("            };");
                 sb.AppendLine("            await _client.UpdatePropertyValueAsync(request);");

--- a/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
@@ -541,7 +541,6 @@ public static class TypeScriptClientGenerator
         }
         sb.AppendLine("        const req = new UpdatePropertyValueRequest();");
         sb.AppendLine("        req.setPropertyName(propertyName);");
-        sb.AppendLine("        req.setArrayIndex(-1); // Default to -1 for non-array properties");
         sb.AppendLine("        req.setNewValue(this.createAnyValue(value));");
         sb.AppendLine("        const response = await this.grpcClient.updatePropertyValue(req);");
         sb.AppendLine("        ");
@@ -585,7 +584,6 @@ public static class TypeScriptClientGenerator
         sb.AppendLine("        options?: {");
         sb.AppendLine("            propertyPath?: string;");
         sb.AppendLine("            collectionKey?: string;");
-        sb.AppendLine("            arrayIndex?: number;");
         sb.AppendLine("            operationType?: 'set' | 'add' | 'remove' | 'clear' | 'insert';");
         sb.AppendLine("        }");
         sb.AppendLine("    ): Promise<UpdatePropertyValueResponse> {");
@@ -595,7 +593,6 @@ public static class TypeScriptClientGenerator
         sb.AppendLine("        ");
         sb.AppendLine("        if (options?.propertyPath) req.setPropertyPath(options.propertyPath);");
         sb.AppendLine("        if (options?.collectionKey) req.setCollectionKey(options.collectionKey);");
-        sb.AppendLine("        if (options?.arrayIndex !== undefined) req.setArrayIndex(options.arrayIndex);");
         sb.AppendLine("        if (options?.operationType) req.setOperationType(options.operationType);");
         sb.AppendLine("        ");
         sb.AppendLine("        const response = await this.grpcClient.updatePropertyValue(req);");

--- a/src/RemoteMvvmTool/Generators/UIGeneratorBase.cs
+++ b/src/RemoteMvvmTool/Generators/UIGeneratorBase.cs
@@ -168,10 +168,10 @@ public abstract class UIGeneratorBase
                     $"{viewModelVariableName}.{metadata.SafePropertyAccess}.ToString()"));
             }
             
-            commands.Add(new TreeCommand(TreeCommandType.CreateNode, $"{metadata.SafeVariableName}Node", 
+            commands.Add(new TreeCommand(TreeCommandType.CreateNode, $"{metadata.SafeVariableName}Node",
                 $"\"{prop.Name}: \" + {metadata.SafeVariableName}Value"));
-            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node", 
-                $"\"{prop.Name}\"", viewModelVariableName, "IsSimpleProperty = true"));
+            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node",
+                $"\"{prop.Name}\"", viewModelVariableName, $"PropertyPath = \"{prop.Name}\", IsSimpleProperty = true"));
             commands.Add(new TreeCommand(TreeCommandType.AddChildNode, "simplePropsNode", $"{metadata.SafeVariableName}Node"));
             
             commands.Add(new TreeCommand(TreeCommandType.TryEnd));
@@ -218,9 +218,9 @@ public abstract class UIGeneratorBase
                 commands.Add(new TreeCommand(TreeCommandType.CreateNode, $"{metadata.SafeVariableName}Node", 
                     $"\"{prop.Name}: \" + {viewModelVariableName}.{metadata.SafePropertyAccess}.ToString()"));
             }
-            
-            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node", 
-                $"\"{prop.Name}\"", viewModelVariableName, "IsBooleanProperty = true"));
+
+            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node",
+                $"\"{prop.Name}\"", viewModelVariableName, $"PropertyPath = \"{prop.Name}\", IsBooleanProperty = true"));
             commands.Add(new TreeCommand(TreeCommandType.AddChildNode, "boolPropsNode", $"{metadata.SafeVariableName}Node"));
             
             commands.Add(new TreeCommand(TreeCommandType.TryEnd));
@@ -256,10 +256,10 @@ public abstract class UIGeneratorBase
             commands.Add(new TreeCommand(TreeCommandType.TryBegin));
             commands.Add(new TreeCommand(TreeCommandType.IfNotNull, $"{viewModelVariableName}.{metadata.SafePropertyAccess}"));
             
-            commands.Add(new TreeCommand(TreeCommandType.CreateNode, $"{metadata.SafeVariableName}Node", 
+            commands.Add(new TreeCommand(TreeCommandType.CreateNode, $"{metadata.SafeVariableName}Node",
                 $"\"{prop.Name} [\" + {viewModelVariableName}.{metadata.SafePropertyAccess}.{metadata.CountProperty} + \" items]\""));
-            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node", 
-                $"\"{prop.Name}\"", viewModelVariableName, "IsCollectionProperty = true"));
+            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node",
+                $"\"{prop.Name}\"", viewModelVariableName, $"PropertyPath = \"{prop.Name}\", IsCollectionProperty = true"));
             commands.Add(new TreeCommand(TreeCommandType.AddChildNode, "collectionPropsNode", $"{metadata.SafeVariableName}Node"));
             
             // Add individual items (limit to first 3 for performance)
@@ -269,7 +269,8 @@ public abstract class UIGeneratorBase
             commands.Add(new TreeCommand(TreeCommandType.TryBegin));
             commands.Add(new TreeCommand(TreeCommandType.AssignValue, "itemText", "item.ToString()"));
             commands.Add(new TreeCommand(TreeCommandType.CreateNode, "itemNode", "\"[\" + idx + \"] \" + itemText"));
-            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, "itemNode", "\"[\" + idx + \"]\"", "item", "IsCollectionItem = true, CollectionIndex = idx"));
+            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, "itemNode", "\"[\" + idx + \"]\"", "item",
+                $"PropertyPath = ((PropertyNodeInfo){metadata.SafeVariableName}Node.Tag).PropertyPath + \"[\" + idx + \"]\", IsCollectionItem = true, CollectionIndex = idx"));
             commands.Add(new TreeCommand(TreeCommandType.AddChildNode, $"{metadata.SafeVariableName}Node", "itemNode"));
             commands.Add(new TreeCommand(TreeCommandType.TryEnd));
             commands.Add(new TreeCommand(TreeCommandType.CatchBegin));
@@ -319,10 +320,10 @@ public abstract class UIGeneratorBase
             
             commands.Add(new TreeCommand(TreeCommandType.AssignValue, $"{metadata.SafeVariableName}TypeName", 
                 $"{viewModelVariableName}.{metadata.SafePropertyAccess}.GetType().Name"));
-            commands.Add(new TreeCommand(TreeCommandType.CreateNode, $"{metadata.SafeVariableName}Node", 
+            commands.Add(new TreeCommand(TreeCommandType.CreateNode, $"{metadata.SafeVariableName}Node",
                 $"\"{prop.Name} (\" + {metadata.SafeVariableName}TypeName + \")\""));
-            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node", 
-                $"\"{prop.Name}\"", $"{viewModelVariableName}.{metadata.SafePropertyAccess}", "IsComplexProperty = true"));
+            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node",
+                $"\"{prop.Name}\"", $"{viewModelVariableName}.{metadata.SafePropertyAccess}", $"PropertyPath = \"{prop.Name}\", IsComplexProperty = true"));
             commands.Add(new TreeCommand(TreeCommandType.AddChildNode, "complexPropsNode", $"{metadata.SafeVariableName}Node"));
             
             commands.Add(new TreeCommand(TreeCommandType.Else));
@@ -374,9 +375,9 @@ public abstract class UIGeneratorBase
                 commands.Add(new TreeCommand(TreeCommandType.CreateNode, $"{metadata.SafeVariableName}Node", 
                     $"\"{prop.Name}: \" + {viewModelVariableName}.{metadata.SafePropertyAccess}.ToString()"));
             }
-            
-            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node", 
-                $"\"{prop.Name}\"", viewModelVariableName, "IsEnumProperty = true"));
+
+            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node",
+                $"\"{prop.Name}\"", viewModelVariableName, $"PropertyPath = \"{prop.Name}\", IsEnumProperty = true"));
             commands.Add(new TreeCommand(TreeCommandType.AddChildNode, "enumPropsNode", $"{metadata.SafeVariableName}Node"));
             
             commands.Add(new TreeCommand(TreeCommandType.TryEnd));
@@ -419,6 +420,7 @@ public abstract class UIGeneratorBase
         public class PropertyNodeInfo
         {
             public string PropertyName { get; set; } = string.Empty;
+            public string PropertyPath { get; set; } = string.Empty;
             public object? Object { get; set; }
             public bool IsSimpleProperty { get; set; }
             public bool IsBooleanProperty { get; set; }

--- a/src/RemoteMvvmTool/Resources/ClientTemplate.tmpl
+++ b/src/RemoteMvvmTool/Resources/ClientTemplate.tmpl
@@ -13,6 +13,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.ComponentModel;
+using System.Collections.Specialized;
 using <<VIEW_MODEL_NS>>;
 #if WPF_DISPATCHER
 using System.Windows;
@@ -27,6 +29,7 @@ namespace <<NAMESPACE>>
         private bool _isInitialized = false;
         private bool _isDisposed = false;
         private readonly string _clientId = Guid.NewGuid().ToString();
+        private bool _suppressLocalUpdates = false;
 
         private string _connectionStatus = "Unknown";
         public string ConnectionStatus
@@ -45,39 +48,40 @@ namespace <<NAMESPACE>>
         /// </summary>
         /// <param name="propertyName">The name of the property to update</param>
         /// <param name="value">The new value to set</param>
-        public async Task UpdatePropertyValueAsync(string propertyName, object? value)
+        public async Task UpdatePropertyValueAsync(string propertyPath, object? value)
         {
             if (!_isInitialized || _isDisposed)
             {
-                Debug.WriteLine($"[ClientProxy:<<VIEW_MODEL_NAME>>] UpdatePropertyValueAsync for {propertyName} skipped - not initialized or disposed");
+                Debug.WriteLine($"[ClientProxy:<<VIEW_MODEL_NAME>>] UpdatePropertyValueAsync for {propertyPath} skipped - not initialized or disposed");
                 return;
             }
 
             try
             {
-                Debug.WriteLine($"[ClientProxy:<<VIEW_MODEL_NAME>>] Updating server property {propertyName} = {value}");
+                Debug.WriteLine($"[ClientProxy:<<VIEW_MODEL_NAME>>] Updating server property {propertyPath} = {value}");
+                var topLevel = propertyPath.Split(new[] {'.','['}, 2)[0];
                 var request = new <<PROTO_NS>>.UpdatePropertyValueRequest
                 {
-                    PropertyName = propertyName,
-                    ArrayIndex = -1,
+                    PropertyName = topLevel,
+                    PropertyPath = propertyPath,
                     ClientId = _clientId,
                     NewValue = PackValueToAny(value)
                 };
 
                 var response = await _grpcClient.UpdatePropertyValueAsync(request, cancellationToken: _cts.Token);
-                Debug.WriteLine($"[ClientProxy:<<VIEW_MODEL_NAME>>] Property {propertyName} updated successfully on server");
+                Debug.WriteLine($"[ClientProxy:<<VIEW_MODEL_NAME>>] Property {propertyPath} updated successfully on server");
             }
             catch (RpcException ex)
             {
-                Debug.WriteLine($"[ClientProxy:<<VIEW_MODEL_NAME>>] Error updating property {propertyName}: {ex.Status.StatusCode} - {ex.Status.Detail}");
+                Debug.WriteLine($"[ClientProxy:<<VIEW_MODEL_NAME>>] Error updating property {propertyPath}: {ex.Status.StatusCode} - {ex.Status.Detail}");
             }
             catch (OperationCanceledException)
             {
-                Debug.WriteLine($"[ClientProxy:<<VIEW_MODEL_NAME>>] Property update {propertyName} cancelled");
+                Debug.WriteLine($"[ClientProxy:<<VIEW_MODEL_NAME>>] Property update {propertyPath} cancelled");
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[ClientProxy:<<VIEW_MODEL_NAME>>] Unexpected error updating property {propertyName}: {ex.Message}");
+                Debug.WriteLine($"[ClientProxy:<<VIEW_MODEL_NAME>>] Unexpected error updating property {propertyPath}: {ex.Message}");
             }
         }
 
@@ -106,6 +110,165 @@ namespace <<NAMESPACE>>
                 System.Enum e => Any.Pack(new Int32Value { Value = Convert.ToInt32(e) }),
                 _ => Any.Pack(new StringValue { Value = value?.ToString() ?? "" })
             };
+        }
+
+        private static object? UnpackAny(Any value)
+        {
+            if (value.Is(StringValue.Descriptor)) return value.Unpack<StringValue>().Value;
+            if (value.Is(Int32Value.Descriptor)) return value.Unpack<Int32Value>().Value;
+            if (value.Is(Int64Value.Descriptor)) return value.Unpack<Int64Value>().Value;
+            if (value.Is(UInt32Value.Descriptor)) return value.Unpack<UInt32Value>().Value;
+            if (value.Is(UInt64Value.Descriptor)) return value.Unpack<UInt64Value>().Value;
+            if (value.Is(FloatValue.Descriptor)) return value.Unpack<FloatValue>().Value;
+            if (value.Is(DoubleValue.Descriptor)) return value.Unpack<DoubleValue>().Value;
+            if (value.Is(BoolValue.Descriptor)) return value.Unpack<BoolValue>().Value;
+            if (value.Is(Timestamp.Descriptor)) return value.Unpack<Timestamp>().ToDateTime();
+            if (value.Is(Google.Protobuf.WellKnownTypes.Duration.Descriptor)) return value.Unpack<Google.Protobuf.WellKnownTypes.Duration>().ToTimeSpan();
+            return null;
+        }
+
+        private static void SetValueByPath(object target, string path, object? newValue)
+        {
+            var segments = path.Split('.');
+            object? current = target;
+
+            for (int i = 0; i < segments.Length; i++)
+            {
+                var part = segments[i];
+                int bracket = part.IndexOf('[');
+                if (bracket >= 0)
+                {
+                    var propName = part[..bracket];
+                    var end = part.IndexOf(']', bracket);
+                    if (end < 0) return;
+                    var indexStr = part[(bracket + 1)..end];
+                    var prop = current?.GetType().GetProperty(propName);
+                    if (prop?.GetValue(current) is System.Collections.IList list && int.TryParse(indexStr, out int idx))
+                    {
+                        if (idx < 0 || idx >= list.Count) return;
+                        if (i == segments.Length - 1)
+                        {
+                            list[idx] = newValue;
+                            if (target is <<VIEW_MODEL_NAME>>RemoteClient rc)
+                            {
+                                rc.AttachLocalPropertyChangedHandlers(list[idx], path);
+                            }
+                            return;
+                        }
+                        current = list[idx];
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    if (i == segments.Length - 1)
+                    {
+                        var prop = current?.GetType().GetProperty(part);
+                        prop?.SetValue(current, newValue);
+                        if (target is <<VIEW_MODEL_NAME>>RemoteClient rc)
+                        {
+                            rc.AttachLocalPropertyChangedHandlers(newValue, path);
+                        }
+                        return;
+                    }
+                    else
+                    {
+                        var prop = current?.GetType().GetProperty(part);
+                        current = prop?.GetValue(current);
+                    }
+                }
+
+                if (current == null) return;
+            }
+        }
+
+        private void AttachLocalPropertyChangedHandlers(object? obj, string prefix)
+        {
+            if (obj == null) return;
+
+            if (obj is INotifyPropertyChanged inpc)
+            {
+                inpc.PropertyChanged += async (s, e) =>
+                {
+                    if (_suppressLocalUpdates) return;
+                    var prop = s?.GetType().GetProperty(e.PropertyName);
+                    if (prop == null) return;
+                    var value = prop.GetValue(s);
+                    var path = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+                    await UpdatePropertyValueAsync(path, value);
+
+                    if (value is INotifyPropertyChanged child)
+                    {
+                        AttachLocalPropertyChangedHandlers(child, path);
+                    }
+                    else if (value is System.Collections.IEnumerable enumVal && value is not string)
+                    {
+                        int idx = 0;
+                        foreach (var item in enumVal)
+                        {
+                            var childPrefix = string.IsNullOrEmpty(path) ? $"[{idx}]" : path + $"[{idx}]";
+                            AttachLocalPropertyChangedHandlers(item, childPrefix);
+                            idx++;
+                        }
+                        if (value is INotifyCollectionChanged incc)
+                        {
+                            var outerPath = path;
+                            incc.CollectionChanged += (s2, args) =>
+                            {
+                                if (args.NewItems != null)
+                                {
+                                    int start = args.NewStartingIndex;
+                                    foreach (var newItem in args.NewItems)
+                                    {
+                                        var childPrefix = string.IsNullOrEmpty(outerPath) ? $"[{start}]" : outerPath + $"[{start}]";
+                                        AttachLocalPropertyChangedHandlers(newItem, childPrefix);
+                                        start++;
+                                    }
+                                }
+                            };
+                        }
+                    }
+                };
+            }
+
+            if (obj is System.Collections.IEnumerable enumerable && obj is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"[{index}]" : prefix + $"[{index}]";
+                    AttachLocalPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (obj is INotifyCollectionChanged incc)
+                {
+                    var outerPrefix = prefix;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(outerPrefix) ? $"[{start}]" : outerPrefix + $"[{start}]";
+                                AttachLocalPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+                return;
+            }
+
+            foreach (var p in obj.GetType().GetProperties())
+            {
+                var val = p.GetValue(obj);
+                var childPrefix = string.IsNullOrEmpty(prefix) ? p.Name : prefix + "." + p.Name;
+                AttachLocalPropertyChangedHandlers(val, childPrefix);
+            }
         }
 
         private async Task StartPingLoopAsync()
@@ -158,7 +321,10 @@ namespace <<NAMESPACE>>
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
                 var state = await _grpcClient.GetStateAsync(new Empty(), cancellationToken: linkedCts.Token);
                 Debug.WriteLine("[<<VIEW_MODEL_NAME>>RemoteClient] Initial state received.");
-<<PROPERTY_ASSIGNMENTS_INIT>>                _isInitialized = true;
+                _suppressLocalUpdates = true;
+<<PROPERTY_ASSIGNMENTS_INIT>>                _suppressLocalUpdates = false;
+                AttachLocalPropertyChangedHandlers(this, string.Empty);
+                _isInitialized = true;
                 Debug.WriteLine("[<<VIEW_MODEL_NAME>>RemoteClient] Initialized successfully.");
                 StartListeningToPropertyChanges(_cts.Token);
                 _ = StartPingLoopAsync();
@@ -190,12 +356,22 @@ namespace <<NAMESPACE>>
                            try
                            {
                                Debug.WriteLine("[<<VIEW_MODEL_NAME>>RemoteClient] Dispatcher: Attempting to update \"" + update.PropertyName + "\" (Update #" + updateCount + ").");
-                               switch (update.PropertyName)
+                               _suppressLocalUpdates = true;
+                               if (update.ChangeType == "nested")
                                {
-<<PROPERTY_UPDATE_CASES>>                                   default: Debug.WriteLine("[ClientProxy:<<VIEW_MODEL_NAME>>] Unknown property in notification: \"" + update.PropertyName + "\""); break;
+                                   var val = UnpackAny(update.NewValue);
+                                   SetValueByPath(this, update.PropertyPath, val);
+                               }
+                               else
+                               {
+                                   switch (update.PropertyName)
+                                   {
+<<PROPERTY_UPDATE_CASES>>                                       default: Debug.WriteLine("[ClientProxy:<<VIEW_MODEL_NAME>>] Unknown property in notification: \"" + update.PropertyName + "\""); break;
+                                   }
                                }
                            }
                            catch (Exception exInAction) { Debug.WriteLine("[ClientProxy:<<VIEW_MODEL_NAME>>] EXCEPTION INSIDE updateAction for \"" + update.PropertyName + "\": " + exInAction.ToString()); }
+                           finally { _suppressLocalUpdates = false; }
                         };
                         #if WPF_DISPATCHER
                         Application.Current?.Dispatcher.Invoke(updateAction);

--- a/src/RemoteMvvmTool/Resources/ServerTemplate.tmpl
+++ b/src/RemoteMvvmTool/Resources/ServerTemplate.tmpl
@@ -12,6 +12,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.ComponentModel;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Threading.Channels;
 using Channel = System.Threading.Channels.Channel;
@@ -49,8 +50,8 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
     {
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         _logger = logger;
-        if (_viewModel is INotifyPropertyChanged inpc) { 
-            inpc.PropertyChanged += ViewModel_PropertyChanged; 
+        if (_viewModel is INotifyPropertyChanged inpc) {
+            AttachNestedPropertyChangedHandlers(inpc, string.Empty);
         }
     }
 
@@ -197,7 +198,14 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
                             response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
                             return response;
                         }
-                        target = list[idx] ?? new();
+                        var nextTarget = list[idx];
+                        if (nextTarget == null)
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Null value encountered at index {idx} for '{propName}'";
+                            return response;
+                        }
+                        target = nextTarget;
                     }
                     else
                     {
@@ -226,47 +234,139 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
                 }
             }
 
-            var finalPropertyName = pathParts[pathParts.Length - 1];
-            var propertyInfo = target?.GetType().GetProperty(finalPropertyName);
-            if (propertyInfo == null)
+            var finalPart = pathParts[pathParts.Length - 1];
+            int finalBracket = finalPart.IndexOf('[');
+            if (finalBracket >= 0)
             {
-                response.Success = false;
-                response.ErrorMessage = $"Property '{finalPropertyName}' not found";
-                return response;
-            }
-
-            if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
-            {
-                response.Success = false;
-                response.ErrorMessage = $"Property '{finalPropertyName}' is read-only";
-                return response;
-            }
-
-            // Detect leaf element update inside a collection (Collection[index].Prop)
-            bool isLeafElementUpdate = propertyPath.Contains("]." + finalPropertyName, StringComparison.Ordinal);
-
-            // Store old value for undo/history
-            var oldValue = propertyInfo.GetValue(target);
-            if (oldValue != null) response.OldValue = PackToAny(oldValue);
-            
-            // Only treat as collection update when modifying the collection itself (not element property)
-            if (!isLeafElementUpdate && (!string.IsNullOrEmpty(request.CollectionKey) || (request.ArrayIndex > -1 && propertyPath.Equals(request.PropertyName, StringComparison.OrdinalIgnoreCase))))
-            {
-                response = HandleCollectionUpdate(target, propertyInfo, request);
-            }
-            else
-            {
-                var convertedValue = ConvertAnyToTargetType(request.NewValue, propertyInfo.PropertyType);
-                if (convertedValue.Success)
+                var propName = finalPart[..finalBracket];
+                var end = finalPart.IndexOf(']', finalBracket);
+                if (end < 0)
                 {
-                    Debug.WriteLine($"[GrpcService:<<VIEWMODEL_NAME>>] Setting property '{finalPropertyName}' via reflection to value: {convertedValue.Value}");
-                    propertyInfo.SetValue(target, convertedValue.Value);
+                    response.Success = false;
+                    response.ErrorMessage = $"Invalid path segment '{finalPart}' in '{propertyPath}'";
+                    return response;
+                }
+                var indexStr = finalPart[(finalBracket + 1)..end];
+                var propertyInfo = target?.GetType().GetProperty(propName);
+                if (propertyInfo == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{propName}' not found";
+                    return response;
+                }
+                var collection = propertyInfo.GetValue(target);
+                if (collection == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Collection property '{propName}' is null";
+                    return response;
+                }
+                if (collection is IList list && int.TryParse(indexStr, out int idx))
+                {
+                    if (idx < 0 || idx >= list.Count)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
+                        return response;
+                    }
+                    var elementType = propertyInfo.PropertyType.GetGenericArguments()[0];
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, elementType);
+                    if (!convertedValue.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = convertedValue.ErrorMessage;
+                        return response;
+                    }
+                    response.OldValue = PackToAny(list[idx]);
+                    list[idx] = convertedValue.Value;
                     response.Success = true;
+                    Debug.WriteLine($"[GrpcService:<<VIEWMODEL_NAME>>] Updated array index {idx} to '{convertedValue.Value}'");
+                }
+                else if (collection is IDictionary dict)
+                {
+                    var keyType = propertyInfo.PropertyType.GetGenericArguments()[0];
+                    var valueType = propertyInfo.PropertyType.GetGenericArguments()[1];
+                    var convertedKey = ConvertStringToTargetType(indexStr, keyType);
+                    if (!convertedKey.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Failed to convert key '{indexStr}': {convertedKey.ErrorMessage}";
+                        return response;
+                    }
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, valueType);
+                    if (!convertedValue.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Failed to convert value: {convertedValue.ErrorMessage}";
+                        return response;
+                    }
+                    if (convertedKey.Value != null && dict.Contains(convertedKey.Value)) response.OldValue = PackToAny(dict[convertedKey.Value]);
+                    dict[convertedKey.Value!] = convertedValue.Value;
+                    response.Success = true;
+                    Debug.WriteLine($"[GrpcService:<<VIEWMODEL_NAME>>] Updated dictionary key '{convertedKey.Value}' to '{convertedValue.Value}'");
                 }
                 else
                 {
                     response.Success = false;
-                    response.ErrorMessage = convertedValue.ErrorMessage;
+                    response.ErrorMessage = $"Property '{propName}' is not an indexable collection";
+                }
+            }
+            else
+            {
+                var propertyInfo = target?.GetType().GetProperty(finalPart);
+                if (propertyInfo == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{finalPart}' not found";
+                    return response;
+                }
+                if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{finalPart}' is read-only";
+                    return response;
+                }
+
+                bool isLeafElementUpdate = propertyPath.Contains("]." + finalPart, StringComparison.Ordinal);
+
+                var oldValue = propertyInfo.GetValue(target);
+                if (oldValue != null) response.OldValue = PackToAny(oldValue);
+
+                if (!isLeafElementUpdate && !string.IsNullOrEmpty(request.CollectionKey) && propertyPath.Equals(request.PropertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    response = HandleCollectionUpdate(target, propertyInfo, request);
+                }
+                else
+                {
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, propertyInfo.PropertyType);
+                    if (convertedValue.Success)
+                    {
+                        Debug.WriteLine($"[GrpcService:<<VIEWMODEL_NAME>>] Setting property '{finalPart}' via reflection to value: {convertedValue.Value}");
+                        propertyInfo.SetValue(target, convertedValue.Value);
+                        response.Success = true;
+                        if (!propertyPath.Equals(request.PropertyName, StringComparison.Ordinal) &&
+                            !typeof(INotifyPropertyChanged).IsAssignableFrom(propertyInfo.DeclaringType!))
+                        {
+                            var notification = new <<PROTO_NS>>.PropertyChangeNotification
+                            {
+                                PropertyName = request.PropertyName,
+                                PropertyPath = propertyPath,
+                                ChangeType = "nested",
+                                NewValue = request.NewValue
+                            };
+                            var sourceClientId = request.ClientId;
+                            foreach (var kvp in _subscriberChannels)
+                            {
+                                if (kvp.Key == sourceClientId) continue;
+                                _ = kvp.Value.Writer.WriteAsync(notification);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = convertedValue.ErrorMessage;
+                    }
                 }
             }
         }
@@ -321,37 +421,10 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
             response.Success = true;
             Debug.WriteLine($"[GrpcService:<<VIEWMODEL_NAME>>] Updated dictionary key '{convertedKey.Value}' to '{convertedValue.Value}'");
         }
-        // Handle list/array element replacement updates
-        else if (collection is System.Collections.IList list && request.ArrayIndex > -1)
-        {
-            if (request.ArrayIndex >= list.Count)
-            {
-                response.Success = false;
-                response.ErrorMessage = $"Array index {request.ArrayIndex} is out of bounds (count: {list.Count})";
-                return response;
-            }
-            
-            var elementType = propertyInfo.PropertyType.GetGenericArguments()[0];
-            var convertedValue = ConvertAnyToTargetType(request.NewValue, elementType);
-            
-            if (!convertedValue.Success)
-            {
-                response.Success = false;
-                response.ErrorMessage = convertedValue.ErrorMessage;
-                return response;
-            }
-            
-            // Store old value
-            response.OldValue = PackToAny(list[request.ArrayIndex]);
-            
-            list[request.ArrayIndex] = convertedValue.Value;
-            response.Success = true;
-            Debug.WriteLine($"[GrpcService:<<VIEWMODEL_NAME>>] Updated array index {request.ArrayIndex} to '{convertedValue.Value}'");
-        }
         else
         {
             response.Success = false;
-            response.ErrorMessage = "Unsupported collection operation or missing index/key";
+            response.ErrorMessage = "Unsupported collection operation or missing key";
         }
         
         return response;
@@ -410,7 +483,13 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
                 return (true, anyValue.Unpack<DoubleValue>().Value, "");
             if (anyValue.Is(BoolValue.Descriptor) && targetType == typeof(bool))
                 return (true, anyValue.Unpack<BoolValue>().Value, "");
-            
+
+            // Handle DateTime conversions
+            if (anyValue.Is(Timestamp.Descriptor) && targetType == typeof(DateTime))
+                return (true, anyValue.Unpack<Timestamp>().ToDateTime(), "");
+            if (anyValue.Is(Timestamp.Descriptor) && targetType == typeof(DateTime?))
+                return (true, (DateTime?)anyValue.Unpack<Timestamp>().ToDateTime(), "");
+
             // Handle additional numeric type conversions
             if (anyValue.Is(Int32Value.Descriptor) && targetType == typeof(short))
                 return (true, (short)anyValue.Unpack<Int32Value>().Value, "");
@@ -499,6 +578,88 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
             return (false, null, $"Conversion error: {ex.Message}");
         }
         return (false, null, $"Cannot convert '{stringValue}' to {targetType.Name}");
+    }
+
+    private void AttachNestedPropertyChangedHandlers(object obj, string prefix)
+    {
+        if (obj is not INotifyPropertyChanged inpc) return;
+        inpc.PropertyChanged += (s, e) =>
+        {
+            var path = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+            ViewModel_PropertyChanged(s, new PropertyChangedEventArgs(path));
+
+            var prop = s?.GetType().GetProperty(e.PropertyName);
+            var val = prop?.GetValue(s);
+            if (val is INotifyPropertyChanged child)
+            {
+                var childPrefix = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+                AttachNestedPropertyChangedHandlers(child, childPrefix);
+            }
+            else if (val is System.Collections.IEnumerable enumerable && val is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"{e.PropertyName}[{index}]" : prefix + $".{e.PropertyName}[{index}]";
+                    if (item != null) AttachNestedPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (val is INotifyCollectionChanged incc)
+                {
+                    var propName = e.PropertyName;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(prefix) ? $"{propName}[{start}]" : prefix + $".{propName}[{start}]";
+                                if (newItem != null) AttachNestedPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+            }
+        };
+
+        foreach (var p in obj.GetType().GetProperties())
+        {
+            var val = p.GetValue(obj);
+            if (val is INotifyPropertyChanged child)
+            {
+                var childPrefix = string.IsNullOrEmpty(prefix) ? p.Name : prefix + "." + p.Name;
+                AttachNestedPropertyChangedHandlers(child, childPrefix);
+            }
+            else if (val is System.Collections.IEnumerable enumerable && val is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"{p.Name}[{index}]" : prefix + $".{p.Name}[{index}]";
+                    if (item != null) AttachNestedPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (val is INotifyCollectionChanged incc)
+                {
+                    var propName = p.Name;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(prefix) ? $"{propName}[{start}]" : prefix + $".{propName}[{start}]";
+                                if (newItem != null) AttachNestedPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+            }
+        }
     }
 
     private async void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/demo/BlazorMonsterClicker/BlazorMonsterClicker/RemoteGenerated/GameViewModelRemoteClient.cs
+++ b/src/demo/BlazorMonsterClicker/BlazorMonsterClicker/RemoteGenerated/GameViewModelRemoteClient.cs
@@ -171,7 +171,6 @@ namespace MonsterClicker.ViewModels.RemoteClients
                 var request = new MonsterClicker.ViewModels.Protos.UpdatePropertyValueRequest
                 {
                     PropertyName = propertyName,
-                    ArrayIndex = -1,
                     NewValue = PackValueToAny(value)
                 };
 

--- a/src/demo/BlazorMonsterClicker/BlazorMonsterClicker/protos/GameViewModelService.proto
+++ b/src/demo/BlazorMonsterClicker/BlazorMonsterClicker/protos/GameViewModelService.proto
@@ -28,9 +28,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/src/demo/MonsterClicker/protos/GameViewModelService.proto
+++ b/src/demo/MonsterClicker/protos/GameViewModelService.proto
@@ -28,9 +28,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
+++ b/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
@@ -14,6 +14,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.ComponentModel;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Threading.Channels;
 using Channel = System.Threading.Channels.Channel;
@@ -51,8 +52,8 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
     {
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         _logger = logger;
-        if (_viewModel is INotifyPropertyChanged inpc) { 
-            inpc.PropertyChanged += ViewModel_PropertyChanged; 
+        if (_viewModel is INotifyPropertyChanged inpc) {
+            AttachNestedPropertyChangedHandlers(inpc, string.Empty);
         }
     }
 
@@ -255,7 +256,14 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
                             response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
                             return response;
                         }
-                        target = list[idx] ?? new();
+                        var nextTarget = list[idx];
+                        if (nextTarget == null)
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Null value encountered at index {idx} for '{propName}'";
+                            return response;
+                        }
+                        target = nextTarget;
                     }
                     else
                     {
@@ -284,47 +292,139 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
                 }
             }
 
-            var finalPropertyName = pathParts[pathParts.Length - 1];
-            var propertyInfo = target?.GetType().GetProperty(finalPropertyName);
-            if (propertyInfo == null)
+            var finalPart = pathParts[pathParts.Length - 1];
+            int finalBracket = finalPart.IndexOf('[');
+            if (finalBracket >= 0)
             {
-                response.Success = false;
-                response.ErrorMessage = $"Property '{finalPropertyName}' not found";
-                return response;
-            }
-
-            if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
-            {
-                response.Success = false;
-                response.ErrorMessage = $"Property '{finalPropertyName}' is read-only";
-                return response;
-            }
-
-            // Detect leaf element update inside a collection (Collection[index].Prop)
-            bool isLeafElementUpdate = propertyPath.Contains("]." + finalPropertyName, StringComparison.Ordinal);
-
-            // Store old value for undo/history
-            var oldValue = propertyInfo.GetValue(target);
-            if (oldValue != null) response.OldValue = PackToAny(oldValue);
-            
-            // Only treat as collection update when modifying the collection itself (not element property)
-            if (!isLeafElementUpdate && (!string.IsNullOrEmpty(request.CollectionKey) || (request.ArrayIndex > -1 && propertyPath.Equals(request.PropertyName, StringComparison.OrdinalIgnoreCase))))
-            {
-                response = HandleCollectionUpdate(target, propertyInfo, request);
-            }
-            else
-            {
-                var convertedValue = ConvertAnyToTargetType(request.NewValue, propertyInfo.PropertyType);
-                if (convertedValue.Success)
+                var propName = finalPart[..finalBracket];
+                var end = finalPart.IndexOf(']', finalBracket);
+                if (end < 0)
                 {
-                    Debug.WriteLine($"[GrpcService:GameViewModel] Setting property '{finalPropertyName}' via reflection to value: {convertedValue.Value}");
-                    propertyInfo.SetValue(target, convertedValue.Value);
+                    response.Success = false;
+                    response.ErrorMessage = $"Invalid path segment '{finalPart}' in '{propertyPath}'";
+                    return response;
+                }
+                var indexStr = finalPart[(finalBracket + 1)..end];
+                var propertyInfo = target?.GetType().GetProperty(propName);
+                if (propertyInfo == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{propName}' not found";
+                    return response;
+                }
+                var collection = propertyInfo.GetValue(target);
+                if (collection == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Collection property '{propName}' is null";
+                    return response;
+                }
+                if (collection is IList list && int.TryParse(indexStr, out int idx))
+                {
+                    if (idx < 0 || idx >= list.Count)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
+                        return response;
+                    }
+                    var elementType = propertyInfo.PropertyType.GetGenericArguments()[0];
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, elementType);
+                    if (!convertedValue.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = convertedValue.ErrorMessage;
+                        return response;
+                    }
+                    response.OldValue = PackToAny(list[idx]);
+                    list[idx] = convertedValue.Value;
                     response.Success = true;
+                    Debug.WriteLine($"[GrpcService:GameViewModel] Updated array index {idx} to '{convertedValue.Value}'");
+                }
+                else if (collection is IDictionary dict)
+                {
+                    var keyType = propertyInfo.PropertyType.GetGenericArguments()[0];
+                    var valueType = propertyInfo.PropertyType.GetGenericArguments()[1];
+                    var convertedKey = ConvertStringToTargetType(indexStr, keyType);
+                    if (!convertedKey.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Failed to convert key '{indexStr}': {convertedKey.ErrorMessage}";
+                        return response;
+                    }
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, valueType);
+                    if (!convertedValue.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Failed to convert value: {convertedValue.ErrorMessage}";
+                        return response;
+                    }
+                    if (convertedKey.Value != null && dict.Contains(convertedKey.Value)) response.OldValue = PackToAny(dict[convertedKey.Value]);
+                    dict[convertedKey.Value!] = convertedValue.Value;
+                    response.Success = true;
+                    Debug.WriteLine($"[GrpcService:GameViewModel] Updated dictionary key '{convertedKey.Value}' to '{convertedValue.Value}'");
                 }
                 else
                 {
                     response.Success = false;
-                    response.ErrorMessage = convertedValue.ErrorMessage;
+                    response.ErrorMessage = $"Property '{propName}' is not an indexable collection";
+                }
+            }
+            else
+            {
+                var propertyInfo = target?.GetType().GetProperty(finalPart);
+                if (propertyInfo == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{finalPart}' not found";
+                    return response;
+                }
+                if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{finalPart}' is read-only";
+                    return response;
+                }
+
+                bool isLeafElementUpdate = propertyPath.Contains("]." + finalPart, StringComparison.Ordinal);
+
+                var oldValue = propertyInfo.GetValue(target);
+                if (oldValue != null) response.OldValue = PackToAny(oldValue);
+
+                if (!isLeafElementUpdate && !string.IsNullOrEmpty(request.CollectionKey) && propertyPath.Equals(request.PropertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    response = HandleCollectionUpdate(target, propertyInfo, request);
+                }
+                else
+                {
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, propertyInfo.PropertyType);
+                    if (convertedValue.Success)
+                    {
+                        Debug.WriteLine($"[GrpcService:GameViewModel] Setting property '{finalPart}' via reflection to value: {convertedValue.Value}");
+                        propertyInfo.SetValue(target, convertedValue.Value);
+                        response.Success = true;
+                        if (!propertyPath.Equals(request.PropertyName, StringComparison.Ordinal) &&
+                            !typeof(INotifyPropertyChanged).IsAssignableFrom(propertyInfo.DeclaringType!))
+                        {
+                            var notification = new MonsterClicker.ViewModels.Protos.PropertyChangeNotification
+                            {
+                                PropertyName = request.PropertyName,
+                                PropertyPath = propertyPath,
+                                ChangeType = "nested",
+                                NewValue = request.NewValue
+                            };
+                            var sourceClientId = request.ClientId;
+                            foreach (var kvp in _subscriberChannels)
+                            {
+                                if (kvp.Key == sourceClientId) continue;
+                                _ = kvp.Value.Writer.WriteAsync(notification);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = convertedValue.ErrorMessage;
+                    }
                 }
             }
         }
@@ -379,37 +479,10 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
             response.Success = true;
             Debug.WriteLine($"[GrpcService:GameViewModel] Updated dictionary key '{convertedKey.Value}' to '{convertedValue.Value}'");
         }
-        // Handle list/array element replacement updates
-        else if (collection is System.Collections.IList list && request.ArrayIndex > -1)
-        {
-            if (request.ArrayIndex >= list.Count)
-            {
-                response.Success = false;
-                response.ErrorMessage = $"Array index {request.ArrayIndex} is out of bounds (count: {list.Count})";
-                return response;
-            }
-            
-            var elementType = propertyInfo.PropertyType.GetGenericArguments()[0];
-            var convertedValue = ConvertAnyToTargetType(request.NewValue, elementType);
-            
-            if (!convertedValue.Success)
-            {
-                response.Success = false;
-                response.ErrorMessage = convertedValue.ErrorMessage;
-                return response;
-            }
-            
-            // Store old value
-            response.OldValue = PackToAny(list[request.ArrayIndex]);
-            
-            list[request.ArrayIndex] = convertedValue.Value;
-            response.Success = true;
-            Debug.WriteLine($"[GrpcService:GameViewModel] Updated array index {request.ArrayIndex} to '{convertedValue.Value}'");
-        }
         else
         {
             response.Success = false;
-            response.ErrorMessage = "Unsupported collection operation or missing index/key";
+            response.ErrorMessage = "Unsupported collection operation or missing key";
         }
         
         return response;
@@ -468,7 +541,13 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
                 return (true, anyValue.Unpack<DoubleValue>().Value, "");
             if (anyValue.Is(BoolValue.Descriptor) && targetType == typeof(bool))
                 return (true, anyValue.Unpack<BoolValue>().Value, "");
-            
+
+            // Handle DateTime conversions
+            if (anyValue.Is(Timestamp.Descriptor) && targetType == typeof(DateTime))
+                return (true, anyValue.Unpack<Timestamp>().ToDateTime(), "");
+            if (anyValue.Is(Timestamp.Descriptor) && targetType == typeof(DateTime?))
+                return (true, (DateTime?)anyValue.Unpack<Timestamp>().ToDateTime(), "");
+
             // Handle additional numeric type conversions
             if (anyValue.Is(Int32Value.Descriptor) && targetType == typeof(short))
                 return (true, (short)anyValue.Unpack<Int32Value>().Value, "");
@@ -557,6 +636,88 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
             return (false, null, $"Conversion error: {ex.Message}");
         }
         return (false, null, $"Cannot convert '{stringValue}' to {targetType.Name}");
+    }
+
+    private void AttachNestedPropertyChangedHandlers(object obj, string prefix)
+    {
+        if (obj is not INotifyPropertyChanged inpc) return;
+        inpc.PropertyChanged += (s, e) =>
+        {
+            var path = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+            ViewModel_PropertyChanged(s, new PropertyChangedEventArgs(path));
+
+            var prop = s?.GetType().GetProperty(e.PropertyName);
+            var val = prop?.GetValue(s);
+            if (val is INotifyPropertyChanged child)
+            {
+                var childPrefix = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+                AttachNestedPropertyChangedHandlers(child, childPrefix);
+            }
+            else if (val is System.Collections.IEnumerable enumerable && val is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"{e.PropertyName}[{index}]" : prefix + $".{e.PropertyName}[{index}]";
+                    if (item != null) AttachNestedPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (val is INotifyCollectionChanged incc)
+                {
+                    var propName = e.PropertyName;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(prefix) ? $"{propName}[{start}]" : prefix + $".{propName}[{start}]";
+                                if (newItem != null) AttachNestedPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+            }
+        };
+
+        foreach (var p in obj.GetType().GetProperties())
+        {
+            var val = p.GetValue(obj);
+            if (val is INotifyPropertyChanged child)
+            {
+                var childPrefix = string.IsNullOrEmpty(prefix) ? p.Name : prefix + "." + p.Name;
+                AttachNestedPropertyChangedHandlers(child, childPrefix);
+            }
+            else if (val is System.Collections.IEnumerable enumerable && val is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"{p.Name}[{index}]" : prefix + $".{p.Name}[{index}]";
+                    if (item != null) AttachNestedPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (val is INotifyCollectionChanged incc)
+                {
+                    var propName = p.Name;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(prefix) ? $"{propName}[{start}]" : prefix + $".{propName}[{start}]";
+                                if (newItem != null) AttachNestedPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+            }
+        }
     }
 
     private async void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/test/GameViewModel/expected/GameViewModelRemoteClient.cs
+++ b/test/GameViewModel/expected/GameViewModelRemoteClient.cs
@@ -15,6 +15,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.ComponentModel;
+using System.Collections.Specialized;
 using Generated.ViewModels;
 #if WPF_DISPATCHER
 using System.Windows;
@@ -29,6 +31,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
         private bool _isInitialized = false;
         private bool _isDisposed = false;
         private readonly string _clientId = Guid.NewGuid().ToString();
+        private bool _suppressLocalUpdates = false;
 
         private string _connectionStatus = "Unknown";
         public string ConnectionStatus
@@ -158,39 +161,40 @@ namespace MonsterClicker.ViewModels.RemoteClients
         /// </summary>
         /// <param name="propertyName">The name of the property to update</param>
         /// <param name="value">The new value to set</param>
-        public async Task UpdatePropertyValueAsync(string propertyName, object? value)
+        public async Task UpdatePropertyValueAsync(string propertyPath, object? value)
         {
             if (!_isInitialized || _isDisposed)
             {
-                Debug.WriteLine($"[ClientProxy:GameViewModel] UpdatePropertyValueAsync for {propertyName} skipped - not initialized or disposed");
+                Debug.WriteLine($"[ClientProxy:GameViewModel] UpdatePropertyValueAsync for {propertyPath} skipped - not initialized or disposed");
                 return;
             }
 
             try
             {
-                Debug.WriteLine($"[ClientProxy:GameViewModel] Updating server property {propertyName} = {value}");
+                Debug.WriteLine($"[ClientProxy:GameViewModel] Updating server property {propertyPath} = {value}");
+                var topLevel = propertyPath.Split(new[] {'.','['}, 2)[0];
                 var request = new MonsterClicker.ViewModels.Protos.UpdatePropertyValueRequest
                 {
-                    PropertyName = propertyName,
-                    ArrayIndex = -1,
+                    PropertyName = topLevel,
+                    PropertyPath = propertyPath,
                     ClientId = _clientId,
                     NewValue = PackValueToAny(value)
                 };
 
                 var response = await _grpcClient.UpdatePropertyValueAsync(request, cancellationToken: _cts.Token);
-                Debug.WriteLine($"[ClientProxy:GameViewModel] Property {propertyName} updated successfully on server");
+                Debug.WriteLine($"[ClientProxy:GameViewModel] Property {propertyPath} updated successfully on server");
             }
             catch (RpcException ex)
             {
-                Debug.WriteLine($"[ClientProxy:GameViewModel] Error updating property {propertyName}: {ex.Status.StatusCode} - {ex.Status.Detail}");
+                Debug.WriteLine($"[ClientProxy:GameViewModel] Error updating property {propertyPath}: {ex.Status.StatusCode} - {ex.Status.Detail}");
             }
             catch (OperationCanceledException)
             {
-                Debug.WriteLine($"[ClientProxy:GameViewModel] Property update {propertyName} cancelled");
+                Debug.WriteLine($"[ClientProxy:GameViewModel] Property update {propertyPath} cancelled");
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[ClientProxy:GameViewModel] Unexpected error updating property {propertyName}: {ex.Message}");
+                Debug.WriteLine($"[ClientProxy:GameViewModel] Unexpected error updating property {propertyPath}: {ex.Message}");
             }
         }
 
@@ -219,6 +223,165 @@ namespace MonsterClicker.ViewModels.RemoteClients
                 System.Enum e => Any.Pack(new Int32Value { Value = Convert.ToInt32(e) }),
                 _ => Any.Pack(new StringValue { Value = value?.ToString() ?? "" })
             };
+        }
+
+        private static object? UnpackAny(Any value)
+        {
+            if (value.Is(StringValue.Descriptor)) return value.Unpack<StringValue>().Value;
+            if (value.Is(Int32Value.Descriptor)) return value.Unpack<Int32Value>().Value;
+            if (value.Is(Int64Value.Descriptor)) return value.Unpack<Int64Value>().Value;
+            if (value.Is(UInt32Value.Descriptor)) return value.Unpack<UInt32Value>().Value;
+            if (value.Is(UInt64Value.Descriptor)) return value.Unpack<UInt64Value>().Value;
+            if (value.Is(FloatValue.Descriptor)) return value.Unpack<FloatValue>().Value;
+            if (value.Is(DoubleValue.Descriptor)) return value.Unpack<DoubleValue>().Value;
+            if (value.Is(BoolValue.Descriptor)) return value.Unpack<BoolValue>().Value;
+            if (value.Is(Timestamp.Descriptor)) return value.Unpack<Timestamp>().ToDateTime();
+            if (value.Is(Google.Protobuf.WellKnownTypes.Duration.Descriptor)) return value.Unpack<Google.Protobuf.WellKnownTypes.Duration>().ToTimeSpan();
+            return null;
+        }
+
+        private static void SetValueByPath(object target, string path, object? newValue)
+        {
+            var segments = path.Split('.');
+            object? current = target;
+
+            for (int i = 0; i < segments.Length; i++)
+            {
+                var part = segments[i];
+                int bracket = part.IndexOf('[');
+                if (bracket >= 0)
+                {
+                    var propName = part[..bracket];
+                    var end = part.IndexOf(']', bracket);
+                    if (end < 0) return;
+                    var indexStr = part[(bracket + 1)..end];
+                    var prop = current?.GetType().GetProperty(propName);
+                    if (prop?.GetValue(current) is System.Collections.IList list && int.TryParse(indexStr, out int idx))
+                    {
+                        if (idx < 0 || idx >= list.Count) return;
+                        if (i == segments.Length - 1)
+                        {
+                            list[idx] = newValue;
+                            if (target is GameViewModelRemoteClient rc)
+                            {
+                                rc.AttachLocalPropertyChangedHandlers(list[idx], path);
+                            }
+                            return;
+                        }
+                        current = list[idx];
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    if (i == segments.Length - 1)
+                    {
+                        var prop = current?.GetType().GetProperty(part);
+                        prop?.SetValue(current, newValue);
+                        if (target is GameViewModelRemoteClient rc)
+                        {
+                            rc.AttachLocalPropertyChangedHandlers(newValue, path);
+                        }
+                        return;
+                    }
+                    else
+                    {
+                        var prop = current?.GetType().GetProperty(part);
+                        current = prop?.GetValue(current);
+                    }
+                }
+
+                if (current == null) return;
+            }
+        }
+
+        private void AttachLocalPropertyChangedHandlers(object? obj, string prefix)
+        {
+            if (obj == null) return;
+
+            if (obj is INotifyPropertyChanged inpc)
+            {
+                inpc.PropertyChanged += async (s, e) =>
+                {
+                    if (_suppressLocalUpdates) return;
+                    var prop = s?.GetType().GetProperty(e.PropertyName);
+                    if (prop == null) return;
+                    var value = prop.GetValue(s);
+                    var path = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+                    await UpdatePropertyValueAsync(path, value);
+
+                    if (value is INotifyPropertyChanged child)
+                    {
+                        AttachLocalPropertyChangedHandlers(child, path);
+                    }
+                    else if (value is System.Collections.IEnumerable enumVal && value is not string)
+                    {
+                        int idx = 0;
+                        foreach (var item in enumVal)
+                        {
+                            var childPrefix = string.IsNullOrEmpty(path) ? $"[{idx}]" : path + $"[{idx}]";
+                            AttachLocalPropertyChangedHandlers(item, childPrefix);
+                            idx++;
+                        }
+                        if (value is INotifyCollectionChanged incc)
+                        {
+                            var outerPath = path;
+                            incc.CollectionChanged += (s2, args) =>
+                            {
+                                if (args.NewItems != null)
+                                {
+                                    int start = args.NewStartingIndex;
+                                    foreach (var newItem in args.NewItems)
+                                    {
+                                        var childPrefix = string.IsNullOrEmpty(outerPath) ? $"[{start}]" : outerPath + $"[{start}]";
+                                        AttachLocalPropertyChangedHandlers(newItem, childPrefix);
+                                        start++;
+                                    }
+                                }
+                            };
+                        }
+                    }
+                };
+            }
+
+            if (obj is System.Collections.IEnumerable enumerable && obj is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"[{index}]" : prefix + $"[{index}]";
+                    AttachLocalPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (obj is INotifyCollectionChanged incc)
+                {
+                    var outerPrefix = prefix;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(outerPrefix) ? $"[{start}]" : outerPrefix + $"[{start}]";
+                                AttachLocalPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+                return;
+            }
+
+            foreach (var p in obj.GetType().GetProperties())
+            {
+                var val = p.GetValue(obj);
+                var childPrefix = string.IsNullOrEmpty(prefix) ? p.Name : prefix + "." + p.Name;
+                AttachLocalPropertyChangedHandlers(val, childPrefix);
+            }
         }
 
         private async Task StartPingLoopAsync()
@@ -279,6 +442,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
                 var state = await _grpcClient.GetStateAsync(new Empty(), cancellationToken: linkedCts.Token);
                 Debug.WriteLine("[GameViewModelRemoteClient] Initial state received.");
+                _suppressLocalUpdates = true;
                 this.MonsterName = state.MonsterName;
                 this.MonsterMaxHealth = state.MonsterMaxHealth;
                 this.MonsterCurrentHealth = state.MonsterCurrentHealth;
@@ -287,6 +451,8 @@ namespace MonsterClicker.ViewModels.RemoteClients
                 this.IsMonsterDefeated = state.IsMonsterDefeated;
                 this.CanUseSpecialAttack = state.CanUseSpecialAttack;
                 this.IsSpecialAttackOnCooldown = state.IsSpecialAttackOnCooldown;
+                _suppressLocalUpdates = false;
+                AttachLocalPropertyChangedHandlers(this, string.Empty);
                 _isInitialized = true;
                 Debug.WriteLine("[GameViewModelRemoteClient] Initialized successfully.");
                 StartListeningToPropertyChanges(_cts.Token);
@@ -358,8 +524,16 @@ namespace MonsterClicker.ViewModels.RemoteClients
                            try
                            {
                                Debug.WriteLine("[GameViewModelRemoteClient] Dispatcher: Attempting to update \"" + update.PropertyName + "\" (Update #" + updateCount + ").");
-                               switch (update.PropertyName)
+                               _suppressLocalUpdates = true;
+                               if (update.ChangeType == "nested")
                                {
+                                   var val = UnpackAny(update.NewValue);
+                                   SetValueByPath(this, update.PropertyPath, val);
+                               }
+                               else
+                               {
+                                   switch (update.PropertyName)
+                                   {
                                    case nameof(MonsterName):
                  if (update.NewValue!.Is(StringValue.Descriptor)) this.MonsterName = update.NewValue.Unpack<StringValue>().Value; break;
                                    case nameof(MonsterMaxHealth):
@@ -376,10 +550,12 @@ namespace MonsterClicker.ViewModels.RemoteClients
                     if (update.NewValue!.Is(BoolValue.Descriptor)) this.CanUseSpecialAttack = update.NewValue.Unpack<BoolValue>().Value; break;
                                    case nameof(IsSpecialAttackOnCooldown):
                     if (update.NewValue!.Is(BoolValue.Descriptor)) this.IsSpecialAttackOnCooldown = update.NewValue.Unpack<BoolValue>().Value; break;
-                                   default: Debug.WriteLine("[ClientProxy:GameViewModel] Unknown property in notification: \"" + update.PropertyName + "\""); break;
+                                       default: Debug.WriteLine("[ClientProxy:GameViewModel] Unknown property in notification: \"" + update.PropertyName + "\""); break;
+                                   }
                                }
                            }
                            catch (Exception exInAction) { Debug.WriteLine("[ClientProxy:GameViewModel] EXCEPTION INSIDE updateAction for \"" + update.PropertyName + "\": " + exInAction.ToString()); }
+                           finally { _suppressLocalUpdates = false; }
                         };
                         #if WPF_DISPATCHER
                         Application.Current?.Dispatcher.Invoke(updateAction);

--- a/test/GameViewModel/expected/GameViewModelRemoteClient.ts
+++ b/test/GameViewModel/expected/GameViewModelRemoteClient.ts
@@ -85,7 +85,6 @@ export class GameViewModelRemoteClient {
     async updatePropertyValue(propertyName: string, value: any): Promise<UpdatePropertyValueResponse> {
         const req = new UpdatePropertyValueRequest();
         req.setPropertyName(propertyName);
-        req.setArrayIndex(-1); // Default to -1 for non-array properties
         req.setNewValue(this.createAnyValue(value));
         const response = await this.grpcClient.updatePropertyValue(req);
         
@@ -127,7 +126,6 @@ export class GameViewModelRemoteClient {
         options?: {
             propertyPath?: string;
             collectionKey?: string;
-            arrayIndex?: number;
             operationType?: 'set' | 'add' | 'remove' | 'clear' | 'insert';
         }
     ): Promise<UpdatePropertyValueResponse> {
@@ -137,7 +135,6 @@ export class GameViewModelRemoteClient {
         
         if (options?.propertyPath) req.setPropertyPath(options.propertyPath);
         if (options?.collectionKey) req.setCollectionKey(options.collectionKey);
-        if (options?.arrayIndex !== undefined) req.setArrayIndex(options.arrayIndex);
         if (options?.operationType) req.setOperationType(options.operationType);
         
         const response = await this.grpcClient.updatePropertyValue(req);

--- a/test/GameViewModel/expected/GameViewModelService.proto
+++ b/test/GameViewModel/expected/GameViewModelService.proto
@@ -28,10 +28,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
-  string client_id = 7;             // Originating client identifier
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/test/PointerTestModel/RemoteGenerated/PointerViewModelGrpcServiceImpl.cs
+++ b/test/PointerTestModel/RemoteGenerated/PointerViewModelGrpcServiceImpl.cs
@@ -291,7 +291,14 @@ public partial class PointerViewModelGrpcServiceImpl : PointerViewModelService.P
                             response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
                             return response;
                         }
-                        target = list[idx] ?? new();
+                        var nextTarget = list[idx];
+                        if (nextTarget == null)
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Null value encountered at index {idx} for '{propName}'";
+                            return response;
+                        }
+                        target = nextTarget;
                     }
                     else
                     {

--- a/test/PointerTestModel/RemoteGenerated/tsProject/protos/PointerViewModelService.proto
+++ b/test/PointerTestModel/RemoteGenerated/tsProject/protos/PointerViewModelService.proto
@@ -34,9 +34,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/test/PointerTestModel/actual/PointerViewModelGrpcServiceImpl.cs
+++ b/test/PointerTestModel/actual/PointerViewModelGrpcServiceImpl.cs
@@ -291,7 +291,14 @@ public partial class PointerViewModelGrpcServiceImpl : PointerViewModelService.P
                             response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
                             return response;
                         }
-                        target = list[idx] ?? new();
+                        var nextTarget = list[idx];
+                        if (nextTarget == null)
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Null value encountered at index {idx} for '{propName}'";
+                            return response;
+                        }
+                        target = nextTarget;
                     }
                     else
                     {

--- a/test/PointerTestModel/expected/PointerViewModelGrpcServiceImpl.cs
+++ b/test/PointerTestModel/expected/PointerViewModelGrpcServiceImpl.cs
@@ -291,7 +291,14 @@ public partial class PointerViewModelGrpcServiceImpl : PointerViewModelService.P
                             response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
                             return response;
                         }
-                        target = list[idx] ?? new();
+                        var nextTarget = list[idx];
+                        if (nextTarget == null)
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Null value encountered at index {idx} for '{propName}'";
+                            return response;
+                        }
+                        target = nextTarget;
                     }
                     else
                     {

--- a/test/PointerTestModel/expected/PointerViewModelService.proto
+++ b/test/PointerTestModel/expected/PointerViewModelService.proto
@@ -34,9 +34,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/test/PointerTestModel/protos/PointerViewModelService.proto
+++ b/test/PointerTestModel/protos/PointerViewModelService.proto
@@ -34,9 +34,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/test/SampleViewModel/actual/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/actual/SampleViewModelGrpcServiceImpl.cs
@@ -14,6 +14,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.ComponentModel;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Threading.Channels;
 using Channel = System.Threading.Channels.Channel;
@@ -43,15 +44,16 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
     }
 
     private readonly SampleViewModel _viewModel;
-    private static readonly ConcurrentDictionary<IServerStreamWriter<SampleApp.ViewModels.Protos.PropertyChangeNotification>, Channel<SampleApp.ViewModels.Protos.PropertyChangeNotification>> _subscriberChannels = new ConcurrentDictionary<IServerStreamWriter<SampleApp.ViewModels.Protos.PropertyChangeNotification>, Channel<SampleApp.ViewModels.Protos.PropertyChangeNotification>>();
+    private static readonly ConcurrentDictionary<string, Channel<SampleApp.ViewModels.Protos.PropertyChangeNotification>> _subscriberChannels = new ConcurrentDictionary<string, Channel<SampleApp.ViewModels.Protos.PropertyChangeNotification>>();
+    private static readonly System.Threading.AsyncLocal<string?> _currentClientId = new();
     private readonly ILogger? _logger;
 
     public SampleViewModelGrpcServiceImpl(SampleViewModel viewModel, ILogger<SampleViewModelGrpcServiceImpl>? logger = null)
     {
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         _logger = logger;
-        if (_viewModel is INotifyPropertyChanged inpc) { 
-            inpc.PropertyChanged += ViewModel_PropertyChanged; 
+        if (_viewModel is INotifyPropertyChanged inpc) {
+            AttachNestedPropertyChangedHandlers(inpc, string.Empty);
         }
     }
 
@@ -78,9 +80,9 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
 
     public override async Task SubscribeToPropertyChanges(SampleApp.ViewModels.Protos.SubscribeRequest request, IServerStreamWriter<SampleApp.ViewModels.Protos.PropertyChangeNotification> responseStream, ServerCallContext context)
     {
-        var clientId = request.ClientId ?? "unknown";
+        var clientId = request.ClientId ?? Guid.NewGuid().ToString();
         var channel = Channel.CreateUnbounded<SampleApp.ViewModels.Protos.PropertyChangeNotification>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
-        _subscriberChannels.TryAdd(responseStream, channel);
+        _subscriberChannels[clientId] = channel;
         ClientCount = _subscriberChannels.Count;
         try
         {
@@ -95,7 +97,7 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
         }
         finally
         {
-            _subscriberChannels.TryRemove(responseStream, out _);
+            _subscriberChannels.TryRemove(clientId, out _);
             channel.Writer.TryComplete();
             ClientCount = _subscriberChannels.Count;
         }
@@ -103,8 +105,9 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
 
     public override Task<SampleApp.ViewModels.Protos.UpdatePropertyValueResponse> UpdatePropertyValue(SampleApp.ViewModels.Protos.UpdatePropertyValueRequest request, ServerCallContext context)
     {
+        _currentClientId.Value = request.ClientId;
         var response = new SampleApp.ViewModels.Protos.UpdatePropertyValueResponse();
-        
+
         try
         {
             // Execute property update directly - MVVM Toolkit handles threading automatically
@@ -116,7 +119,11 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             response.Success = false;
             response.ErrorMessage = ex.Message;
         }
-        
+        finally
+        {
+            _currentClientId.Value = null;
+        }
+
         Debug.WriteLine($"[GrpcService:SampleViewModel] UpdatePropertyValue result: Success={response.Success}, Error={response.ErrorMessage}");
         return Task.FromResult(response);
     }
@@ -207,7 +214,14 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                             response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
                             return response;
                         }
-                        target = list[idx] ?? new();
+                        var nextTarget = list[idx];
+                        if (nextTarget == null)
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Null value encountered at index {idx} for '{propName}'";
+                            return response;
+                        }
+                        target = nextTarget;
                     }
                     else
                     {
@@ -236,47 +250,139 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                 }
             }
 
-            var finalPropertyName = pathParts[pathParts.Length - 1];
-            var propertyInfo = target?.GetType().GetProperty(finalPropertyName);
-            if (propertyInfo == null)
+            var finalPart = pathParts[pathParts.Length - 1];
+            int finalBracket = finalPart.IndexOf('[');
+            if (finalBracket >= 0)
             {
-                response.Success = false;
-                response.ErrorMessage = $"Property '{finalPropertyName}' not found";
-                return response;
-            }
-
-            if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
-            {
-                response.Success = false;
-                response.ErrorMessage = $"Property '{finalPropertyName}' is read-only";
-                return response;
-            }
-
-            // Detect leaf element update inside a collection (Collection[index].Prop)
-            bool isLeafElementUpdate = propertyPath.Contains("]." + finalPropertyName, StringComparison.Ordinal);
-
-            // Store old value for undo/history
-            var oldValue = propertyInfo.GetValue(target);
-            if (oldValue != null) response.OldValue = PackToAny(oldValue);
-            
-            // Only treat as collection update when modifying the collection itself (not element property)
-            if (!isLeafElementUpdate && (!string.IsNullOrEmpty(request.CollectionKey) || (request.ArrayIndex > -1 && propertyPath.Equals(request.PropertyName, StringComparison.OrdinalIgnoreCase))))
-            {
-                response = HandleCollectionUpdate(target, propertyInfo, request);
-            }
-            else
-            {
-                var convertedValue = ConvertAnyToTargetType(request.NewValue, propertyInfo.PropertyType);
-                if (convertedValue.Success)
+                var propName = finalPart[..finalBracket];
+                var end = finalPart.IndexOf(']', finalBracket);
+                if (end < 0)
                 {
-                    Debug.WriteLine($"[GrpcService:SampleViewModel] Setting property '{finalPropertyName}' via reflection to value: {convertedValue.Value}");
-                    propertyInfo.SetValue(target, convertedValue.Value);
+                    response.Success = false;
+                    response.ErrorMessage = $"Invalid path segment '{finalPart}' in '{propertyPath}'";
+                    return response;
+                }
+                var indexStr = finalPart[(finalBracket + 1)..end];
+                var propertyInfo = target?.GetType().GetProperty(propName);
+                if (propertyInfo == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{propName}' not found";
+                    return response;
+                }
+                var collection = propertyInfo.GetValue(target);
+                if (collection == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Collection property '{propName}' is null";
+                    return response;
+                }
+                if (collection is IList list && int.TryParse(indexStr, out int idx))
+                {
+                    if (idx < 0 || idx >= list.Count)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
+                        return response;
+                    }
+                    var elementType = propertyInfo.PropertyType.GetGenericArguments()[0];
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, elementType);
+                    if (!convertedValue.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = convertedValue.ErrorMessage;
+                        return response;
+                    }
+                    response.OldValue = PackToAny(list[idx]);
+                    list[idx] = convertedValue.Value;
                     response.Success = true;
+                    Debug.WriteLine($"[GrpcService:SampleViewModel] Updated array index {idx} to '{convertedValue.Value}'");
+                }
+                else if (collection is IDictionary dict)
+                {
+                    var keyType = propertyInfo.PropertyType.GetGenericArguments()[0];
+                    var valueType = propertyInfo.PropertyType.GetGenericArguments()[1];
+                    var convertedKey = ConvertStringToTargetType(indexStr, keyType);
+                    if (!convertedKey.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Failed to convert key '{indexStr}': {convertedKey.ErrorMessage}";
+                        return response;
+                    }
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, valueType);
+                    if (!convertedValue.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Failed to convert value: {convertedValue.ErrorMessage}";
+                        return response;
+                    }
+                    if (convertedKey.Value != null && dict.Contains(convertedKey.Value)) response.OldValue = PackToAny(dict[convertedKey.Value]);
+                    dict[convertedKey.Value!] = convertedValue.Value;
+                    response.Success = true;
+                    Debug.WriteLine($"[GrpcService:SampleViewModel] Updated dictionary key '{convertedKey.Value}' to '{convertedValue.Value}'");
                 }
                 else
                 {
                     response.Success = false;
-                    response.ErrorMessage = convertedValue.ErrorMessage;
+                    response.ErrorMessage = $"Property '{propName}' is not an indexable collection";
+                }
+            }
+            else
+            {
+                var propertyInfo = target?.GetType().GetProperty(finalPart);
+                if (propertyInfo == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{finalPart}' not found";
+                    return response;
+                }
+                if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{finalPart}' is read-only";
+                    return response;
+                }
+
+                bool isLeafElementUpdate = propertyPath.Contains("]." + finalPart, StringComparison.Ordinal);
+
+                var oldValue = propertyInfo.GetValue(target);
+                if (oldValue != null) response.OldValue = PackToAny(oldValue);
+
+                if (!isLeafElementUpdate && !string.IsNullOrEmpty(request.CollectionKey) && propertyPath.Equals(request.PropertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    response = HandleCollectionUpdate(target, propertyInfo, request);
+                }
+                else
+                {
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, propertyInfo.PropertyType);
+                    if (convertedValue.Success)
+                    {
+                        Debug.WriteLine($"[GrpcService:SampleViewModel] Setting property '{finalPart}' via reflection to value: {convertedValue.Value}");
+                        propertyInfo.SetValue(target, convertedValue.Value);
+                        response.Success = true;
+                        if (!propertyPath.Equals(request.PropertyName, StringComparison.Ordinal) &&
+                            !typeof(INotifyPropertyChanged).IsAssignableFrom(propertyInfo.DeclaringType!))
+                        {
+                            var notification = new SampleApp.ViewModels.Protos.PropertyChangeNotification
+                            {
+                                PropertyName = request.PropertyName,
+                                PropertyPath = propertyPath,
+                                ChangeType = "nested",
+                                NewValue = request.NewValue
+                            };
+                            var sourceClientId = request.ClientId;
+                            foreach (var kvp in _subscriberChannels)
+                            {
+                                if (kvp.Key == sourceClientId) continue;
+                                _ = kvp.Value.Writer.WriteAsync(notification);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = convertedValue.ErrorMessage;
+                    }
                 }
             }
         }
@@ -331,37 +437,10 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             response.Success = true;
             Debug.WriteLine($"[GrpcService:SampleViewModel] Updated dictionary key '{convertedKey.Value}' to '{convertedValue.Value}'");
         }
-        // Handle list/array element replacement updates
-        else if (collection is System.Collections.IList list && request.ArrayIndex > -1)
-        {
-            if (request.ArrayIndex >= list.Count)
-            {
-                response.Success = false;
-                response.ErrorMessage = $"Array index {request.ArrayIndex} is out of bounds (count: {list.Count})";
-                return response;
-            }
-            
-            var elementType = propertyInfo.PropertyType.GetGenericArguments()[0];
-            var convertedValue = ConvertAnyToTargetType(request.NewValue, elementType);
-            
-            if (!convertedValue.Success)
-            {
-                response.Success = false;
-                response.ErrorMessage = convertedValue.ErrorMessage;
-                return response;
-            }
-            
-            // Store old value
-            response.OldValue = PackToAny(list[request.ArrayIndex]);
-            
-            list[request.ArrayIndex] = convertedValue.Value;
-            response.Success = true;
-            Debug.WriteLine($"[GrpcService:SampleViewModel] Updated array index {request.ArrayIndex} to '{convertedValue.Value}'");
-        }
         else
         {
             response.Success = false;
-            response.ErrorMessage = "Unsupported collection operation or missing index/key";
+            response.ErrorMessage = "Unsupported collection operation or missing key";
         }
         
         return response;
@@ -420,7 +499,13 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                 return (true, anyValue.Unpack<DoubleValue>().Value, "");
             if (anyValue.Is(BoolValue.Descriptor) && targetType == typeof(bool))
                 return (true, anyValue.Unpack<BoolValue>().Value, "");
-            
+
+            // Handle DateTime conversions
+            if (anyValue.Is(Timestamp.Descriptor) && targetType == typeof(DateTime))
+                return (true, anyValue.Unpack<Timestamp>().ToDateTime(), "");
+            if (anyValue.Is(Timestamp.Descriptor) && targetType == typeof(DateTime?))
+                return (true, (DateTime?)anyValue.Unpack<Timestamp>().ToDateTime(), "");
+
             // Handle additional numeric type conversions
             if (anyValue.Is(Int32Value.Descriptor) && targetType == typeof(short))
                 return (true, (short)anyValue.Unpack<Int32Value>().Value, "");
@@ -511,6 +596,88 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
         return (false, null, $"Cannot convert '{stringValue}' to {targetType.Name}");
     }
 
+    private void AttachNestedPropertyChangedHandlers(object obj, string prefix)
+    {
+        if (obj is not INotifyPropertyChanged inpc) return;
+        inpc.PropertyChanged += (s, e) =>
+        {
+            var path = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+            ViewModel_PropertyChanged(s, new PropertyChangedEventArgs(path));
+
+            var prop = s?.GetType().GetProperty(e.PropertyName);
+            var val = prop?.GetValue(s);
+            if (val is INotifyPropertyChanged child)
+            {
+                var childPrefix = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+                AttachNestedPropertyChangedHandlers(child, childPrefix);
+            }
+            else if (val is System.Collections.IEnumerable enumerable && val is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"{e.PropertyName}[{index}]" : prefix + $".{e.PropertyName}[{index}]";
+                    if (item != null) AttachNestedPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (val is INotifyCollectionChanged incc)
+                {
+                    var propName = e.PropertyName;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(prefix) ? $"{propName}[{start}]" : prefix + $".{propName}[{start}]";
+                                if (newItem != null) AttachNestedPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+            }
+        };
+
+        foreach (var p in obj.GetType().GetProperties())
+        {
+            var val = p.GetValue(obj);
+            if (val is INotifyPropertyChanged child)
+            {
+                var childPrefix = string.IsNullOrEmpty(prefix) ? p.Name : prefix + "." + p.Name;
+                AttachNestedPropertyChangedHandlers(child, childPrefix);
+            }
+            else if (val is System.Collections.IEnumerable enumerable && val is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"{p.Name}[{index}]" : prefix + $".{p.Name}[{index}]";
+                    if (item != null) AttachNestedPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (val is INotifyCollectionChanged incc)
+                {
+                    var propName = p.Name;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(prefix) ? $"{propName}[{start}]" : prefix + $".{propName}[{start}]";
+                                if (newItem != null) AttachNestedPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+            }
+        }
+    }
+
     private async void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (string.IsNullOrEmpty(e.PropertyName)) return;
@@ -528,11 +695,14 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
         };
         notification.NewValue = PackToAny(newValue);
 
+        var sourceClientId = _currentClientId.Value;
         // Send notifications to unbounded channels - use fire-and-forget Task.Run to avoid blocking the UI thread
         _ = Task.Run(async () =>
         {
-            foreach (var channelWriter in _subscriberChannels.Values.Select(c => c.Writer))
+            foreach (var kvp in _subscriberChannels)
             {
+                if (kvp.Key == sourceClientId) continue;
+                var channelWriter = kvp.Value.Writer;
                 try {
                     await channelWriter.WriteAsync(notification);
                 }

--- a/test/SampleViewModel/actual2/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/actual2/SampleViewModelGrpcServiceImpl.cs
@@ -14,6 +14,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.ComponentModel;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Threading.Channels;
 using Channel = System.Threading.Channels.Channel;
@@ -51,8 +52,8 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
     {
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         _logger = logger;
-        if (_viewModel is INotifyPropertyChanged inpc) { 
-            inpc.PropertyChanged += ViewModel_PropertyChanged; 
+        if (_viewModel is INotifyPropertyChanged inpc) {
+            AttachNestedPropertyChangedHandlers(inpc, string.Empty);
         }
     }
 
@@ -213,7 +214,14 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                             response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
                             return response;
                         }
-                        target = list[idx] ?? new();
+                        var nextTarget = list[idx];
+                        if (nextTarget == null)
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Null value encountered at index {idx} for '{propName}'";
+                            return response;
+                        }
+                        target = nextTarget;
                     }
                     else
                     {
@@ -242,47 +250,139 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                 }
             }
 
-            var finalPropertyName = pathParts[pathParts.Length - 1];
-            var propertyInfo = target?.GetType().GetProperty(finalPropertyName);
-            if (propertyInfo == null)
+            var finalPart = pathParts[pathParts.Length - 1];
+            int finalBracket = finalPart.IndexOf('[');
+            if (finalBracket >= 0)
             {
-                response.Success = false;
-                response.ErrorMessage = $"Property '{finalPropertyName}' not found";
-                return response;
-            }
-
-            if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
-            {
-                response.Success = false;
-                response.ErrorMessage = $"Property '{finalPropertyName}' is read-only";
-                return response;
-            }
-
-            // Detect leaf element update inside a collection (Collection[index].Prop)
-            bool isLeafElementUpdate = propertyPath.Contains("]." + finalPropertyName, StringComparison.Ordinal);
-
-            // Store old value for undo/history
-            var oldValue = propertyInfo.GetValue(target);
-            if (oldValue != null) response.OldValue = PackToAny(oldValue);
-            
-            // Only treat as collection update when modifying the collection itself (not element property)
-            if (!isLeafElementUpdate && (!string.IsNullOrEmpty(request.CollectionKey) || (request.ArrayIndex > -1 && propertyPath.Equals(request.PropertyName, StringComparison.OrdinalIgnoreCase))))
-            {
-                response = HandleCollectionUpdate(target, propertyInfo, request);
-            }
-            else
-            {
-                var convertedValue = ConvertAnyToTargetType(request.NewValue, propertyInfo.PropertyType);
-                if (convertedValue.Success)
+                var propName = finalPart[..finalBracket];
+                var end = finalPart.IndexOf(']', finalBracket);
+                if (end < 0)
                 {
-                    Debug.WriteLine($"[GrpcService:SampleViewModel] Setting property '{finalPropertyName}' via reflection to value: {convertedValue.Value}");
-                    propertyInfo.SetValue(target, convertedValue.Value);
+                    response.Success = false;
+                    response.ErrorMessage = $"Invalid path segment '{finalPart}' in '{propertyPath}'";
+                    return response;
+                }
+                var indexStr = finalPart[(finalBracket + 1)..end];
+                var propertyInfo = target?.GetType().GetProperty(propName);
+                if (propertyInfo == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{propName}' not found";
+                    return response;
+                }
+                var collection = propertyInfo.GetValue(target);
+                if (collection == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Collection property '{propName}' is null";
+                    return response;
+                }
+                if (collection is IList list && int.TryParse(indexStr, out int idx))
+                {
+                    if (idx < 0 || idx >= list.Count)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
+                        return response;
+                    }
+                    var elementType = propertyInfo.PropertyType.GetGenericArguments()[0];
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, elementType);
+                    if (!convertedValue.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = convertedValue.ErrorMessage;
+                        return response;
+                    }
+                    response.OldValue = PackToAny(list[idx]);
+                    list[idx] = convertedValue.Value;
                     response.Success = true;
+                    Debug.WriteLine($"[GrpcService:SampleViewModel] Updated array index {idx} to '{convertedValue.Value}'");
+                }
+                else if (collection is IDictionary dict)
+                {
+                    var keyType = propertyInfo.PropertyType.GetGenericArguments()[0];
+                    var valueType = propertyInfo.PropertyType.GetGenericArguments()[1];
+                    var convertedKey = ConvertStringToTargetType(indexStr, keyType);
+                    if (!convertedKey.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Failed to convert key '{indexStr}': {convertedKey.ErrorMessage}";
+                        return response;
+                    }
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, valueType);
+                    if (!convertedValue.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Failed to convert value: {convertedValue.ErrorMessage}";
+                        return response;
+                    }
+                    if (convertedKey.Value != null && dict.Contains(convertedKey.Value)) response.OldValue = PackToAny(dict[convertedKey.Value]);
+                    dict[convertedKey.Value!] = convertedValue.Value;
+                    response.Success = true;
+                    Debug.WriteLine($"[GrpcService:SampleViewModel] Updated dictionary key '{convertedKey.Value}' to '{convertedValue.Value}'");
                 }
                 else
                 {
                     response.Success = false;
-                    response.ErrorMessage = convertedValue.ErrorMessage;
+                    response.ErrorMessage = $"Property '{propName}' is not an indexable collection";
+                }
+            }
+            else
+            {
+                var propertyInfo = target?.GetType().GetProperty(finalPart);
+                if (propertyInfo == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{finalPart}' not found";
+                    return response;
+                }
+                if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{finalPart}' is read-only";
+                    return response;
+                }
+
+                bool isLeafElementUpdate = propertyPath.Contains("]." + finalPart, StringComparison.Ordinal);
+
+                var oldValue = propertyInfo.GetValue(target);
+                if (oldValue != null) response.OldValue = PackToAny(oldValue);
+
+                if (!isLeafElementUpdate && !string.IsNullOrEmpty(request.CollectionKey) && propertyPath.Equals(request.PropertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    response = HandleCollectionUpdate(target, propertyInfo, request);
+                }
+                else
+                {
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, propertyInfo.PropertyType);
+                    if (convertedValue.Success)
+                    {
+                        Debug.WriteLine($"[GrpcService:SampleViewModel] Setting property '{finalPart}' via reflection to value: {convertedValue.Value}");
+                        propertyInfo.SetValue(target, convertedValue.Value);
+                        response.Success = true;
+                        if (!propertyPath.Equals(request.PropertyName, StringComparison.Ordinal) &&
+                            !typeof(INotifyPropertyChanged).IsAssignableFrom(propertyInfo.DeclaringType!))
+                        {
+                            var notification = new SampleApp.ViewModels.Protos.PropertyChangeNotification
+                            {
+                                PropertyName = request.PropertyName,
+                                PropertyPath = propertyPath,
+                                ChangeType = "nested",
+                                NewValue = request.NewValue
+                            };
+                            var sourceClientId = request.ClientId;
+                            foreach (var kvp in _subscriberChannels)
+                            {
+                                if (kvp.Key == sourceClientId) continue;
+                                _ = kvp.Value.Writer.WriteAsync(notification);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = convertedValue.ErrorMessage;
+                    }
                 }
             }
         }
@@ -337,37 +437,10 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             response.Success = true;
             Debug.WriteLine($"[GrpcService:SampleViewModel] Updated dictionary key '{convertedKey.Value}' to '{convertedValue.Value}'");
         }
-        // Handle list/array element replacement updates
-        else if (collection is System.Collections.IList list && request.ArrayIndex > -1)
-        {
-            if (request.ArrayIndex >= list.Count)
-            {
-                response.Success = false;
-                response.ErrorMessage = $"Array index {request.ArrayIndex} is out of bounds (count: {list.Count})";
-                return response;
-            }
-            
-            var elementType = propertyInfo.PropertyType.GetGenericArguments()[0];
-            var convertedValue = ConvertAnyToTargetType(request.NewValue, elementType);
-            
-            if (!convertedValue.Success)
-            {
-                response.Success = false;
-                response.ErrorMessage = convertedValue.ErrorMessage;
-                return response;
-            }
-            
-            // Store old value
-            response.OldValue = PackToAny(list[request.ArrayIndex]);
-            
-            list[request.ArrayIndex] = convertedValue.Value;
-            response.Success = true;
-            Debug.WriteLine($"[GrpcService:SampleViewModel] Updated array index {request.ArrayIndex} to '{convertedValue.Value}'");
-        }
         else
         {
             response.Success = false;
-            response.ErrorMessage = "Unsupported collection operation or missing index/key";
+            response.ErrorMessage = "Unsupported collection operation or missing key";
         }
         
         return response;
@@ -426,7 +499,13 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                 return (true, anyValue.Unpack<DoubleValue>().Value, "");
             if (anyValue.Is(BoolValue.Descriptor) && targetType == typeof(bool))
                 return (true, anyValue.Unpack<BoolValue>().Value, "");
-            
+
+            // Handle DateTime conversions
+            if (anyValue.Is(Timestamp.Descriptor) && targetType == typeof(DateTime))
+                return (true, anyValue.Unpack<Timestamp>().ToDateTime(), "");
+            if (anyValue.Is(Timestamp.Descriptor) && targetType == typeof(DateTime?))
+                return (true, (DateTime?)anyValue.Unpack<Timestamp>().ToDateTime(), "");
+
             // Handle additional numeric type conversions
             if (anyValue.Is(Int32Value.Descriptor) && targetType == typeof(short))
                 return (true, (short)anyValue.Unpack<Int32Value>().Value, "");
@@ -515,6 +594,88 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             return (false, null, $"Conversion error: {ex.Message}");
         }
         return (false, null, $"Cannot convert '{stringValue}' to {targetType.Name}");
+    }
+
+    private void AttachNestedPropertyChangedHandlers(object obj, string prefix)
+    {
+        if (obj is not INotifyPropertyChanged inpc) return;
+        inpc.PropertyChanged += (s, e) =>
+        {
+            var path = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+            ViewModel_PropertyChanged(s, new PropertyChangedEventArgs(path));
+
+            var prop = s?.GetType().GetProperty(e.PropertyName);
+            var val = prop?.GetValue(s);
+            if (val is INotifyPropertyChanged child)
+            {
+                var childPrefix = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+                AttachNestedPropertyChangedHandlers(child, childPrefix);
+            }
+            else if (val is System.Collections.IEnumerable enumerable && val is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"{e.PropertyName}[{index}]" : prefix + $".{e.PropertyName}[{index}]";
+                    if (item != null) AttachNestedPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (val is INotifyCollectionChanged incc)
+                {
+                    var propName = e.PropertyName;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(prefix) ? $"{propName}[{start}]" : prefix + $".{propName}[{start}]";
+                                if (newItem != null) AttachNestedPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+            }
+        };
+
+        foreach (var p in obj.GetType().GetProperties())
+        {
+            var val = p.GetValue(obj);
+            if (val is INotifyPropertyChanged child)
+            {
+                var childPrefix = string.IsNullOrEmpty(prefix) ? p.Name : prefix + "." + p.Name;
+                AttachNestedPropertyChangedHandlers(child, childPrefix);
+            }
+            else if (val is System.Collections.IEnumerable enumerable && val is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"{p.Name}[{index}]" : prefix + $".{p.Name}[{index}]";
+                    if (item != null) AttachNestedPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (val is INotifyCollectionChanged incc)
+                {
+                    var propName = p.Name;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(prefix) ? $"{propName}[{start}]" : prefix + $".{propName}[{start}]";
+                                if (newItem != null) AttachNestedPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+            }
+        }
     }
 
     private async void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/test/SampleViewModel/actual2/SampleViewModelRemoteClient.cs
+++ b/test/SampleViewModel/actual2/SampleViewModelRemoteClient.cs
@@ -15,6 +15,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.ComponentModel;
+using System.Collections.Specialized;
 using Generated.ViewModels;
 #if WPF_DISPATCHER
 using System.Windows;
@@ -29,6 +31,7 @@ namespace SampleApp.ViewModels.RemoteClients
         private bool _isInitialized = false;
         private bool _isDisposed = false;
         private readonly string _clientId = Guid.NewGuid().ToString();
+        private bool _suppressLocalUpdates = false;
 
         private string _connectionStatus = "Unknown";
         public string ConnectionStatus
@@ -80,39 +83,40 @@ namespace SampleApp.ViewModels.RemoteClients
         /// </summary>
         /// <param name="propertyName">The name of the property to update</param>
         /// <param name="value">The new value to set</param>
-        public async Task UpdatePropertyValueAsync(string propertyName, object? value)
+        public async Task UpdatePropertyValueAsync(string propertyPath, object? value)
         {
             if (!_isInitialized || _isDisposed)
             {
-                Debug.WriteLine($"[ClientProxy:SampleViewModel] UpdatePropertyValueAsync for {propertyName} skipped - not initialized or disposed");
+                Debug.WriteLine($"[ClientProxy:SampleViewModel] UpdatePropertyValueAsync for {propertyPath} skipped - not initialized or disposed");
                 return;
             }
 
             try
             {
-                Debug.WriteLine($"[ClientProxy:SampleViewModel] Updating server property {propertyName} = {value}");
+                Debug.WriteLine($"[ClientProxy:SampleViewModel] Updating server property {propertyPath} = {value}");
+                var topLevel = propertyPath.Split(new[] {'.','['}, 2)[0];
                 var request = new SampleApp.ViewModels.Protos.UpdatePropertyValueRequest
                 {
-                    PropertyName = propertyName,
-                    ArrayIndex = -1,
+                    PropertyName = topLevel,
+                    PropertyPath = propertyPath,
                     ClientId = _clientId,
                     NewValue = PackValueToAny(value)
                 };
 
                 var response = await _grpcClient.UpdatePropertyValueAsync(request, cancellationToken: _cts.Token);
-                Debug.WriteLine($"[ClientProxy:SampleViewModel] Property {propertyName} updated successfully on server");
+                Debug.WriteLine($"[ClientProxy:SampleViewModel] Property {propertyPath} updated successfully on server");
             }
             catch (RpcException ex)
             {
-                Debug.WriteLine($"[ClientProxy:SampleViewModel] Error updating property {propertyName}: {ex.Status.StatusCode} - {ex.Status.Detail}");
+                Debug.WriteLine($"[ClientProxy:SampleViewModel] Error updating property {propertyPath}: {ex.Status.StatusCode} - {ex.Status.Detail}");
             }
             catch (OperationCanceledException)
             {
-                Debug.WriteLine($"[ClientProxy:SampleViewModel] Property update {propertyName} cancelled");
+                Debug.WriteLine($"[ClientProxy:SampleViewModel] Property update {propertyPath} cancelled");
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[ClientProxy:SampleViewModel] Unexpected error updating property {propertyName}: {ex.Message}");
+                Debug.WriteLine($"[ClientProxy:SampleViewModel] Unexpected error updating property {propertyPath}: {ex.Message}");
             }
         }
 
@@ -141,6 +145,165 @@ namespace SampleApp.ViewModels.RemoteClients
                 System.Enum e => Any.Pack(new Int32Value { Value = Convert.ToInt32(e) }),
                 _ => Any.Pack(new StringValue { Value = value?.ToString() ?? "" })
             };
+        }
+
+        private static object? UnpackAny(Any value)
+        {
+            if (value.Is(StringValue.Descriptor)) return value.Unpack<StringValue>().Value;
+            if (value.Is(Int32Value.Descriptor)) return value.Unpack<Int32Value>().Value;
+            if (value.Is(Int64Value.Descriptor)) return value.Unpack<Int64Value>().Value;
+            if (value.Is(UInt32Value.Descriptor)) return value.Unpack<UInt32Value>().Value;
+            if (value.Is(UInt64Value.Descriptor)) return value.Unpack<UInt64Value>().Value;
+            if (value.Is(FloatValue.Descriptor)) return value.Unpack<FloatValue>().Value;
+            if (value.Is(DoubleValue.Descriptor)) return value.Unpack<DoubleValue>().Value;
+            if (value.Is(BoolValue.Descriptor)) return value.Unpack<BoolValue>().Value;
+            if (value.Is(Timestamp.Descriptor)) return value.Unpack<Timestamp>().ToDateTime();
+            if (value.Is(Google.Protobuf.WellKnownTypes.Duration.Descriptor)) return value.Unpack<Google.Protobuf.WellKnownTypes.Duration>().ToTimeSpan();
+            return null;
+        }
+
+        private static void SetValueByPath(object target, string path, object? newValue)
+        {
+            var segments = path.Split('.');
+            object? current = target;
+
+            for (int i = 0; i < segments.Length; i++)
+            {
+                var part = segments[i];
+                int bracket = part.IndexOf('[');
+                if (bracket >= 0)
+                {
+                    var propName = part[..bracket];
+                    var end = part.IndexOf(']', bracket);
+                    if (end < 0) return;
+                    var indexStr = part[(bracket + 1)..end];
+                    var prop = current?.GetType().GetProperty(propName);
+                    if (prop?.GetValue(current) is System.Collections.IList list && int.TryParse(indexStr, out int idx))
+                    {
+                        if (idx < 0 || idx >= list.Count) return;
+                        if (i == segments.Length - 1)
+                        {
+                            list[idx] = newValue;
+                            if (target is SampleViewModelRemoteClient rc)
+                            {
+                                rc.AttachLocalPropertyChangedHandlers(list[idx], path);
+                            }
+                            return;
+                        }
+                        current = list[idx];
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    if (i == segments.Length - 1)
+                    {
+                        var prop = current?.GetType().GetProperty(part);
+                        prop?.SetValue(current, newValue);
+                        if (target is SampleViewModelRemoteClient rc)
+                        {
+                            rc.AttachLocalPropertyChangedHandlers(newValue, path);
+                        }
+                        return;
+                    }
+                    else
+                    {
+                        var prop = current?.GetType().GetProperty(part);
+                        current = prop?.GetValue(current);
+                    }
+                }
+
+                if (current == null) return;
+            }
+        }
+
+        private void AttachLocalPropertyChangedHandlers(object? obj, string prefix)
+        {
+            if (obj == null) return;
+
+            if (obj is INotifyPropertyChanged inpc)
+            {
+                inpc.PropertyChanged += async (s, e) =>
+                {
+                    if (_suppressLocalUpdates) return;
+                    var prop = s?.GetType().GetProperty(e.PropertyName);
+                    if (prop == null) return;
+                    var value = prop.GetValue(s);
+                    var path = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+                    await UpdatePropertyValueAsync(path, value);
+
+                    if (value is INotifyPropertyChanged child)
+                    {
+                        AttachLocalPropertyChangedHandlers(child, path);
+                    }
+                    else if (value is System.Collections.IEnumerable enumVal && value is not string)
+                    {
+                        int idx = 0;
+                        foreach (var item in enumVal)
+                        {
+                            var childPrefix = string.IsNullOrEmpty(path) ? $"[{idx}]" : path + $"[{idx}]";
+                            AttachLocalPropertyChangedHandlers(item, childPrefix);
+                            idx++;
+                        }
+                        if (value is INotifyCollectionChanged incc)
+                        {
+                            var outerPath = path;
+                            incc.CollectionChanged += (s2, args) =>
+                            {
+                                if (args.NewItems != null)
+                                {
+                                    int start = args.NewStartingIndex;
+                                    foreach (var newItem in args.NewItems)
+                                    {
+                                        var childPrefix = string.IsNullOrEmpty(outerPath) ? $"[{start}]" : outerPath + $"[{start}]";
+                                        AttachLocalPropertyChangedHandlers(newItem, childPrefix);
+                                        start++;
+                                    }
+                                }
+                            };
+                        }
+                    }
+                };
+            }
+
+            if (obj is System.Collections.IEnumerable enumerable && obj is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"[{index}]" : prefix + $"[{index}]";
+                    AttachLocalPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (obj is INotifyCollectionChanged incc)
+                {
+                    var outerPrefix = prefix;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(outerPrefix) ? $"[{start}]" : outerPrefix + $"[{start}]";
+                                AttachLocalPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+                return;
+            }
+
+            foreach (var p in obj.GetType().GetProperties())
+            {
+                var val = p.GetValue(obj);
+                var childPrefix = string.IsNullOrEmpty(prefix) ? p.Name : prefix + "." + p.Name;
+                AttachLocalPropertyChangedHandlers(val, childPrefix);
+            }
         }
 
         private async Task StartPingLoopAsync()
@@ -195,8 +358,11 @@ namespace SampleApp.ViewModels.RemoteClients
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
                 var state = await _grpcClient.GetStateAsync(new Empty(), cancellationToken: linkedCts.Token);
                 Debug.WriteLine("[SampleViewModelRemoteClient] Initial state received.");
+                _suppressLocalUpdates = true;
                 this.Name = state.Name;
                 this.Count = state.Count;
+                _suppressLocalUpdates = false;
+                AttachLocalPropertyChangedHandlers(this, string.Empty);
                 _isInitialized = true;
                 Debug.WriteLine("[SampleViewModelRemoteClient] Initialized successfully.");
                 StartListeningToPropertyChanges(_cts.Token);
@@ -268,16 +434,26 @@ namespace SampleApp.ViewModels.RemoteClients
                            try
                            {
                                Debug.WriteLine("[SampleViewModelRemoteClient] Dispatcher: Attempting to update \"" + update.PropertyName + "\" (Update #" + updateCount + ").");
-                               switch (update.PropertyName)
+                               _suppressLocalUpdates = true;
+                               if (update.ChangeType == "nested")
                                {
+                                   var val = UnpackAny(update.NewValue);
+                                   SetValueByPath(this, update.PropertyPath, val);
+                               }
+                               else
+                               {
+                                   switch (update.PropertyName)
+                                   {
                                    case nameof(Name):
                  if (update.NewValue!.Is(StringValue.Descriptor)) this.Name = update.NewValue.Unpack<StringValue>().Value; break;
                                    case nameof(Count):
                      if (update.NewValue!.Is(Int32Value.Descriptor)) this.Count = (int)update.NewValue.Unpack<Int32Value>().Value; break;
-                                   default: Debug.WriteLine("[ClientProxy:SampleViewModel] Unknown property in notification: \"" + update.PropertyName + "\""); break;
+                                       default: Debug.WriteLine("[ClientProxy:SampleViewModel] Unknown property in notification: \"" + update.PropertyName + "\""); break;
+                                   }
                                }
                            }
                            catch (Exception exInAction) { Debug.WriteLine("[ClientProxy:SampleViewModel] EXCEPTION INSIDE updateAction for \"" + update.PropertyName + "\": " + exInAction.ToString()); }
+                           finally { _suppressLocalUpdates = false; }
                         };
                         #if WPF_DISPATCHER
                         Application.Current?.Dispatcher.Invoke(updateAction);

--- a/test/SampleViewModel/actual2/SampleViewModelRemoteClient.ts
+++ b/test/SampleViewModel/actual2/SampleViewModelRemoteClient.ts
@@ -67,7 +67,6 @@ export class SampleViewModelRemoteClient {
     async updatePropertyValue(propertyName: string, value: any): Promise<UpdatePropertyValueResponse> {
         const req = new UpdatePropertyValueRequest();
         req.setPropertyName(propertyName);
-        req.setArrayIndex(-1); // Default to -1 for non-array properties
         req.setNewValue(this.createAnyValue(value));
         const response = await this.grpcClient.updatePropertyValue(req);
         
@@ -109,7 +108,6 @@ export class SampleViewModelRemoteClient {
         options?: {
             propertyPath?: string;
             collectionKey?: string;
-            arrayIndex?: number;
             operationType?: 'set' | 'add' | 'remove' | 'clear' | 'insert';
         }
     ): Promise<UpdatePropertyValueResponse> {
@@ -119,7 +117,6 @@ export class SampleViewModelRemoteClient {
         
         if (options?.propertyPath) req.setPropertyPath(options.propertyPath);
         if (options?.collectionKey) req.setCollectionKey(options.collectionKey);
-        if (options?.arrayIndex !== undefined) req.setArrayIndex(options.arrayIndex);
         if (options?.operationType) req.setOperationType(options.operationType);
         
         const response = await this.grpcClient.updatePropertyValue(req);

--- a/test/SampleViewModel/actual2/SampleViewModelService.proto
+++ b/test/SampleViewModel/actual2/SampleViewModelService.proto
@@ -22,10 +22,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
-  string client_id = 7;             // Originating client identifier
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
@@ -14,6 +14,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.ComponentModel;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Threading.Channels;
 using Channel = System.Threading.Channels.Channel;
@@ -51,8 +52,8 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
     {
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         _logger = logger;
-        if (_viewModel is INotifyPropertyChanged inpc) { 
-            inpc.PropertyChanged += ViewModel_PropertyChanged; 
+        if (_viewModel is INotifyPropertyChanged inpc) {
+            AttachNestedPropertyChangedHandlers(inpc, string.Empty);
         }
     }
 
@@ -213,7 +214,14 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                             response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
                             return response;
                         }
-                        target = list[idx] ?? new();
+                        var nextTarget = list[idx];
+                        if (nextTarget == null)
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Null value encountered at index {idx} for '{propName}'";
+                            return response;
+                        }
+                        target = nextTarget;
                     }
                     else
                     {
@@ -242,47 +250,139 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                 }
             }
 
-            var finalPropertyName = pathParts[pathParts.Length - 1];
-            var propertyInfo = target?.GetType().GetProperty(finalPropertyName);
-            if (propertyInfo == null)
+            var finalPart = pathParts[pathParts.Length - 1];
+            int finalBracket = finalPart.IndexOf('[');
+            if (finalBracket >= 0)
             {
-                response.Success = false;
-                response.ErrorMessage = $"Property '{finalPropertyName}' not found";
-                return response;
-            }
-
-            if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
-            {
-                response.Success = false;
-                response.ErrorMessage = $"Property '{finalPropertyName}' is read-only";
-                return response;
-            }
-
-            // Detect leaf element update inside a collection (Collection[index].Prop)
-            bool isLeafElementUpdate = propertyPath.Contains("]." + finalPropertyName, StringComparison.Ordinal);
-
-            // Store old value for undo/history
-            var oldValue = propertyInfo.GetValue(target);
-            if (oldValue != null) response.OldValue = PackToAny(oldValue);
-            
-            // Only treat as collection update when modifying the collection itself (not element property)
-            if (!isLeafElementUpdate && (!string.IsNullOrEmpty(request.CollectionKey) || (request.ArrayIndex > -1 && propertyPath.Equals(request.PropertyName, StringComparison.OrdinalIgnoreCase))))
-            {
-                response = HandleCollectionUpdate(target, propertyInfo, request);
-            }
-            else
-            {
-                var convertedValue = ConvertAnyToTargetType(request.NewValue, propertyInfo.PropertyType);
-                if (convertedValue.Success)
+                var propName = finalPart[..finalBracket];
+                var end = finalPart.IndexOf(']', finalBracket);
+                if (end < 0)
                 {
-                    Debug.WriteLine($"[GrpcService:SampleViewModel] Setting property '{finalPropertyName}' via reflection to value: {convertedValue.Value}");
-                    propertyInfo.SetValue(target, convertedValue.Value);
+                    response.Success = false;
+                    response.ErrorMessage = $"Invalid path segment '{finalPart}' in '{propertyPath}'";
+                    return response;
+                }
+                var indexStr = finalPart[(finalBracket + 1)..end];
+                var propertyInfo = target?.GetType().GetProperty(propName);
+                if (propertyInfo == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{propName}' not found";
+                    return response;
+                }
+                var collection = propertyInfo.GetValue(target);
+                if (collection == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Collection property '{propName}' is null";
+                    return response;
+                }
+                if (collection is IList list && int.TryParse(indexStr, out int idx))
+                {
+                    if (idx < 0 || idx >= list.Count)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
+                        return response;
+                    }
+                    var elementType = propertyInfo.PropertyType.GetGenericArguments()[0];
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, elementType);
+                    if (!convertedValue.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = convertedValue.ErrorMessage;
+                        return response;
+                    }
+                    response.OldValue = PackToAny(list[idx]);
+                    list[idx] = convertedValue.Value;
                     response.Success = true;
+                    Debug.WriteLine($"[GrpcService:SampleViewModel] Updated array index {idx} to '{convertedValue.Value}'");
+                }
+                else if (collection is IDictionary dict)
+                {
+                    var keyType = propertyInfo.PropertyType.GetGenericArguments()[0];
+                    var valueType = propertyInfo.PropertyType.GetGenericArguments()[1];
+                    var convertedKey = ConvertStringToTargetType(indexStr, keyType);
+                    if (!convertedKey.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Failed to convert key '{indexStr}': {convertedKey.ErrorMessage}";
+                        return response;
+                    }
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, valueType);
+                    if (!convertedValue.Success)
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = $"Failed to convert value: {convertedValue.ErrorMessage}";
+                        return response;
+                    }
+                    if (convertedKey.Value != null && dict.Contains(convertedKey.Value)) response.OldValue = PackToAny(dict[convertedKey.Value]);
+                    dict[convertedKey.Value!] = convertedValue.Value;
+                    response.Success = true;
+                    Debug.WriteLine($"[GrpcService:SampleViewModel] Updated dictionary key '{convertedKey.Value}' to '{convertedValue.Value}'");
                 }
                 else
                 {
                     response.Success = false;
-                    response.ErrorMessage = convertedValue.ErrorMessage;
+                    response.ErrorMessage = $"Property '{propName}' is not an indexable collection";
+                }
+            }
+            else
+            {
+                var propertyInfo = target?.GetType().GetProperty(finalPart);
+                if (propertyInfo == null)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{finalPart}' not found";
+                    return response;
+                }
+                if (propertyInfo.SetMethod == null || !propertyInfo.SetMethod.IsPublic)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Property '{finalPart}' is read-only";
+                    return response;
+                }
+
+                bool isLeafElementUpdate = propertyPath.Contains("]." + finalPart, StringComparison.Ordinal);
+
+                var oldValue = propertyInfo.GetValue(target);
+                if (oldValue != null) response.OldValue = PackToAny(oldValue);
+
+                if (!isLeafElementUpdate && !string.IsNullOrEmpty(request.CollectionKey) && propertyPath.Equals(request.PropertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    response = HandleCollectionUpdate(target, propertyInfo, request);
+                }
+                else
+                {
+                    var convertedValue = ConvertAnyToTargetType(request.NewValue, propertyInfo.PropertyType);
+                    if (convertedValue.Success)
+                    {
+                        Debug.WriteLine($"[GrpcService:SampleViewModel] Setting property '{finalPart}' via reflection to value: {convertedValue.Value}");
+                        propertyInfo.SetValue(target, convertedValue.Value);
+                        response.Success = true;
+                        if (!propertyPath.Equals(request.PropertyName, StringComparison.Ordinal) &&
+                            !typeof(INotifyPropertyChanged).IsAssignableFrom(propertyInfo.DeclaringType!))
+                        {
+                            var notification = new SampleApp.ViewModels.Protos.PropertyChangeNotification
+                            {
+                                PropertyName = request.PropertyName,
+                                PropertyPath = propertyPath,
+                                ChangeType = "nested",
+                                NewValue = request.NewValue
+                            };
+                            var sourceClientId = request.ClientId;
+                            foreach (var kvp in _subscriberChannels)
+                            {
+                                if (kvp.Key == sourceClientId) continue;
+                                _ = kvp.Value.Writer.WriteAsync(notification);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        response.Success = false;
+                        response.ErrorMessage = convertedValue.ErrorMessage;
+                    }
                 }
             }
         }
@@ -337,37 +437,10 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             response.Success = true;
             Debug.WriteLine($"[GrpcService:SampleViewModel] Updated dictionary key '{convertedKey.Value}' to '{convertedValue.Value}'");
         }
-        // Handle list/array element replacement updates
-        else if (collection is System.Collections.IList list && request.ArrayIndex > -1)
-        {
-            if (request.ArrayIndex >= list.Count)
-            {
-                response.Success = false;
-                response.ErrorMessage = $"Array index {request.ArrayIndex} is out of bounds (count: {list.Count})";
-                return response;
-            }
-            
-            var elementType = propertyInfo.PropertyType.GetGenericArguments()[0];
-            var convertedValue = ConvertAnyToTargetType(request.NewValue, elementType);
-            
-            if (!convertedValue.Success)
-            {
-                response.Success = false;
-                response.ErrorMessage = convertedValue.ErrorMessage;
-                return response;
-            }
-            
-            // Store old value
-            response.OldValue = PackToAny(list[request.ArrayIndex]);
-            
-            list[request.ArrayIndex] = convertedValue.Value;
-            response.Success = true;
-            Debug.WriteLine($"[GrpcService:SampleViewModel] Updated array index {request.ArrayIndex} to '{convertedValue.Value}'");
-        }
         else
         {
             response.Success = false;
-            response.ErrorMessage = "Unsupported collection operation or missing index/key";
+            response.ErrorMessage = "Unsupported collection operation or missing key";
         }
         
         return response;
@@ -426,7 +499,13 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                 return (true, anyValue.Unpack<DoubleValue>().Value, "");
             if (anyValue.Is(BoolValue.Descriptor) && targetType == typeof(bool))
                 return (true, anyValue.Unpack<BoolValue>().Value, "");
-            
+
+            // Handle DateTime conversions
+            if (anyValue.Is(Timestamp.Descriptor) && targetType == typeof(DateTime))
+                return (true, anyValue.Unpack<Timestamp>().ToDateTime(), "");
+            if (anyValue.Is(Timestamp.Descriptor) && targetType == typeof(DateTime?))
+                return (true, (DateTime?)anyValue.Unpack<Timestamp>().ToDateTime(), "");
+
             // Handle additional numeric type conversions
             if (anyValue.Is(Int32Value.Descriptor) && targetType == typeof(short))
                 return (true, (short)anyValue.Unpack<Int32Value>().Value, "");
@@ -515,6 +594,88 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             return (false, null, $"Conversion error: {ex.Message}");
         }
         return (false, null, $"Cannot convert '{stringValue}' to {targetType.Name}");
+    }
+
+    private void AttachNestedPropertyChangedHandlers(object obj, string prefix)
+    {
+        if (obj is not INotifyPropertyChanged inpc) return;
+        inpc.PropertyChanged += (s, e) =>
+        {
+            var path = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+            ViewModel_PropertyChanged(s, new PropertyChangedEventArgs(path));
+
+            var prop = s?.GetType().GetProperty(e.PropertyName);
+            var val = prop?.GetValue(s);
+            if (val is INotifyPropertyChanged child)
+            {
+                var childPrefix = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+                AttachNestedPropertyChangedHandlers(child, childPrefix);
+            }
+            else if (val is System.Collections.IEnumerable enumerable && val is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"{e.PropertyName}[{index}]" : prefix + $".{e.PropertyName}[{index}]";
+                    if (item != null) AttachNestedPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (val is INotifyCollectionChanged incc)
+                {
+                    var propName = e.PropertyName;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(prefix) ? $"{propName}[{start}]" : prefix + $".{propName}[{start}]";
+                                if (newItem != null) AttachNestedPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+            }
+        };
+
+        foreach (var p in obj.GetType().GetProperties())
+        {
+            var val = p.GetValue(obj);
+            if (val is INotifyPropertyChanged child)
+            {
+                var childPrefix = string.IsNullOrEmpty(prefix) ? p.Name : prefix + "." + p.Name;
+                AttachNestedPropertyChangedHandlers(child, childPrefix);
+            }
+            else if (val is System.Collections.IEnumerable enumerable && val is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"{p.Name}[{index}]" : prefix + $".{p.Name}[{index}]";
+                    if (item != null) AttachNestedPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (val is INotifyCollectionChanged incc)
+                {
+                    var propName = p.Name;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(prefix) ? $"{propName}[{start}]" : prefix + $".{propName}[{start}]";
+                                if (newItem != null) AttachNestedPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+            }
+        }
     }
 
     private async void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
@@ -15,6 +15,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.ComponentModel;
+using System.Collections.Specialized;
 using Generated.ViewModels;
 #if WPF_DISPATCHER
 using System.Windows;
@@ -29,6 +31,7 @@ namespace SampleApp.ViewModels.RemoteClients
         private bool _isInitialized = false;
         private bool _isDisposed = false;
         private readonly string _clientId = Guid.NewGuid().ToString();
+        private bool _suppressLocalUpdates = false;
 
         private string _connectionStatus = "Unknown";
         public string ConnectionStatus
@@ -80,39 +83,40 @@ namespace SampleApp.ViewModels.RemoteClients
         /// </summary>
         /// <param name="propertyName">The name of the property to update</param>
         /// <param name="value">The new value to set</param>
-        public async Task UpdatePropertyValueAsync(string propertyName, object? value)
+        public async Task UpdatePropertyValueAsync(string propertyPath, object? value)
         {
             if (!_isInitialized || _isDisposed)
             {
-                Debug.WriteLine($"[ClientProxy:SampleViewModel] UpdatePropertyValueAsync for {propertyName} skipped - not initialized or disposed");
+                Debug.WriteLine($"[ClientProxy:SampleViewModel] UpdatePropertyValueAsync for {propertyPath} skipped - not initialized or disposed");
                 return;
             }
 
             try
             {
-                Debug.WriteLine($"[ClientProxy:SampleViewModel] Updating server property {propertyName} = {value}");
+                Debug.WriteLine($"[ClientProxy:SampleViewModel] Updating server property {propertyPath} = {value}");
+                var topLevel = propertyPath.Split(new[] {'.','['}, 2)[0];
                 var request = new SampleApp.ViewModels.Protos.UpdatePropertyValueRequest
                 {
-                    PropertyName = propertyName,
-                    ArrayIndex = -1,
+                    PropertyName = topLevel,
+                    PropertyPath = propertyPath,
                     ClientId = _clientId,
                     NewValue = PackValueToAny(value)
                 };
 
                 var response = await _grpcClient.UpdatePropertyValueAsync(request, cancellationToken: _cts.Token);
-                Debug.WriteLine($"[ClientProxy:SampleViewModel] Property {propertyName} updated successfully on server");
+                Debug.WriteLine($"[ClientProxy:SampleViewModel] Property {propertyPath} updated successfully on server");
             }
             catch (RpcException ex)
             {
-                Debug.WriteLine($"[ClientProxy:SampleViewModel] Error updating property {propertyName}: {ex.Status.StatusCode} - {ex.Status.Detail}");
+                Debug.WriteLine($"[ClientProxy:SampleViewModel] Error updating property {propertyPath}: {ex.Status.StatusCode} - {ex.Status.Detail}");
             }
             catch (OperationCanceledException)
             {
-                Debug.WriteLine($"[ClientProxy:SampleViewModel] Property update {propertyName} cancelled");
+                Debug.WriteLine($"[ClientProxy:SampleViewModel] Property update {propertyPath} cancelled");
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[ClientProxy:SampleViewModel] Unexpected error updating property {propertyName}: {ex.Message}");
+                Debug.WriteLine($"[ClientProxy:SampleViewModel] Unexpected error updating property {propertyPath}: {ex.Message}");
             }
         }
 
@@ -141,6 +145,165 @@ namespace SampleApp.ViewModels.RemoteClients
                 System.Enum e => Any.Pack(new Int32Value { Value = Convert.ToInt32(e) }),
                 _ => Any.Pack(new StringValue { Value = value?.ToString() ?? "" })
             };
+        }
+
+        private static object? UnpackAny(Any value)
+        {
+            if (value.Is(StringValue.Descriptor)) return value.Unpack<StringValue>().Value;
+            if (value.Is(Int32Value.Descriptor)) return value.Unpack<Int32Value>().Value;
+            if (value.Is(Int64Value.Descriptor)) return value.Unpack<Int64Value>().Value;
+            if (value.Is(UInt32Value.Descriptor)) return value.Unpack<UInt32Value>().Value;
+            if (value.Is(UInt64Value.Descriptor)) return value.Unpack<UInt64Value>().Value;
+            if (value.Is(FloatValue.Descriptor)) return value.Unpack<FloatValue>().Value;
+            if (value.Is(DoubleValue.Descriptor)) return value.Unpack<DoubleValue>().Value;
+            if (value.Is(BoolValue.Descriptor)) return value.Unpack<BoolValue>().Value;
+            if (value.Is(Timestamp.Descriptor)) return value.Unpack<Timestamp>().ToDateTime();
+            if (value.Is(Google.Protobuf.WellKnownTypes.Duration.Descriptor)) return value.Unpack<Google.Protobuf.WellKnownTypes.Duration>().ToTimeSpan();
+            return null;
+        }
+
+        private static void SetValueByPath(object target, string path, object? newValue)
+        {
+            var segments = path.Split('.');
+            object? current = target;
+
+            for (int i = 0; i < segments.Length; i++)
+            {
+                var part = segments[i];
+                int bracket = part.IndexOf('[');
+                if (bracket >= 0)
+                {
+                    var propName = part[..bracket];
+                    var end = part.IndexOf(']', bracket);
+                    if (end < 0) return;
+                    var indexStr = part[(bracket + 1)..end];
+                    var prop = current?.GetType().GetProperty(propName);
+                    if (prop?.GetValue(current) is System.Collections.IList list && int.TryParse(indexStr, out int idx))
+                    {
+                        if (idx < 0 || idx >= list.Count) return;
+                        if (i == segments.Length - 1)
+                        {
+                            list[idx] = newValue;
+                            if (target is SampleViewModelRemoteClient rc)
+                            {
+                                rc.AttachLocalPropertyChangedHandlers(list[idx], path);
+                            }
+                            return;
+                        }
+                        current = list[idx];
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    if (i == segments.Length - 1)
+                    {
+                        var prop = current?.GetType().GetProperty(part);
+                        prop?.SetValue(current, newValue);
+                        if (target is SampleViewModelRemoteClient rc)
+                        {
+                            rc.AttachLocalPropertyChangedHandlers(newValue, path);
+                        }
+                        return;
+                    }
+                    else
+                    {
+                        var prop = current?.GetType().GetProperty(part);
+                        current = prop?.GetValue(current);
+                    }
+                }
+
+                if (current == null) return;
+            }
+        }
+
+        private void AttachLocalPropertyChangedHandlers(object? obj, string prefix)
+        {
+            if (obj == null) return;
+
+            if (obj is INotifyPropertyChanged inpc)
+            {
+                inpc.PropertyChanged += async (s, e) =>
+                {
+                    if (_suppressLocalUpdates) return;
+                    var prop = s?.GetType().GetProperty(e.PropertyName);
+                    if (prop == null) return;
+                    var value = prop.GetValue(s);
+                    var path = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+                    await UpdatePropertyValueAsync(path, value);
+
+                    if (value is INotifyPropertyChanged child)
+                    {
+                        AttachLocalPropertyChangedHandlers(child, path);
+                    }
+                    else if (value is System.Collections.IEnumerable enumVal && value is not string)
+                    {
+                        int idx = 0;
+                        foreach (var item in enumVal)
+                        {
+                            var childPrefix = string.IsNullOrEmpty(path) ? $"[{idx}]" : path + $"[{idx}]";
+                            AttachLocalPropertyChangedHandlers(item, childPrefix);
+                            idx++;
+                        }
+                        if (value is INotifyCollectionChanged incc)
+                        {
+                            var outerPath = path;
+                            incc.CollectionChanged += (s2, args) =>
+                            {
+                                if (args.NewItems != null)
+                                {
+                                    int start = args.NewStartingIndex;
+                                    foreach (var newItem in args.NewItems)
+                                    {
+                                        var childPrefix = string.IsNullOrEmpty(outerPath) ? $"[{start}]" : outerPath + $"[{start}]";
+                                        AttachLocalPropertyChangedHandlers(newItem, childPrefix);
+                                        start++;
+                                    }
+                                }
+                            };
+                        }
+                    }
+                };
+            }
+
+            if (obj is System.Collections.IEnumerable enumerable && obj is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"[{index}]" : prefix + $"[{index}]";
+                    AttachLocalPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                if (obj is INotifyCollectionChanged incc)
+                {
+                    var outerPrefix = prefix;
+                    incc.CollectionChanged += (s2, args) =>
+                    {
+                        if (args.NewItems != null)
+                        {
+                            int start = args.NewStartingIndex;
+                            foreach (var newItem in args.NewItems)
+                            {
+                                var childPrefix = string.IsNullOrEmpty(outerPrefix) ? $"[{start}]" : outerPrefix + $"[{start}]";
+                                AttachLocalPropertyChangedHandlers(newItem, childPrefix);
+                                start++;
+                            }
+                        }
+                    };
+                }
+                return;
+            }
+
+            foreach (var p in obj.GetType().GetProperties())
+            {
+                var val = p.GetValue(obj);
+                var childPrefix = string.IsNullOrEmpty(prefix) ? p.Name : prefix + "." + p.Name;
+                AttachLocalPropertyChangedHandlers(val, childPrefix);
+            }
         }
 
         private async Task StartPingLoopAsync()
@@ -195,8 +358,11 @@ namespace SampleApp.ViewModels.RemoteClients
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
                 var state = await _grpcClient.GetStateAsync(new Empty(), cancellationToken: linkedCts.Token);
                 Debug.WriteLine("[SampleViewModelRemoteClient] Initial state received.");
+                _suppressLocalUpdates = true;
                 this.Name = state.Name;
                 this.Count = state.Count;
+                _suppressLocalUpdates = false;
+                AttachLocalPropertyChangedHandlers(this, string.Empty);
                 _isInitialized = true;
                 Debug.WriteLine("[SampleViewModelRemoteClient] Initialized successfully.");
                 StartListeningToPropertyChanges(_cts.Token);
@@ -268,16 +434,26 @@ namespace SampleApp.ViewModels.RemoteClients
                            try
                            {
                                Debug.WriteLine("[SampleViewModelRemoteClient] Dispatcher: Attempting to update \"" + update.PropertyName + "\" (Update #" + updateCount + ").");
-                               switch (update.PropertyName)
+                               _suppressLocalUpdates = true;
+                               if (update.ChangeType == "nested")
                                {
+                                   var val = UnpackAny(update.NewValue);
+                                   SetValueByPath(this, update.PropertyPath, val);
+                               }
+                               else
+                               {
+                                   switch (update.PropertyName)
+                                   {
                                    case nameof(Name):
                  if (update.NewValue!.Is(StringValue.Descriptor)) this.Name = update.NewValue.Unpack<StringValue>().Value; break;
                                    case nameof(Count):
                      if (update.NewValue!.Is(Int32Value.Descriptor)) this.Count = (int)update.NewValue.Unpack<Int32Value>().Value; break;
-                                   default: Debug.WriteLine("[ClientProxy:SampleViewModel] Unknown property in notification: \"" + update.PropertyName + "\""); break;
+                                       default: Debug.WriteLine("[ClientProxy:SampleViewModel] Unknown property in notification: \"" + update.PropertyName + "\""); break;
+                                   }
                                }
                            }
                            catch (Exception exInAction) { Debug.WriteLine("[ClientProxy:SampleViewModel] EXCEPTION INSIDE updateAction for \"" + update.PropertyName + "\": " + exInAction.ToString()); }
+                           finally { _suppressLocalUpdates = false; }
                         };
                         #if WPF_DISPATCHER
                         Application.Current?.Dispatcher.Invoke(updateAction);

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
@@ -67,7 +67,6 @@ export class SampleViewModelRemoteClient {
     async updatePropertyValue(propertyName: string, value: any): Promise<UpdatePropertyValueResponse> {
         const req = new UpdatePropertyValueRequest();
         req.setPropertyName(propertyName);
-        req.setArrayIndex(-1); // Default to -1 for non-array properties
         req.setNewValue(this.createAnyValue(value));
         const response = await this.grpcClient.updatePropertyValue(req);
         
@@ -109,7 +108,6 @@ export class SampleViewModelRemoteClient {
         options?: {
             propertyPath?: string;
             collectionKey?: string;
-            arrayIndex?: number;
             operationType?: 'set' | 'add' | 'remove' | 'clear' | 'insert';
         }
     ): Promise<UpdatePropertyValueResponse> {
@@ -119,7 +117,6 @@ export class SampleViewModelRemoteClient {
         
         if (options?.propertyPath) req.setPropertyPath(options.propertyPath);
         if (options?.collectionKey) req.setCollectionKey(options.collectionKey);
-        if (options?.arrayIndex !== undefined) req.setArrayIndex(options.arrayIndex);
         if (options?.operationType) req.setOperationType(options.operationType);
         
         const response = await this.grpcClient.updatePropertyValue(req);

--- a/test/SampleViewModel/expected/SampleViewModelService.proto
+++ b/test/SampleViewModel/expected/SampleViewModelService.proto
@@ -22,10 +22,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
-  string client_id = 7;             // Originating client identifier
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/test/SimpleViewModelTest/ViewModels/generated/MainViewModelGrpcServiceImpl.cs
+++ b/test/SimpleViewModelTest/ViewModels/generated/MainViewModelGrpcServiceImpl.cs
@@ -200,7 +200,14 @@ public partial class MainViewModelGrpcServiceImpl : MainViewModelService.MainVie
                             response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
                             return response;
                         }
-                        target = list[idx] ?? new();
+                        var nextTarget = list[idx];
+                        if (nextTarget == null)
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Null value encountered at index {idx} for '{propName}'";
+                            return response;
+                        }
+                        target = nextTarget;
                     }
                     else
                     {

--- a/test/SimpleViewModelTest/ViewModels/protos/MainViewModelService.proto
+++ b/test/SimpleViewModelTest/ViewModels/protos/MainViewModelService.proto
@@ -26,9 +26,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelGrpcServiceImpl.cs
+++ b/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelGrpcServiceImpl.cs
@@ -249,7 +249,14 @@ public partial class HP3LSThermalTestViewModelGrpcServiceImpl : HP3LSThermalTest
                             response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
                             return response;
                         }
-                        target = list[idx] ?? new();
+                        var nextTarget = list[idx];
+                        if (nextTarget == null)
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Null value encountered at index {idx} for '{propName}'";
+                            return response;
+                        }
+                        target = nextTarget;
                     }
                     else
                     {

--- a/test/ThermalTest/ViewModels/generated/csProject/protos/HP3LSThermalTestViewModelService.proto
+++ b/test/ThermalTest/ViewModels/generated/csProject/protos/HP3LSThermalTestViewModelService.proto
@@ -52,9 +52,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/test/ThermalTest/ViewModels/generated/tsProject/protos/HP3LSThermalTestViewModelService.proto
+++ b/test/ThermalTest/ViewModels/generated/tsProject/protos/HP3LSThermalTestViewModelService.proto
@@ -52,9 +52,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/test/ThermalTest/ViewModels/protos/HP3LSThermalTestViewModelService.proto
+++ b/test/ThermalTest/ViewModels/protos/HP3LSThermalTestViewModelService.proto
@@ -52,9 +52,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/test/ThermalTest/ViewModels/tsProjectUpdated/protos/HP3LSThermalTestViewModelService.proto
+++ b/test/ThermalTest/ViewModels/tsProjectUpdated/protos/HP3LSThermalTestViewModelService.proto
@@ -52,9 +52,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {


### PR DESCRIPTION
## Summary
- drop `array_index` from `UpdatePropertyValueRequest` and send collection updates using bracketed property paths
- regenerate expected client and server outputs to reflect property-path indexing
- document property-path array access in update examples

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c37c2a1b8083208695ff06bd0ee540