### PR TITLE
Drop array index from update requests and add property paths

### DIFF
--- a/docs/UpdatePropertyValueExamples.md
+++ b/docs/UpdatePropertyValueExamples.md
@@ -71,17 +71,27 @@ var request = new UpdatePropertyValueRequest
 };
 ```
 
-### 3. Array Element Updates  
+### 3. Array Element Updates
 ```csharp
 var request = new UpdatePropertyValueRequest
 {
     PropertyName = "Scores",
-    ArrayIndex = 5,                  // Update element at index 5
+    PropertyPath = "Scores[5]",     // Use bracket notation for array access
     NewValue = Any.Pack(new Int32Value { Value = 1500 })
 };
 ```
 
-### 4. Complex Collection Operations
+### 4. Nested Dictionary Property Updates
+```csharp
+var request = new UpdatePropertyValueRequest
+{
+    PropertyName = "Company",
+    PropertyPath = "Company.Departments[CA][LosAngeles].Name", // Dictionary key access
+    NewValue = Any.Pack(new StringValue { Value = "Central Office" })
+};
+```
+
+### 5. Complex Collection Operations
 ```csharp
 // Add to collection
 var addRequest = new UpdatePropertyValueRequest

--- a/src/RemoteMvvmTool/Generators/ProtoGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/ProtoGenerator.cs
@@ -263,10 +263,9 @@ public static class ProtoGenerator
         body.AppendLine("  google.protobuf.Any new_value = 2;");
         body.AppendLine("  // Optional fields for complex property updates");
         body.AppendLine("  string property_path = 3;          // For nested properties like \"User.Address.Street\"");
-        body.AppendLine("  string collection_key = 4;         // For dictionary keys or array indices");
-        body.AppendLine("  int32 array_index = 5;             // For updating specific array elements");
-        body.AppendLine("  string operation_type = 6;         // \"set\", \"add\", \"remove\", \"clear\", \"insert\"");
-        body.AppendLine("  string client_id = 7;             // Originating client identifier");
+        body.AppendLine("  string collection_key = 4;         // For dictionary keys");
+        body.AppendLine("  string operation_type = 5;         // \"set\", \"add\", \"remove\", \"clear\", \"insert\"");
+        body.AppendLine("  string client_id = 6;             // Originating client identifier");
         body.AppendLine("}");
         body.AppendLine();
         body.AppendLine("message UpdatePropertyValueResponse {");

--- a/src/RemoteMvvmTool/Generators/StronglyTypedTestClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/StronglyTypedTestClientGenerator.cs
@@ -137,7 +137,6 @@ public static class StronglyTypedTestClientGenerator
         sb.AppendLine("        var request = new UpdatePropertyValueRequest");
         sb.AppendLine("        {");
         sb.AppendLine("            PropertyName = propertyName,");
-        sb.AppendLine("            ArrayIndex = -1,");
         sb.AppendLine("            NewValue = Any.Pack(CreateValueFromObject(value))");
         sb.AppendLine("        };");
         sb.AppendLine("        await _grpcClient.UpdatePropertyValueAsync(request);");
@@ -149,7 +148,6 @@ public static class StronglyTypedTestClientGenerator
         sb.AppendLine("        {");
         sb.AppendLine("            PropertyName = propertyName,");
         sb.AppendLine("            PropertyPath = $\"{collectionName}[{index}].{propertyName}\",");
-        sb.AppendLine("            ArrayIndex = index,");
         sb.AppendLine("            NewValue = Any.Pack(CreateValueFromObject(value))");
         sb.AppendLine("        };");
         sb.AppendLine("        await _grpcClient.UpdatePropertyValueAsync(request);");
@@ -184,7 +182,6 @@ public static class StronglyTypedTestClientGenerator
             sb.AppendLine("        var request = new UpdatePropertyValueRequest");
             sb.AppendLine("        {");
             sb.AppendLine($"            PropertyName = \"{prop.Name}\",");
-            sb.AppendLine("            ArrayIndex = -1,");
             if (prop.TypeString == "System.String") sb.AppendLine("            NewValue = Any.Pack(new StringValue { Value = value })");
             else if (prop.TypeString == "System.Int32") sb.AppendLine("            NewValue = Any.Pack(new Int32Value { Value = value })");
             else if (prop.TypeString == "System.Boolean") sb.AppendLine("            NewValue = Any.Pack(new BoolValue { Value = value })");
@@ -296,7 +293,6 @@ public static class StronglyTypedTestClientGenerator
                 sb.AppendLine("            var request = new UpdatePropertyValueRequest { ");
                 sb.AppendLine("                PropertyName = propertyName,");
                 sb.AppendLine("                PropertyPath = $\"{_collectionName}[{_index}].{propertyName}\",");
-                sb.AppendLine("                ArrayIndex = _index,");
                 sb.AppendLine("                NewValue = Any.Pack(protoValue) ");
                 sb.AppendLine("            };");
                 sb.AppendLine("            await _client.UpdatePropertyValueAsync(request);");

--- a/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/TypeScriptClientGenerator.cs
@@ -541,7 +541,6 @@ public static class TypeScriptClientGenerator
         }
         sb.AppendLine("        const req = new UpdatePropertyValueRequest();");
         sb.AppendLine("        req.setPropertyName(propertyName);");
-        sb.AppendLine("        req.setArrayIndex(-1); // Default to -1 for non-array properties");
         sb.AppendLine("        req.setNewValue(this.createAnyValue(value));");
         sb.AppendLine("        const response = await this.grpcClient.updatePropertyValue(req);");
         sb.AppendLine("        ");
@@ -585,7 +584,6 @@ public static class TypeScriptClientGenerator
         sb.AppendLine("        options?: {");
         sb.AppendLine("            propertyPath?: string;");
         sb.AppendLine("            collectionKey?: string;");
-        sb.AppendLine("            arrayIndex?: number;");
         sb.AppendLine("            operationType?: 'set' | 'add' | 'remove' | 'clear' | 'insert';");
         sb.AppendLine("        }");
         sb.AppendLine("    ): Promise<UpdatePropertyValueResponse> {");
@@ -595,7 +593,6 @@ public static class TypeScriptClientGenerator
         sb.AppendLine("        ");
         sb.AppendLine("        if (options?.propertyPath) req.setPropertyPath(options.propertyPath);");
         sb.AppendLine("        if (options?.collectionKey) req.setCollectionKey(options.collectionKey);");
-        sb.AppendLine("        if (options?.arrayIndex !== undefined) req.setArrayIndex(options.arrayIndex);");
         sb.AppendLine("        if (options?.operationType) req.setOperationType(options.operationType);");
         sb.AppendLine("        ");
         sb.AppendLine("        const response = await this.grpcClient.updatePropertyValue(req);");

--- a/src/RemoteMvvmTool/Generators/UIGeneratorBase.cs
+++ b/src/RemoteMvvmTool/Generators/UIGeneratorBase.cs
@@ -170,8 +170,8 @@ public abstract class UIGeneratorBase
             
             commands.Add(new TreeCommand(TreeCommandType.CreateNode, $"{metadata.SafeVariableName}Node", 
                 $"\"{prop.Name}: \" + {metadata.SafeVariableName}Value"));
-            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node", 
-                $"\"{prop.Name}\"", viewModelVariableName, "IsSimpleProperty = true"));
+            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node",
+                $"\"{prop.Name}\"", viewModelVariableName, $"IsSimpleProperty = true, PropertyPath = \"{prop.Name}\"") );
             commands.Add(new TreeCommand(TreeCommandType.AddChildNode, "simplePropsNode", $"{metadata.SafeVariableName}Node"));
             
             commands.Add(new TreeCommand(TreeCommandType.TryEnd));
@@ -219,8 +219,8 @@ public abstract class UIGeneratorBase
                     $"\"{prop.Name}: \" + {viewModelVariableName}.{metadata.SafePropertyAccess}.ToString()"));
             }
             
-            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node", 
-                $"\"{prop.Name}\"", viewModelVariableName, "IsBooleanProperty = true"));
+            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node",
+                $"\"{prop.Name}\"", viewModelVariableName, $"IsBooleanProperty = true, PropertyPath = \"{prop.Name}\"") );
             commands.Add(new TreeCommand(TreeCommandType.AddChildNode, "boolPropsNode", $"{metadata.SafeVariableName}Node"));
             
             commands.Add(new TreeCommand(TreeCommandType.TryEnd));
@@ -258,8 +258,8 @@ public abstract class UIGeneratorBase
             
             commands.Add(new TreeCommand(TreeCommandType.CreateNode, $"{metadata.SafeVariableName}Node", 
                 $"\"{prop.Name} [\" + {viewModelVariableName}.{metadata.SafePropertyAccess}.{metadata.CountProperty} + \" items]\""));
-            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node", 
-                $"\"{prop.Name}\"", viewModelVariableName, "IsCollectionProperty = true"));
+            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node",
+                $"\"{prop.Name}\"", viewModelVariableName, $"IsCollectionProperty = true, PropertyPath = \"{prop.Name}\"") );
             commands.Add(new TreeCommand(TreeCommandType.AddChildNode, "collectionPropsNode", $"{metadata.SafeVariableName}Node"));
             
             // Add individual items (limit to first 3 for performance)
@@ -269,7 +269,7 @@ public abstract class UIGeneratorBase
             commands.Add(new TreeCommand(TreeCommandType.TryBegin));
             commands.Add(new TreeCommand(TreeCommandType.AssignValue, "itemText", "item.ToString()"));
             commands.Add(new TreeCommand(TreeCommandType.CreateNode, "itemNode", "\"[\" + idx + \"] \" + itemText"));
-            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, "itemNode", "\"[\" + idx + \"]\"", "item", "IsCollectionItem = true, CollectionIndex = idx"));
+            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, "itemNode", "\"[\" + idx + \"]\"", "item", $"IsCollectionItem = true, CollectionIndex = idx, PropertyPath = \"{prop.Name}[\" + idx + \"]\"") );
             commands.Add(new TreeCommand(TreeCommandType.AddChildNode, $"{metadata.SafeVariableName}Node", "itemNode"));
             commands.Add(new TreeCommand(TreeCommandType.TryEnd));
             commands.Add(new TreeCommand(TreeCommandType.CatchBegin));
@@ -321,8 +321,8 @@ public abstract class UIGeneratorBase
                 $"{viewModelVariableName}.{metadata.SafePropertyAccess}.GetType().Name"));
             commands.Add(new TreeCommand(TreeCommandType.CreateNode, $"{metadata.SafeVariableName}Node", 
                 $"\"{prop.Name} (\" + {metadata.SafeVariableName}TypeName + \")\""));
-            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node", 
-                $"\"{prop.Name}\"", $"{viewModelVariableName}.{metadata.SafePropertyAccess}", "IsComplexProperty = true"));
+            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node",
+                $"\"{prop.Name}\"", $"{viewModelVariableName}.{metadata.SafePropertyAccess}", $"IsComplexProperty = true, PropertyPath = \"{prop.Name}\"") );
             commands.Add(new TreeCommand(TreeCommandType.AddChildNode, "complexPropsNode", $"{metadata.SafeVariableName}Node"));
             
             commands.Add(new TreeCommand(TreeCommandType.Else));
@@ -375,8 +375,8 @@ public abstract class UIGeneratorBase
                     $"\"{prop.Name}: \" + {viewModelVariableName}.{metadata.SafePropertyAccess}.ToString()"));
             }
             
-            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node", 
-                $"\"{prop.Name}\"", viewModelVariableName, "IsEnumProperty = true"));
+            commands.Add(new TreeCommand(TreeCommandType.SetNodeTag, $"{metadata.SafeVariableName}Node",
+                $"\"{prop.Name}\"", viewModelVariableName, $"IsEnumProperty = true, PropertyPath = \"{prop.Name}\"") );
             commands.Add(new TreeCommand(TreeCommandType.AddChildNode, "enumPropsNode", $"{metadata.SafeVariableName}Node"));
             
             commands.Add(new TreeCommand(TreeCommandType.TryEnd));
@@ -419,6 +419,7 @@ public abstract class UIGeneratorBase
         public class PropertyNodeInfo
         {
             public string PropertyName { get; set; } = string.Empty;
+            public string PropertyPath { get; set; } = string.Empty;
             public object? Object { get; set; }
             public bool IsSimpleProperty { get; set; }
             public bool IsBooleanProperty { get; set; }

--- a/src/RemoteMvvmTool/Resources/ClientTemplate.tmpl
+++ b/src/RemoteMvvmTool/Resources/ClientTemplate.tmpl
@@ -62,7 +62,6 @@ namespace <<NAMESPACE>>
                 {
                     PropertyName = topLevel,
                     PropertyPath = propertyPath,
-                    ArrayIndex = -1,
                     ClientId = _clientId,
                     NewValue = PackValueToAny(value)
                 };
@@ -138,27 +137,50 @@ namespace <<NAMESPACE>>
                 if (bracket >= 0)
                 {
                     var propName = part[..bracket];
-                    var end = part.IndexOf(']', bracket);
-                    if (end < 0) return;
-                    var indexStr = part[(bracket + 1)..end];
                     var prop = current?.GetType().GetProperty(propName);
-                    if (prop?.GetValue(current) is System.Collections.IList list && int.TryParse(indexStr, out int idx))
+                    current = prop?.GetValue(current);
+                    var remainder = part[bracket..];
+                    while (remainder.StartsWith("["))
                     {
-                        if (idx < 0 || idx >= list.Count) return;
-                        if (i == segments.Length - 1)
+                        var end = remainder.IndexOf(']', 1);
+                        if (end < 0) return;
+                        var indexStr = remainder[1..end];
+                        remainder = remainder[(end + 1)..];
+
+                        if (current is System.Collections.IList list && int.TryParse(indexStr, out int idx))
                         {
-                            list[idx] = newValue;
-                            if (target is <<VIEW_MODEL_NAME>>RemoteClient rc)
+                            if (idx < 0 || idx >= list.Count) return;
+                            if (i == segments.Length - 1 && remainder.Length == 0)
                             {
-                                rc.AttachLocalPropertyChangedHandlers(list[idx], path);
+                                list[idx] = newValue;
+                                if (target is <<VIEW_MODEL_NAME>>RemoteClient rc)
+                                {
+                                    rc.AttachLocalPropertyChangedHandlers(list[idx], path);
+                                }
+                                return;
                             }
+                            current = list[idx];
+                        }
+                        else if (current is System.Collections.IDictionary dict)
+                        {
+                            var key = indexStr;
+                            if (i == segments.Length - 1 && remainder.Length == 0)
+                            {
+                                dict[key] = newValue;
+                                if (target is <<VIEW_MODEL_NAME>>RemoteClient rc)
+                                {
+                                    rc.AttachLocalPropertyChangedHandlers(newValue, path);
+                                }
+                                return;
+                            }
+                            current = dict[key];
+                        }
+                        else
+                        {
                             return;
                         }
-                        current = list[idx];
-                    }
-                    else
-                    {
-                        return;
+
+                        if (current == null) return;
                     }
                 }
                 else

--- a/src/RemoteMvvmTool/Resources/ServerTemplate.tmpl
+++ b/src/RemoteMvvmTool/Resources/ServerTemplate.tmpl
@@ -166,7 +166,7 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
             object target = _viewModel;
             var pathParts = propertyPath.Split('.');
             
-            // Navigate to nested property if needed, handling collection indices
+            // Navigate to nested property if needed, handling collection indices and dictionary keys
             for (int i = 0; i < pathParts.Length - 1; i++)
             {
                 var part = pathParts[i];
@@ -174,14 +174,6 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
                 if (bracketIndex >= 0)
                 {
                     var propName = part[..bracketIndex];
-                    var end = part.IndexOf(']', bracketIndex);
-                    if (end < 0)
-                    {
-                        response.Success = false;
-                        response.ErrorMessage = $"Invalid path segment '{part}' in '{propertyPath}'";
-                        return response;
-                    }
-                    var indexStr = part[(bracketIndex + 1)..end];
                     var prop = target?.GetType().GetProperty(propName);
                     if (prop == null)
                     {
@@ -189,22 +181,57 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
                         response.ErrorMessage = $"Property '{propName}' not found in path '{propertyPath}'";
                         return response;
                     }
-                    if (prop.GetValue(target) is IList list && int.TryParse(indexStr, out int idx))
+                    var nextTarget = prop.GetValue(target);
+                    var remainder = part[bracketIndex..];
+                    while (remainder.StartsWith("["))
                     {
-                        if (idx < 0 || idx >= list.Count)
+                        var end = remainder.IndexOf(']', 1);
+                        if (end < 0)
                         {
                             response.Success = false;
-                            response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
+                            response.ErrorMessage = $"Invalid path segment '{part}' in '{propertyPath}'";
                             return response;
                         }
-                        target = list[idx] ?? new();
+                        var indexStr = remainder[1..end];
+                        remainder = remainder[(end + 1)..];
+
+                        if (nextTarget is IList list && int.TryParse(indexStr, out int idx))
+                        {
+                            if (idx < 0 || idx >= list.Count)
+                            {
+                                response.Success = false;
+                                response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
+                                return response;
+                            }
+                            nextTarget = list[idx];
+                        }
+                        else if (nextTarget is IDictionary dict)
+                        {
+                            var keyType = nextTarget.GetType().GetGenericArguments()[0];
+                            var keyResult = ConvertStringToTargetType(indexStr, keyType);
+                            if (!keyResult.Success)
+                            {
+                                response.Success = false;
+                                response.ErrorMessage = keyResult.ErrorMessage;
+                                return response;
+                            }
+                            nextTarget = dict[keyResult.Value!];
+                        }
+                        else
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Property '{propName}' is not an indexable collection";
+                            return response;
+                        }
+
+                        if (nextTarget == null)
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Null value encountered at '{propName}' in path '{propertyPath}'";
+                            return response;
+                        }
                     }
-                    else
-                    {
-                        response.Success = false;
-                        response.ErrorMessage = $"Property '{propName}' is not an indexable list";
-                        return response;
-                    }
+                    target = nextTarget;
                 }
                 else
                 {
@@ -226,7 +253,22 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
                 }
             }
 
-            var finalPropertyName = pathParts[pathParts.Length - 1];
+            var finalPart = pathParts[pathParts.Length - 1];
+            var bracketPos = finalPart.IndexOf('[');
+            var finalPropertyName = bracketPos >= 0 ? finalPart[..bracketPos] : finalPart;
+            int collectionIndex = -1;
+            if (bracketPos >= 0)
+            {
+                var end = finalPart.IndexOf(']', bracketPos);
+                if (end < 0)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Invalid path segment '{finalPart}' in '{propertyPath}'";
+                    return response;
+                }
+                var indexStr = finalPart[(bracketPos + 1)..end];
+                int.TryParse(indexStr, out collectionIndex);
+            }
             var propertyInfo = target?.GetType().GetProperty(finalPropertyName);
             if (propertyInfo == null)
             {
@@ -250,9 +292,9 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
             if (oldValue != null) response.OldValue = PackToAny(oldValue);
             
             // Only treat as collection update when modifying the collection itself (not element property)
-            if (!isLeafElementUpdate && (!string.IsNullOrEmpty(request.CollectionKey) || (request.ArrayIndex > -1 && propertyPath.Equals(request.PropertyName, StringComparison.OrdinalIgnoreCase))))
+            if (!isLeafElementUpdate && (!string.IsNullOrEmpty(request.CollectionKey) || collectionIndex > -1))
             {
-                response = HandleCollectionUpdate(target, propertyInfo, request);
+                response = HandleCollectionUpdate(target, propertyInfo, request, collectionIndex);
             }
             else
             {
@@ -297,7 +339,7 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
         return response;
     }
 
-    private <<PROTO_NS>>.UpdatePropertyValueResponse HandleCollectionUpdate(object target, System.Reflection.PropertyInfo propertyInfo, <<PROTO_NS>>.UpdatePropertyValueRequest request)
+    private <<PROTO_NS>>.UpdatePropertyValueResponse HandleCollectionUpdate(object target, System.Reflection.PropertyInfo propertyInfo, <<PROTO_NS>>.UpdatePropertyValueRequest request, int arrayIndex)
     {
         var response = new <<PROTO_NS>>.UpdatePropertyValueResponse();
         
@@ -339,12 +381,12 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
             Debug.WriteLine($"[GrpcService:<<VIEWMODEL_NAME>>] Updated dictionary key '{convertedKey.Value}' to '{convertedValue.Value}'");
         }
         // Handle list/array element replacement updates
-        else if (collection is System.Collections.IList list && request.ArrayIndex > -1)
+        else if (collection is System.Collections.IList list && arrayIndex > -1)
         {
-            if (request.ArrayIndex >= list.Count)
+            if (arrayIndex >= list.Count)
             {
                 response.Success = false;
-                response.ErrorMessage = $"Array index {request.ArrayIndex} is out of bounds (count: {list.Count})";
+                response.ErrorMessage = $"Array index {arrayIndex} is out of bounds (count: {list.Count})";
                 return response;
             }
             
@@ -359,11 +401,11 @@ public partial class <<VIEWMODEL_NAME>>GrpcServiceImpl : <<SERVICE_NAME>>.<<SERV
             }
             
             // Store old value
-            response.OldValue = PackToAny(list[request.ArrayIndex]);
-            
-            list[request.ArrayIndex] = convertedValue.Value;
+            response.OldValue = PackToAny(list[arrayIndex]);
+
+            list[arrayIndex] = convertedValue.Value;
             response.Success = true;
-            Debug.WriteLine($"[GrpcService:<<VIEWMODEL_NAME>>] Updated array index {request.ArrayIndex} to '{convertedValue.Value}'");
+            Debug.WriteLine($"[GrpcService:<<VIEWMODEL_NAME>>] Updated array index {arrayIndex} to '{convertedValue.Value}'");
         }
         else
         {

--- a/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
+++ b/test/GameViewModel/expected/GameViewModelGrpcServiceImpl.cs
@@ -224,7 +224,7 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
             object target = _viewModel;
             var pathParts = propertyPath.Split('.');
             
-            // Navigate to nested property if needed, handling collection indices
+            // Navigate to nested property if needed, handling collection indices and dictionary keys
             for (int i = 0; i < pathParts.Length - 1; i++)
             {
                 var part = pathParts[i];
@@ -232,14 +232,6 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
                 if (bracketIndex >= 0)
                 {
                     var propName = part[..bracketIndex];
-                    var end = part.IndexOf(']', bracketIndex);
-                    if (end < 0)
-                    {
-                        response.Success = false;
-                        response.ErrorMessage = $"Invalid path segment '{part}' in '{propertyPath}'";
-                        return response;
-                    }
-                    var indexStr = part[(bracketIndex + 1)..end];
                     var prop = target?.GetType().GetProperty(propName);
                     if (prop == null)
                     {
@@ -247,22 +239,57 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
                         response.ErrorMessage = $"Property '{propName}' not found in path '{propertyPath}'";
                         return response;
                     }
-                    if (prop.GetValue(target) is IList list && int.TryParse(indexStr, out int idx))
+                    var nextTarget = prop.GetValue(target);
+                    var remainder = part[bracketIndex..];
+                    while (remainder.StartsWith("["))
                     {
-                        if (idx < 0 || idx >= list.Count)
+                        var end = remainder.IndexOf(']', 1);
+                        if (end < 0)
                         {
                             response.Success = false;
-                            response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
+                            response.ErrorMessage = $"Invalid path segment '{part}' in '{propertyPath}'";
                             return response;
                         }
-                        target = list[idx] ?? new();
+                        var indexStr = remainder[1..end];
+                        remainder = remainder[(end + 1)..];
+
+                        if (nextTarget is IList list && int.TryParse(indexStr, out int idx))
+                        {
+                            if (idx < 0 || idx >= list.Count)
+                            {
+                                response.Success = false;
+                                response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
+                                return response;
+                            }
+                            nextTarget = list[idx];
+                        }
+                        else if (nextTarget is IDictionary dict)
+                        {
+                            var keyType = nextTarget.GetType().GetGenericArguments()[0];
+                            var keyResult = ConvertStringToTargetType(indexStr, keyType);
+                            if (!keyResult.Success)
+                            {
+                                response.Success = false;
+                                response.ErrorMessage = keyResult.ErrorMessage;
+                                return response;
+                            }
+                            nextTarget = dict[keyResult.Value!];
+                        }
+                        else
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Property '{propName}' is not an indexable collection";
+                            return response;
+                        }
+
+                        if (nextTarget == null)
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Null value encountered at '{propName}' in path '{propertyPath}'";
+                            return response;
+                        }
                     }
-                    else
-                    {
-                        response.Success = false;
-                        response.ErrorMessage = $"Property '{propName}' is not an indexable list";
-                        return response;
-                    }
+                    target = nextTarget;
                 }
                 else
                 {
@@ -284,7 +311,22 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
                 }
             }
 
-            var finalPropertyName = pathParts[pathParts.Length - 1];
+            var finalPart = pathParts[pathParts.Length - 1];
+            var bracketPos = finalPart.IndexOf('[');
+            var finalPropertyName = bracketPos >= 0 ? finalPart[..bracketPos] : finalPart;
+            int collectionIndex = -1;
+            if (bracketPos >= 0)
+            {
+                var end = finalPart.IndexOf(']', bracketPos);
+                if (end < 0)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Invalid path segment '{finalPart}' in '{propertyPath}'";
+                    return response;
+                }
+                var indexStr = finalPart[(bracketPos + 1)..end];
+                int.TryParse(indexStr, out collectionIndex);
+            }
             var propertyInfo = target?.GetType().GetProperty(finalPropertyName);
             if (propertyInfo == null)
             {
@@ -308,9 +350,9 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
             if (oldValue != null) response.OldValue = PackToAny(oldValue);
             
             // Only treat as collection update when modifying the collection itself (not element property)
-            if (!isLeafElementUpdate && (!string.IsNullOrEmpty(request.CollectionKey) || (request.ArrayIndex > -1 && propertyPath.Equals(request.PropertyName, StringComparison.OrdinalIgnoreCase))))
+            if (!isLeafElementUpdate && (!string.IsNullOrEmpty(request.CollectionKey) || collectionIndex > -1))
             {
-                response = HandleCollectionUpdate(target, propertyInfo, request);
+                response = HandleCollectionUpdate(target, propertyInfo, request, collectionIndex);
             }
             else
             {
@@ -355,7 +397,7 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
         return response;
     }
 
-    private MonsterClicker.ViewModels.Protos.UpdatePropertyValueResponse HandleCollectionUpdate(object target, System.Reflection.PropertyInfo propertyInfo, MonsterClicker.ViewModels.Protos.UpdatePropertyValueRequest request)
+    private MonsterClicker.ViewModels.Protos.UpdatePropertyValueResponse HandleCollectionUpdate(object target, System.Reflection.PropertyInfo propertyInfo, MonsterClicker.ViewModels.Protos.UpdatePropertyValueRequest request, int arrayIndex)
     {
         var response = new MonsterClicker.ViewModels.Protos.UpdatePropertyValueResponse();
         
@@ -397,12 +439,12 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
             Debug.WriteLine($"[GrpcService:GameViewModel] Updated dictionary key '{convertedKey.Value}' to '{convertedValue.Value}'");
         }
         // Handle list/array element replacement updates
-        else if (collection is System.Collections.IList list && request.ArrayIndex > -1)
+        else if (collection is System.Collections.IList list && arrayIndex > -1)
         {
-            if (request.ArrayIndex >= list.Count)
+            if (arrayIndex >= list.Count)
             {
                 response.Success = false;
-                response.ErrorMessage = $"Array index {request.ArrayIndex} is out of bounds (count: {list.Count})";
+                response.ErrorMessage = $"Array index {arrayIndex} is out of bounds (count: {list.Count})";
                 return response;
             }
             
@@ -417,11 +459,11 @@ public partial class GameViewModelGrpcServiceImpl : GameViewModelService.GameVie
             }
             
             // Store old value
-            response.OldValue = PackToAny(list[request.ArrayIndex]);
-            
-            list[request.ArrayIndex] = convertedValue.Value;
+            response.OldValue = PackToAny(list[arrayIndex]);
+
+            list[arrayIndex] = convertedValue.Value;
             response.Success = true;
-            Debug.WriteLine($"[GrpcService:GameViewModel] Updated array index {request.ArrayIndex} to '{convertedValue.Value}'");
+            Debug.WriteLine($"[GrpcService:GameViewModel] Updated array index {arrayIndex} to '{convertedValue.Value}'");
         }
         else
         {

--- a/test/GameViewModel/expected/GameViewModelRemoteClient.cs
+++ b/test/GameViewModel/expected/GameViewModelRemoteClient.cs
@@ -175,7 +175,6 @@ namespace MonsterClicker.ViewModels.RemoteClients
                 {
                     PropertyName = topLevel,
                     PropertyPath = propertyPath,
-                    ArrayIndex = -1,
                     ClientId = _clientId,
                     NewValue = PackValueToAny(value)
                 };
@@ -251,27 +250,50 @@ namespace MonsterClicker.ViewModels.RemoteClients
                 if (bracket >= 0)
                 {
                     var propName = part[..bracket];
-                    var end = part.IndexOf(']', bracket);
-                    if (end < 0) return;
-                    var indexStr = part[(bracket + 1)..end];
                     var prop = current?.GetType().GetProperty(propName);
-                    if (prop?.GetValue(current) is System.Collections.IList list && int.TryParse(indexStr, out int idx))
+                    current = prop?.GetValue(current);
+                    var remainder = part[bracket..];
+                    while (remainder.StartsWith("["))
                     {
-                        if (idx < 0 || idx >= list.Count) return;
-                        if (i == segments.Length - 1)
+                        var end = remainder.IndexOf(']', 1);
+                        if (end < 0) return;
+                        var indexStr = remainder[1..end];
+                        remainder = remainder[(end + 1)..];
+
+                        if (current is System.Collections.IList list && int.TryParse(indexStr, out int idx))
                         {
-                            list[idx] = newValue;
-                            if (target is GameViewModelRemoteClient rc)
+                            if (idx < 0 || idx >= list.Count) return;
+                            if (i == segments.Length - 1 && remainder.Length == 0)
                             {
-                                rc.AttachLocalPropertyChangedHandlers(list[idx], path);
+                                list[idx] = newValue;
+                                if (target is GameViewModelRemoteClient rc)
+                                {
+                                    rc.AttachLocalPropertyChangedHandlers(list[idx], path);
+                                }
+                                return;
                             }
+                            current = list[idx];
+                        }
+                        else if (current is System.Collections.IDictionary dict)
+                        {
+                            var key = indexStr;
+                            if (i == segments.Length - 1 && remainder.Length == 0)
+                            {
+                                dict[key] = newValue;
+                                if (target is GameViewModelRemoteClient rc)
+                                {
+                                    rc.AttachLocalPropertyChangedHandlers(newValue, path);
+                                }
+                                return;
+                            }
+                            current = dict[key];
+                        }
+                        else
+                        {
                             return;
                         }
-                        current = list[idx];
-                    }
-                    else
-                    {
-                        return;
+
+                        if (current == null) return;
                     }
                 }
                 else

--- a/test/GameViewModel/expected/GameViewModelRemoteClient.ts
+++ b/test/GameViewModel/expected/GameViewModelRemoteClient.ts
@@ -85,7 +85,6 @@ export class GameViewModelRemoteClient {
     async updatePropertyValue(propertyName: string, value: any): Promise<UpdatePropertyValueResponse> {
         const req = new UpdatePropertyValueRequest();
         req.setPropertyName(propertyName);
-        req.setArrayIndex(-1); // Default to -1 for non-array properties
         req.setNewValue(this.createAnyValue(value));
         const response = await this.grpcClient.updatePropertyValue(req);
         
@@ -127,7 +126,6 @@ export class GameViewModelRemoteClient {
         options?: {
             propertyPath?: string;
             collectionKey?: string;
-            arrayIndex?: number;
             operationType?: 'set' | 'add' | 'remove' | 'clear' | 'insert';
         }
     ): Promise<UpdatePropertyValueResponse> {
@@ -137,7 +135,6 @@ export class GameViewModelRemoteClient {
         
         if (options?.propertyPath) req.setPropertyPath(options.propertyPath);
         if (options?.collectionKey) req.setCollectionKey(options.collectionKey);
-        if (options?.arrayIndex !== undefined) req.setArrayIndex(options.arrayIndex);
         if (options?.operationType) req.setOperationType(options.operationType);
         
         const response = await this.grpcClient.updatePropertyValue(req);

--- a/test/GameViewModel/expected/GameViewModelService.proto
+++ b/test/GameViewModel/expected/GameViewModelService.proto
@@ -28,10 +28,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
-  string client_id = 7;             // Originating client identifier
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/test/PointerTestModel/expected/PointerViewModelRemoteClient.cs
+++ b/test/PointerTestModel/expected/PointerViewModelRemoteClient.cs
@@ -15,19 +15,20 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.ComponentModel;
 using Generated.ViewModels;
-#if WPF_DISPATCHER
-using System.Windows;
-#endif
 
 namespace Pointer.ViewModels.RemoteClients
 {
     public partial class PointerViewModelRemoteClient : ObservableObject, IDisposable
     {
         private readonly Pointer.ViewModels.Protos.PointerViewModelService.PointerViewModelServiceClient _grpcClient;
+        private readonly SynchronizationContext? _syncContext;
         private CancellationTokenSource _cts = new CancellationTokenSource();
         private bool _isInitialized = false;
         private bool _isDisposed = false;
+        private readonly string _clientId = Guid.NewGuid().ToString();
+        private bool _suppressLocalUpdates = false;
 
         private string _connectionStatus = "Unknown";
         public string ConnectionStatus
@@ -231,6 +232,7 @@ namespace Pointer.ViewModels.RemoteClients
         public PointerViewModelRemoteClient(Pointer.ViewModels.Protos.PointerViewModelService.PointerViewModelServiceClient grpcClient)
         {
             _grpcClient = grpcClient ?? throw new ArgumentNullException(nameof(grpcClient));
+            _syncContext = SynchronizationContext.Current;
             InitializeCommand = new RelayCommand(RemoteExecute_Initialize);
             OnCursorTestCommand = new RelayCommand(RemoteExecute_OnCursorTest);
             OnClickTestCommand = new RelayCommand<int>(RemoteExecute_OnClickTest);
@@ -247,38 +249,41 @@ namespace Pointer.ViewModels.RemoteClients
         /// </summary>
         /// <param name="propertyName">The name of the property to update</param>
         /// <param name="value">The new value to set</param>
-        public async Task UpdatePropertyValueAsync(string propertyName, object? value)
+        public async Task UpdatePropertyValueAsync(string propertyPath, object? value)
         {
             if (!_isInitialized || _isDisposed)
             {
-                Debug.WriteLine($"[ClientProxy:PointerViewModel] UpdatePropertyValueAsync for {propertyName} skipped - not initialized or disposed");
+                Debug.WriteLine($"[ClientProxy:PointerViewModel] UpdatePropertyValueAsync for {propertyPath} skipped - not initialized or disposed");
                 return;
             }
 
             try
             {
-                Debug.WriteLine($"[ClientProxy:PointerViewModel] Updating server property {propertyName} = {value}");
+                Debug.WriteLine($"[ClientProxy:PointerViewModel] Updating server property {propertyPath} = {value}");
+                var topLevel = propertyPath.Split(new[] {'.','['}, 2)[0];
                 var request = new Pointer.ViewModels.Protos.UpdatePropertyValueRequest
                 {
-                    PropertyName = propertyName,
+                    PropertyName = topLevel,
+                    PropertyPath = propertyPath,
                     ArrayIndex = -1,
+                    ClientId = _clientId,
                     NewValue = PackValueToAny(value)
                 };
 
                 var response = await _grpcClient.UpdatePropertyValueAsync(request, cancellationToken: _cts.Token);
-                Debug.WriteLine($"[ClientProxy:PointerViewModel] Property {propertyName} updated successfully on server");
+                Debug.WriteLine($"[ClientProxy:PointerViewModel] Property {propertyPath} updated successfully on server");
             }
             catch (RpcException ex)
             {
-                Debug.WriteLine($"[ClientProxy:PointerViewModel] Error updating property {propertyName}: {ex.Status.StatusCode} - {ex.Status.Detail}");
+                Debug.WriteLine($"[ClientProxy:PointerViewModel] Error updating property {propertyPath}: {ex.Status.StatusCode} - {ex.Status.Detail}");
             }
             catch (OperationCanceledException)
             {
-                Debug.WriteLine($"[ClientProxy:PointerViewModel] Property update {propertyName} cancelled");
+                Debug.WriteLine($"[ClientProxy:PointerViewModel] Property update {propertyPath} cancelled");
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[ClientProxy:PointerViewModel] Unexpected error updating property {propertyName}: {ex.Message}");
+                Debug.WriteLine($"[ClientProxy:PointerViewModel] Unexpected error updating property {propertyPath}: {ex.Message}");
             }
         }
 
@@ -307,6 +312,116 @@ namespace Pointer.ViewModels.RemoteClients
                 System.Enum e => Any.Pack(new Int32Value { Value = Convert.ToInt32(e) }),
                 _ => Any.Pack(new StringValue { Value = value?.ToString() ?? "" })
             };
+        }
+
+        private static object? UnpackAny(Any value)
+        {
+            if (value.Is(StringValue.Descriptor)) return value.Unpack<StringValue>().Value;
+            if (value.Is(Int32Value.Descriptor)) return value.Unpack<Int32Value>().Value;
+            if (value.Is(Int64Value.Descriptor)) return value.Unpack<Int64Value>().Value;
+            if (value.Is(UInt32Value.Descriptor)) return value.Unpack<UInt32Value>().Value;
+            if (value.Is(UInt64Value.Descriptor)) return value.Unpack<UInt64Value>().Value;
+            if (value.Is(FloatValue.Descriptor)) return value.Unpack<FloatValue>().Value;
+            if (value.Is(DoubleValue.Descriptor)) return value.Unpack<DoubleValue>().Value;
+            if (value.Is(BoolValue.Descriptor)) return value.Unpack<BoolValue>().Value;
+            if (value.Is(Timestamp.Descriptor)) return value.Unpack<Timestamp>().ToDateTime();
+            if (value.Is(Google.Protobuf.WellKnownTypes.Duration.Descriptor)) return value.Unpack<Google.Protobuf.WellKnownTypes.Duration>().ToTimeSpan();
+            return null;
+        }
+
+        private static void SetValueByPath(object target, string path, object? newValue)
+        {
+            var segments = path.Split('.');
+            object? current = target;
+
+            for (int i = 0; i < segments.Length; i++)
+            {
+                var part = segments[i];
+                int bracket = part.IndexOf('[');
+                if (bracket >= 0)
+                {
+                    var propName = part[..bracket];
+                    var end = part.IndexOf(']', bracket);
+                    if (end < 0) return;
+                    var indexStr = part[(bracket + 1)..end];
+                    var prop = current?.GetType().GetProperty(propName);
+                    if (prop?.GetValue(current) is System.Collections.IList list && int.TryParse(indexStr, out int idx))
+                    {
+                        if (idx < 0 || idx >= list.Count) return;
+                        if (i == segments.Length - 1)
+                        {
+                            list[idx] = newValue;
+                            if (target is PointerViewModelRemoteClient rc)
+                            {
+                                rc.AttachLocalPropertyChangedHandlers(list[idx], path);
+                            }
+                            return;
+                        }
+                        current = list[idx];
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    if (i == segments.Length - 1)
+                    {
+                        var prop = current?.GetType().GetProperty(part);
+                        prop?.SetValue(current, newValue);
+                        if (target is PointerViewModelRemoteClient rc)
+                        {
+                            rc.AttachLocalPropertyChangedHandlers(newValue, path);
+                        }
+                        return;
+                    }
+                    else
+                    {
+                        var prop = current?.GetType().GetProperty(part);
+                        current = prop?.GetValue(current);
+                    }
+                }
+
+                if (current == null) return;
+            }
+        }
+
+        private void AttachLocalPropertyChangedHandlers(object? obj, string prefix)
+        {
+            if (obj == null) return;
+
+            if (obj is INotifyPropertyChanged inpc)
+            {
+                inpc.PropertyChanged += async (s, e) =>
+                {
+                    if (_suppressLocalUpdates) return;
+                    var prop = s?.GetType().GetProperty(e.PropertyName);
+                    if (prop == null) return;
+                    var value = prop.GetValue(s);
+                    var path = string.IsNullOrEmpty(prefix) ? e.PropertyName : prefix + "." + e.PropertyName;
+                    await UpdatePropertyValueAsync(path, value);
+                };
+            }
+
+            if (obj is System.Collections.IEnumerable enumerable && obj is not string)
+            {
+                int index = 0;
+                foreach (var item in enumerable)
+                {
+                    var childPrefix = string.IsNullOrEmpty(prefix) ? $"[{index}]" : prefix + $"[{index}]";
+                    AttachLocalPropertyChangedHandlers(item, childPrefix);
+                    index++;
+                }
+                return;
+            }
+
+            foreach (var p in obj.GetType().GetProperties())
+            {
+                var val = p.GetValue(obj);
+                var childPrefix = string.IsNullOrEmpty(prefix) ? p.Name : prefix + "." + p.Name;
+                AttachLocalPropertyChangedHandlers(val, childPrefix);
+            }
         }
 
         private async Task StartPingLoopAsync()
@@ -373,6 +488,7 @@ namespace Pointer.ViewModels.RemoteClients
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
                 var state = await _grpcClient.GetStateAsync(new Empty(), cancellationToken: linkedCts.Token);
                 Debug.WriteLine("[PointerViewModelRemoteClient] Initial state received.");
+                _suppressLocalUpdates = true;
                 this.Show = state.Show;
                 this.ShowSpinner = state.ShowSpinner;
                 this.ClicksToPass = state.ClicksToPass;
@@ -387,6 +503,8 @@ namespace Pointer.ViewModels.RemoteClients
                 this.TimerText = state.TimerText;
                 this.SelectedDevice = state.SelectedDevice;
                 this.LastClickCount = state.LastClickCount;
+                _suppressLocalUpdates = false;
+                AttachLocalPropertyChangedHandlers(this, string.Empty);
                 _isInitialized = true;
                 Debug.WriteLine("[PointerViewModelRemoteClient] Initialized successfully.");
                 StartListeningToPropertyChanges(_cts.Token);
@@ -522,7 +640,7 @@ namespace Pointer.ViewModels.RemoteClients
                 Debug.WriteLine("[PointerViewModelRemoteClient] Starting property change listener...");
                 try
                 {
-                    var subscribeRequest = new Pointer.ViewModels.Protos.SubscribeRequest { ClientId = Guid.NewGuid().ToString() };
+                    var subscribeRequest = new Pointer.ViewModels.Protos.SubscribeRequest { ClientId = _clientId };
                     using var call = _grpcClient.SubscribeToPropertyChanges(subscribeRequest, cancellationToken: cancellationToken);
                     Debug.WriteLine("[PointerViewModelRemoteClient] Subscribed to property changes. Waiting for updates...");
                     int updateCount = 0;
@@ -536,8 +654,16 @@ namespace Pointer.ViewModels.RemoteClients
                            try
                            {
                                Debug.WriteLine("[PointerViewModelRemoteClient] Dispatcher: Attempting to update \"" + update.PropertyName + "\" (Update #" + updateCount + ").");
-                               switch (update.PropertyName)
+                               _suppressLocalUpdates = true;
+                               if (update.ChangeType == "nested")
                                {
+                                   var val = UnpackAny(update.NewValue);
+                                   SetValueByPath(this, update.PropertyPath, val);
+                               }
+                               else
+                               {
+                                   switch (update.PropertyName)
+                                   {
                                    case nameof(Show):
                     if (update.NewValue!.Is(BoolValue.Descriptor)) this.Show = update.NewValue.Unpack<BoolValue>().Value; break;
                                    case nameof(ShowSpinner):
@@ -566,16 +692,17 @@ namespace Pointer.ViewModels.RemoteClients
                  if (update.NewValue!.Is(StringValue.Descriptor)) this.SelectedDevice = update.NewValue.Unpack<StringValue>().Value; break;
                                    case nameof(LastClickCount):
                      if (update.NewValue!.Is(Int32Value.Descriptor)) this.LastClickCount = (int)update.NewValue.Unpack<Int32Value>().Value; break;
-                                   default: Debug.WriteLine("[ClientProxy:PointerViewModel] Unknown property in notification: \"" + update.PropertyName + "\""); break;
+                                       default: Debug.WriteLine("[ClientProxy:PointerViewModel] Unknown property in notification: \"" + update.PropertyName + "\""); break;
+                                   }
                                }
                            }
                            catch (Exception exInAction) { Debug.WriteLine("[ClientProxy:PointerViewModel] EXCEPTION INSIDE updateAction for \"" + update.PropertyName + "\": " + exInAction.ToString()); }
+                           finally { _suppressLocalUpdates = false; }
                         };
-                        #if WPF_DISPATCHER
-                        Application.Current?.Dispatcher.Invoke(updateAction);
-                        #else
-                        updateAction();
-                        #endif
+                        if (_syncContext != null)
+                            _syncContext.Post(_ => updateAction(), null);
+                        else
+                            updateAction();
                         Debug.WriteLine("[PointerViewModelRemoteClient] Processed update #" + updateCount + " for \"" + update.PropertyName + "\". Still listening...");
                     }
                     Debug.WriteLine("[PointerViewModelRemoteClient] ReadAllAsync completed or cancelled after " + updateCount + " updates.");

--- a/test/PointerTestModel/expected/PointerViewModelService.proto
+++ b/test/PointerTestModel/expected/PointerViewModelService.proto
@@ -37,6 +37,7 @@ message UpdatePropertyValueRequest {
   string collection_key = 4;         // For dictionary keys or array indices
   int32 array_index = 5;             // For updating specific array elements
   string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 7;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {

--- a/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptCompilationTests.cs
+++ b/test/RemoteMvvmTool.Tests/TypeScript/TypeScriptCompilationTests.cs
@@ -142,7 +142,7 @@ export {{ UpdatePropertyValueResponse }};
 ");
         File.WriteAllText(Path.Combine(gen, serviceName + "_pb.js"),
             $"exports.{vmName}State = class {{}};" +
-            "exports.UpdatePropertyValueRequest = class { constructor(){ this.p=''; this.v=undefined; this.path=''; this.key=''; this.idx=-1; this.op=''; } setPropertyName(v){ this.p=v; } getPropertyName(){ return this.p; } setNewValue(v){ this.v=v; } getNewValue(){ return this.v; } setPropertyPath(v){ this.path=v; } getPropertyPath(){ return this.path; } setCollectionKey(v){ this.key=v; } getCollectionKey(){ return this.key; } setArrayIndex(v){ this.idx=v; } getArrayIndex(){ return this.idx; } setOperationType(v){ this.op=v; } getOperationType(){ return this.op; } };" +
+            "exports.UpdatePropertyValueRequest = class { constructor(){ this.p=''; this.v=undefined; this.path=''; this.key=''; this.op=''; } setPropertyName(v){ this.p=v; } getPropertyName(){ return this.p; } setNewValue(v){ this.v=v; } getNewValue(){ return this.v; } setPropertyPath(v){ this.path=v; } getPropertyPath(){ return this.path; } setCollectionKey(v){ this.key=v; } getCollectionKey(){ return this.key; } setOperationType(v){ this.op=v; } getOperationType(){ return this.op; } };" +
             "exports.UpdatePropertyValueResponse = class { constructor(){ this.success=true; this.error=''; } getSuccess(){ return this.success; } setSuccess(v){ this.success=v; } getErrorMessage(){ return this.error; } setErrorMessage(v){ this.error=v; } };" +
             "exports.SubscribeRequest = class { setClientId(){} };" +
             "exports.PropertyChangeNotification = class { getPropertyName(){return ''} getNewValue(){return null} getPropertyPath(){return ''} };" +
@@ -152,7 +152,7 @@ export {{ UpdatePropertyValueResponse }};
             "exports.CancelTestRequest = class {};");
         File.WriteAllText(Path.Combine(gen, serviceName + "_pb.d.ts"),
             $"export class {vmName}State {{}}\n" +
-            "export class UpdatePropertyValueRequest { setPropertyName(v:string):void; getPropertyName():string; setNewValue(v:any):void; getNewValue():any; setPropertyPath(v:string):void; getPropertyPath():string; setCollectionKey(v:string):void; getCollectionKey():string; setArrayIndex(v:number):void; getArrayIndex():number; setOperationType(v:string):void; getOperationType():string; }\n" +
+            "export class UpdatePropertyValueRequest { setPropertyName(v:string):void; getPropertyName():string; setNewValue(v:any):void; getNewValue():any; setPropertyPath(v:string):void; getPropertyPath():string; setCollectionKey(v:string):void; getCollectionKey():string; setOperationType(v:string):void; getOperationType():string; }\n" +
             "export class UpdatePropertyValueResponse { getSuccess():boolean; setSuccess(v:boolean):void; getErrorMessage():string; setErrorMessage(v:string):void; }\n" +
             "export class SubscribeRequest { setClientId(v:string):void; }\n" +
             "export class PropertyChangeNotification { getPropertyName():string; getNewValue():any; getPropertyPath():string; }\n" +

--- a/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
+++ b/test/SampleViewModel/expected/SampleViewModelGrpcServiceImpl.cs
@@ -182,7 +182,7 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             object target = _viewModel;
             var pathParts = propertyPath.Split('.');
             
-            // Navigate to nested property if needed, handling collection indices
+            // Navigate to nested property if needed, handling collection indices and dictionary keys
             for (int i = 0; i < pathParts.Length - 1; i++)
             {
                 var part = pathParts[i];
@@ -190,14 +190,6 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                 if (bracketIndex >= 0)
                 {
                     var propName = part[..bracketIndex];
-                    var end = part.IndexOf(']', bracketIndex);
-                    if (end < 0)
-                    {
-                        response.Success = false;
-                        response.ErrorMessage = $"Invalid path segment '{part}' in '{propertyPath}'";
-                        return response;
-                    }
-                    var indexStr = part[(bracketIndex + 1)..end];
                     var prop = target?.GetType().GetProperty(propName);
                     if (prop == null)
                     {
@@ -205,22 +197,57 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                         response.ErrorMessage = $"Property '{propName}' not found in path '{propertyPath}'";
                         return response;
                     }
-                    if (prop.GetValue(target) is IList list && int.TryParse(indexStr, out int idx))
+                    var nextTarget = prop.GetValue(target);
+                    var remainder = part[bracketIndex..];
+                    while (remainder.StartsWith("["))
                     {
-                        if (idx < 0 || idx >= list.Count)
+                        var end = remainder.IndexOf(']', 1);
+                        if (end < 0)
                         {
                             response.Success = false;
-                            response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
+                            response.ErrorMessage = $"Invalid path segment '{part}' in '{propertyPath}'";
                             return response;
                         }
-                        target = list[idx] ?? new();
+                        var indexStr = remainder[1..end];
+                        remainder = remainder[(end + 1)..];
+
+                        if (nextTarget is IList list && int.TryParse(indexStr, out int idx))
+                        {
+                            if (idx < 0 || idx >= list.Count)
+                            {
+                                response.Success = false;
+                                response.ErrorMessage = $"Index {idx} out of range for '{propName}'";
+                                return response;
+                            }
+                            nextTarget = list[idx];
+                        }
+                        else if (nextTarget is IDictionary dict)
+                        {
+                            var keyType = nextTarget.GetType().GetGenericArguments()[0];
+                            var keyResult = ConvertStringToTargetType(indexStr, keyType);
+                            if (!keyResult.Success)
+                            {
+                                response.Success = false;
+                                response.ErrorMessage = keyResult.ErrorMessage;
+                                return response;
+                            }
+                            nextTarget = dict[keyResult.Value!];
+                        }
+                        else
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Property '{propName}' is not an indexable collection";
+                            return response;
+                        }
+
+                        if (nextTarget == null)
+                        {
+                            response.Success = false;
+                            response.ErrorMessage = $"Null value encountered at '{propName}' in path '{propertyPath}'";
+                            return response;
+                        }
                     }
-                    else
-                    {
-                        response.Success = false;
-                        response.ErrorMessage = $"Property '{propName}' is not an indexable list";
-                        return response;
-                    }
+                    target = nextTarget;
                 }
                 else
                 {
@@ -242,7 +269,22 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
                 }
             }
 
-            var finalPropertyName = pathParts[pathParts.Length - 1];
+            var finalPart = pathParts[pathParts.Length - 1];
+            var bracketPos = finalPart.IndexOf('[');
+            var finalPropertyName = bracketPos >= 0 ? finalPart[..bracketPos] : finalPart;
+            int collectionIndex = -1;
+            if (bracketPos >= 0)
+            {
+                var end = finalPart.IndexOf(']', bracketPos);
+                if (end < 0)
+                {
+                    response.Success = false;
+                    response.ErrorMessage = $"Invalid path segment '{finalPart}' in '{propertyPath}'";
+                    return response;
+                }
+                var indexStr = finalPart[(bracketPos + 1)..end];
+                int.TryParse(indexStr, out collectionIndex);
+            }
             var propertyInfo = target?.GetType().GetProperty(finalPropertyName);
             if (propertyInfo == null)
             {
@@ -266,9 +308,9 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             if (oldValue != null) response.OldValue = PackToAny(oldValue);
             
             // Only treat as collection update when modifying the collection itself (not element property)
-            if (!isLeafElementUpdate && (!string.IsNullOrEmpty(request.CollectionKey) || (request.ArrayIndex > -1 && propertyPath.Equals(request.PropertyName, StringComparison.OrdinalIgnoreCase))))
+            if (!isLeafElementUpdate && (!string.IsNullOrEmpty(request.CollectionKey) || collectionIndex > -1))
             {
-                response = HandleCollectionUpdate(target, propertyInfo, request);
+                response = HandleCollectionUpdate(target, propertyInfo, request, collectionIndex);
             }
             else
             {
@@ -313,7 +355,7 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
         return response;
     }
 
-    private SampleApp.ViewModels.Protos.UpdatePropertyValueResponse HandleCollectionUpdate(object target, System.Reflection.PropertyInfo propertyInfo, SampleApp.ViewModels.Protos.UpdatePropertyValueRequest request)
+    private SampleApp.ViewModels.Protos.UpdatePropertyValueResponse HandleCollectionUpdate(object target, System.Reflection.PropertyInfo propertyInfo, SampleApp.ViewModels.Protos.UpdatePropertyValueRequest request, int arrayIndex)
     {
         var response = new SampleApp.ViewModels.Protos.UpdatePropertyValueResponse();
         
@@ -355,12 +397,12 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             Debug.WriteLine($"[GrpcService:SampleViewModel] Updated dictionary key '{convertedKey.Value}' to '{convertedValue.Value}'");
         }
         // Handle list/array element replacement updates
-        else if (collection is System.Collections.IList list && request.ArrayIndex > -1)
+        else if (collection is System.Collections.IList list && arrayIndex > -1)
         {
-            if (request.ArrayIndex >= list.Count)
+            if (arrayIndex >= list.Count)
             {
                 response.Success = false;
-                response.ErrorMessage = $"Array index {request.ArrayIndex} is out of bounds (count: {list.Count})";
+                response.ErrorMessage = $"Array index {arrayIndex} is out of bounds (count: {list.Count})";
                 return response;
             }
             
@@ -375,11 +417,11 @@ public partial class SampleViewModelGrpcServiceImpl : CounterService.CounterServ
             }
             
             // Store old value
-            response.OldValue = PackToAny(list[request.ArrayIndex]);
-            
-            list[request.ArrayIndex] = convertedValue.Value;
+            response.OldValue = PackToAny(list[arrayIndex]);
+
+            list[arrayIndex] = convertedValue.Value;
             response.Success = true;
-            Debug.WriteLine($"[GrpcService:SampleViewModel] Updated array index {request.ArrayIndex} to '{convertedValue.Value}'");
+            Debug.WriteLine($"[GrpcService:SampleViewModel] Updated array index {arrayIndex} to '{convertedValue.Value}'");
         }
         else
         {

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
@@ -97,7 +97,6 @@ namespace SampleApp.ViewModels.RemoteClients
                 {
                     PropertyName = topLevel,
                     PropertyPath = propertyPath,
-                    ArrayIndex = -1,
                     ClientId = _clientId,
                     NewValue = PackValueToAny(value)
                 };
@@ -173,27 +172,50 @@ namespace SampleApp.ViewModels.RemoteClients
                 if (bracket >= 0)
                 {
                     var propName = part[..bracket];
-                    var end = part.IndexOf(']', bracket);
-                    if (end < 0) return;
-                    var indexStr = part[(bracket + 1)..end];
                     var prop = current?.GetType().GetProperty(propName);
-                    if (prop?.GetValue(current) is System.Collections.IList list && int.TryParse(indexStr, out int idx))
+                    current = prop?.GetValue(current);
+                    var remainder = part[bracket..];
+                    while (remainder.StartsWith("["))
                     {
-                        if (idx < 0 || idx >= list.Count) return;
-                        if (i == segments.Length - 1)
+                        var end = remainder.IndexOf(']', 1);
+                        if (end < 0) return;
+                        var indexStr = remainder[1..end];
+                        remainder = remainder[(end + 1)..];
+
+                        if (current is System.Collections.IList list && int.TryParse(indexStr, out int idx))
                         {
-                            list[idx] = newValue;
-                            if (target is SampleViewModelRemoteClient rc)
+                            if (idx < 0 || idx >= list.Count) return;
+                            if (i == segments.Length - 1 && remainder.Length == 0)
                             {
-                                rc.AttachLocalPropertyChangedHandlers(list[idx], path);
+                                list[idx] = newValue;
+                                if (target is SampleViewModelRemoteClient rc)
+                                {
+                                    rc.AttachLocalPropertyChangedHandlers(list[idx], path);
+                                }
+                                return;
                             }
+                            current = list[idx];
+                        }
+                        else if (current is System.Collections.IDictionary dict)
+                        {
+                            var key = indexStr;
+                            if (i == segments.Length - 1 && remainder.Length == 0)
+                            {
+                                dict[key] = newValue;
+                                if (target is SampleViewModelRemoteClient rc)
+                                {
+                                    rc.AttachLocalPropertyChangedHandlers(newValue, path);
+                                }
+                                return;
+                            }
+                            current = dict[key];
+                        }
+                        else
+                        {
                             return;
                         }
-                        current = list[idx];
-                    }
-                    else
-                    {
-                        return;
+
+                        if (current == null) return;
                     }
                 }
                 else

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.ts
@@ -67,7 +67,6 @@ export class SampleViewModelRemoteClient {
     async updatePropertyValue(propertyName: string, value: any): Promise<UpdatePropertyValueResponse> {
         const req = new UpdatePropertyValueRequest();
         req.setPropertyName(propertyName);
-        req.setArrayIndex(-1); // Default to -1 for non-array properties
         req.setNewValue(this.createAnyValue(value));
         const response = await this.grpcClient.updatePropertyValue(req);
         
@@ -109,7 +108,6 @@ export class SampleViewModelRemoteClient {
         options?: {
             propertyPath?: string;
             collectionKey?: string;
-            arrayIndex?: number;
             operationType?: 'set' | 'add' | 'remove' | 'clear' | 'insert';
         }
     ): Promise<UpdatePropertyValueResponse> {
@@ -119,7 +117,6 @@ export class SampleViewModelRemoteClient {
         
         if (options?.propertyPath) req.setPropertyPath(options.propertyPath);
         if (options?.collectionKey) req.setCollectionKey(options.collectionKey);
-        if (options?.arrayIndex !== undefined) req.setArrayIndex(options.arrayIndex);
         if (options?.operationType) req.setOperationType(options.operationType);
         
         const response = await this.grpcClient.updatePropertyValue(req);

--- a/test/SampleViewModel/expected/SampleViewModelService.proto
+++ b/test/SampleViewModel/expected/SampleViewModelService.proto
@@ -22,10 +22,9 @@ message UpdatePropertyValueRequest {
   google.protobuf.Any new_value = 2;
   // Optional fields for complex property updates
   string property_path = 3;          // For nested properties like "User.Address.Street"
-  string collection_key = 4;         // For dictionary keys or array indices
-  int32 array_index = 5;             // For updating specific array elements
-  string operation_type = 6;         // "set", "add", "remove", "clear", "insert"
-  string client_id = 7;             // Originating client identifier
+  string collection_key = 4;         // For dictionary keys
+  string operation_type = 5;         // "set", "add", "remove", "clear", "insert"
+  string client_id = 6;             // Originating client identifier
 }
 
 message UpdatePropertyValueResponse {


### PR DESCRIPTION
## Summary
- extend property-path parsing to handle nested dictionary keys and multi-level indexes
- regenerate expected client/server outputs
- document dictionary key access using bracket notation

## Testing
- ✅ `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c5ecc834b4832097b01ff4ff18f891