### PR TITLE
Add ViewModel serialization for WPF and WinForms

### DIFF
--- a/src/RemoteMvvmTool/Generators/WinFormsClientUIGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/WinFormsClientUIGenerator.cs
@@ -92,6 +92,8 @@ public class WinFormsClientUIGenerator : UIGeneratorBase
         sb.AppendLine("                refreshBtn.Click += (_, __) => LoadTree();");
         sb.AppendLine("                expandBtn.Click += (_, __) => tree.ExpandAll();");
         sb.AppendLine("                collapseBtn.Click += (_, __) => tree.CollapseAll();");
+        sb.AppendLine("                saveBtn.Click += (_, __) => SaveViewModel(vm);");
+        sb.AppendLine("                loadBtn.Click += (_, __) => { LoadViewModel(vm); LoadTree(); };");
         sb.AppendLine();
         sb.AppendLine("                tree.AfterSelect += (_, e) =>");
         sb.AppendLine("                {");
@@ -247,7 +249,40 @@ public class WinFormsClientUIGenerator : UIGeneratorBase
         sb.AppendLine("                detailLayout.RowCount = 1;");
         sb.AppendLine("            }");
         sb.AppendLine("        }");
-        
+
+        sb.AppendLine();
+        sb.AppendLine("        private static void SaveViewModel(object vm)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            using var dlg = new SaveFileDialog { Filter = \"ViewModel State (*.bin)|*.bin|All Files (*.*)|*.*\" };");
+        sb.AppendLine("            if (dlg.ShowDialog() == DialogResult.OK)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                try");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    vm.GetType().GetMethod(\"SaveToFile\")?.Invoke(vm, new object[] { dlg.FileName });");
+        sb.AppendLine("                }");
+        sb.AppendLine("                catch (Exception ex)");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    MessageBox.Show($\"Error saving view model: {ex.Message}\", \"Save Error\", MessageBoxButtons.OK, MessageBoxIcon.Error);");
+        sb.AppendLine("                }");
+        sb.AppendLine("            }");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+        sb.AppendLine("        private static void LoadViewModel(object vm)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            using var dlg = new OpenFileDialog { Filter = \"ViewModel State (*.bin)|*.bin|All Files (*.*)|*.*\" };");
+        sb.AppendLine("            if (dlg.ShowDialog() == DialogResult.OK)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                try");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    vm.GetType().GetMethod(\"LoadFromFile\")?.Invoke(vm, new object[] { dlg.FileName });");
+        sb.AppendLine("                }");
+        sb.AppendLine("                catch (Exception ex)");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    MessageBox.Show($\"Error loading view model: {ex.Message}\", \"Load Error\", MessageBoxButtons.OK, MessageBoxIcon.Error);");
+        sb.AppendLine("                }");
+        sb.AppendLine("            }");
+        sb.AppendLine("        }");
+
         sb.AppendLine("    }");
         sb.AppendLine("}");
         return sb.ToString();
@@ -260,6 +295,8 @@ public class WinFormsClientUIGenerator : UIGeneratorBase
         root.Children.Add(new ButtonComponent("refreshBtn", "Refresh"));
         root.Children.Add(new ButtonComponent("expandBtn", "Expand All"));
         root.Children.Add(new ButtonComponent("collapseBtn", "Collapse"));
+        root.Children.Add(new ButtonComponent("saveBtn", "Save"));
+        root.Children.Add(new ButtonComponent("loadBtn", "Load"));
         return root;
     }
 

--- a/src/RemoteMvvmTool/Generators/WinFormsServerUIGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/WinFormsServerUIGenerator.cs
@@ -86,6 +86,8 @@ public class WinFormsServerUIGenerator : UIGeneratorBase
         sb.AppendLine("                refreshBtn.Click += (_, __) => LoadTree();");
         sb.AppendLine("                expandBtn.Click += (_, __) => tree.ExpandAll();");
         sb.AppendLine("                collapseBtn.Click += (_, __) => tree.CollapseAll();");
+        sb.AppendLine("                saveBtn.Click += (_, __) => SaveViewModel(vm);");
+        sb.AppendLine("                loadBtn.Click += (_, __) => { LoadViewModel(vm); LoadTree(); UpdateServerStatus(); };");
         sb.AppendLine();
         sb.AppendLine("                tree.AfterSelect += (_, e) =>");
         sb.AppendLine("                {");
@@ -148,7 +150,40 @@ public class WinFormsServerUIGenerator : UIGeneratorBase
         sb.AppendLine();
         sb.AppendLine("            detailLayout.RowCount = row;");
         sb.AppendLine("        }");
-        
+
+        sb.AppendLine();
+        sb.AppendLine("        private static void SaveViewModel(object vm)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            using var dlg = new SaveFileDialog { Filter = \"ViewModel State (*.bin)|*.bin|All Files (*.*)|*.*\" };");
+        sb.AppendLine("            if (dlg.ShowDialog() == DialogResult.OK)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                try");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    vm.GetType().GetMethod(\"SaveToFile\")?.Invoke(vm, new object[] { dlg.FileName });");
+        sb.AppendLine("                }");
+        sb.AppendLine("                catch (Exception ex)");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    MessageBox.Show($\"Error saving view model: {ex.Message}\", \"Save Error\", MessageBoxButtons.OK, MessageBoxIcon.Error);");
+        sb.AppendLine("                }");
+        sb.AppendLine("            }");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+        sb.AppendLine("        private static void LoadViewModel(object vm)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            using var dlg = new OpenFileDialog { Filter = \"ViewModel State (*.bin)|*.bin|All Files (*.*)|*.*\" };");
+        sb.AppendLine("            if (dlg.ShowDialog() == DialogResult.OK)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                try");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    vm.GetType().GetMethod(\"LoadFromFile\")?.Invoke(vm, new object[] { dlg.FileName });");
+        sb.AppendLine("                }");
+        sb.AppendLine("                catch (Exception ex)");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    MessageBox.Show($\"Error loading view model: {ex.Message}\", \"Load Error\", MessageBoxButtons.OK, MessageBoxIcon.Error);");
+        sb.AppendLine("                }");
+        sb.AppendLine("            }");
+        sb.AppendLine("        }");
+
         sb.AppendLine("    }");
         sb.AppendLine("}");
         return sb.ToString();
@@ -161,6 +196,8 @@ public class WinFormsServerUIGenerator : UIGeneratorBase
         root.Children.Add(new ButtonComponent("refreshBtn", "Refresh"));
         root.Children.Add(new ButtonComponent("expandBtn", "Expand All"));
         root.Children.Add(new ButtonComponent("collapseBtn", "Collapse"));
+        root.Children.Add(new ButtonComponent("saveBtn", "Save"));
+        root.Children.Add(new ButtonComponent("loadBtn", "Load"));
         return root;
     }
 

--- a/src/RemoteMvvmTool/Generators/WpfClientUIGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/WpfClientUIGenerator.cs
@@ -81,6 +81,8 @@ public class WpfClientUIGenerator : UIGeneratorBase
         sb.AppendLine("using System.Linq;");
         sb.AppendLine("using System.Windows;");
         sb.AppendLine("using System.Windows.Controls;");
+        sb.AppendLine("using System.Reflection;");
+        sb.AppendLine("using Microsoft.Win32;");
         sb.AppendLine("using Generated.Clients;");
         sb.AppendLine();
         sb.AppendLine("namespace GuiClientApp");
@@ -105,6 +107,8 @@ public class WpfClientUIGenerator : UIGeneratorBase
         sb.AppendLine("            RefreshBtn.Click += (_, __) => LoadTree();");
         sb.AppendLine("            ExpandAllBtn.Click += (_, __) => ExpandAll(PropertyTreeView);");
         sb.AppendLine("            CollapseAllBtn.Click += (_, __) => CollapseAll(PropertyTreeView);");
+        sb.AppendLine("            SaveBtn.Click += (_, __) => SaveViewModel();");
+        sb.AppendLine("            LoadBtn.Click += (_, __) => LoadViewModel();");
         sb.AppendLine();
         sb.AppendLine("            // Set up property change monitoring");
         sb.AppendLine("            if (_viewModel is INotifyPropertyChanged inpc)");
@@ -193,7 +197,41 @@ public class WpfClientUIGenerator : UIGeneratorBase
         sb.AppendLine("            }");
         sb.AppendLine("        }");
         sb.AppendLine();
-        
+
+        sb.AppendLine("        private void SaveViewModel()");
+        sb.AppendLine("        {");
+        sb.AppendLine("            var dlg = new SaveFileDialog { Filter = \"ViewModel State (*.bin)|*.bin|All Files (*.*)|*.*\" };");
+        sb.AppendLine("            if (dlg.ShowDialog() == true)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                try");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    _viewModel.GetType().GetMethod(\"SaveToFile\")?.Invoke(_viewModel, new object[] { dlg.FileName });");
+        sb.AppendLine("                }");
+        sb.AppendLine("                catch (Exception ex)");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    MessageBox.Show($\"Error saving view model: {ex.Message}\", \"Save Error\");");
+        sb.AppendLine("                }");
+        sb.AppendLine("            }");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+        sb.AppendLine("        private void LoadViewModel()");
+        sb.AppendLine("        {");
+        sb.AppendLine("            var dlg = new OpenFileDialog { Filter = \"ViewModel State (*.bin)|*.bin|All Files (*.*)|*.*\" };");
+        sb.AppendLine("            if (dlg.ShowDialog() == true)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                try");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    _viewModel.GetType().GetMethod(\"LoadFromFile\")?.Invoke(_viewModel, new object[] { dlg.FileName });");
+        sb.AppendLine("                    LoadTree();");
+        sb.AppendLine("                }");
+        sb.AppendLine("                catch (Exception ex)");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    MessageBox.Show($\"Error loading view model: {ex.Message}\", \"Load Error\");");
+        sb.AppendLine("                }");
+        sb.AppendLine("            }");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+
         // Helper methods
         sb.AppendLine("        private void ExpandAll(ItemsControl control)");
         sb.AppendLine("        {");
@@ -388,6 +426,8 @@ public class WpfClientUIGenerator : UIGeneratorBase
         root.Children.Add(new ButtonComponent("RefreshBtn", "Refresh"));
         root.Children.Add(new ButtonComponent("ExpandAllBtn", "Expand All"));
         root.Children.Add(new ButtonComponent("CollapseAllBtn", "Collapse"));
+        root.Children.Add(new ButtonComponent("SaveBtn", "Save"));
+        root.Children.Add(new ButtonComponent("LoadBtn", "Load"));
         return root;
     }
 

--- a/src/RemoteMvvmTool/Generators/WpfServerUIGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/WpfServerUIGenerator.cs
@@ -74,6 +74,8 @@ public class WpfServerUIGenerator : UIGeneratorBase
         sb.AppendLine("using System.Linq;");
         sb.AppendLine("using System.Windows;");
         sb.AppendLine("using System.Windows.Controls;");
+        sb.AppendLine("using System.Reflection;");
+        sb.AppendLine("using Microsoft.Win32;");
         sb.AppendLine();
         sb.AppendLine("namespace ServerApp");
         sb.AppendLine("{");
@@ -97,6 +99,8 @@ public class WpfServerUIGenerator : UIGeneratorBase
         sb.AppendLine("            RefreshBtn.Click += (_, __) => LoadTree();");
         sb.AppendLine("            ExpandAllBtn.Click += (_, __) => ExpandAll(PropertyTreeView);");
         sb.AppendLine("            CollapseAllBtn.Click += (_, __) => CollapseAll(PropertyTreeView);");
+        sb.AppendLine("            SaveBtn.Click += (_, __) => SaveViewModel();");
+        sb.AppendLine("            LoadBtn.Click += (_, __) => LoadViewModel();");
         sb.AppendLine();
         sb.AppendLine("            // Set up property change monitoring");
         sb.AppendLine("            if (_viewModel is INotifyPropertyChanged inpc)");
@@ -133,7 +137,42 @@ public class WpfServerUIGenerator : UIGeneratorBase
         // Generate the enhanced tree loading logic using framework-agnostic approach
         sb.Append("        " + GenerateFrameworkAgnosticTreeLogic("PropertyTreeView", "_viewModel").Replace("\n", "\n        "));
         sb.AppendLine();
-        
+
+        sb.AppendLine("        private void SaveViewModel()");
+        sb.AppendLine("        {");
+        sb.AppendLine("            var dlg = new SaveFileDialog { Filter = \"ViewModel State (*.bin)|*.bin|All Files (*.*)|*.*\" };");
+        sb.AppendLine("            if (dlg.ShowDialog() == true)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                try");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    _viewModel.GetType().GetMethod(\"SaveToFile\")?.Invoke(_viewModel, new object[] { dlg.FileName });");
+        sb.AppendLine("                }");
+        sb.AppendLine("                catch (Exception ex)");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    MessageBox.Show($\"Error saving view model: {ex.Message}\", \"Save Error\");");
+        sb.AppendLine("                }");
+        sb.AppendLine("            }");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+        sb.AppendLine("        private void LoadViewModel()");
+        sb.AppendLine("        {");
+        sb.AppendLine("            var dlg = new OpenFileDialog { Filter = \"ViewModel State (*.bin)|*.bin|All Files (*.*)|*.*\" };");
+        sb.AppendLine("            if (dlg.ShowDialog() == true)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                try");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    _viewModel.GetType().GetMethod(\"LoadFromFile\")?.Invoke(_viewModel, new object[] { dlg.FileName });");
+        sb.AppendLine("                    LoadTree();");
+        sb.AppendLine("                    UpdateServerStatus();");
+        sb.AppendLine("                }");
+        sb.AppendLine("                catch (Exception ex)");
+        sb.AppendLine("                {");
+        sb.AppendLine("                    MessageBox.Show($\"Error loading view model: {ex.Message}\", \"Load Error\");");
+        sb.AppendLine("                }");
+        sb.AppendLine("            }");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+
         // Server status update method
         sb.AppendLine("        private void UpdateServerStatus()");
         sb.AppendLine("        {");
@@ -357,6 +396,8 @@ public class WpfServerUIGenerator : UIGeneratorBase
         root.Children.Add(new ButtonComponent("RefreshBtn", "Refresh"));
         root.Children.Add(new ButtonComponent("ExpandAllBtn", "Expand All"));
         root.Children.Add(new ButtonComponent("CollapseAllBtn", "Collapse"));
+        root.Children.Add(new ButtonComponent("SaveBtn", "Save"));
+        root.Children.Add(new ButtonComponent("LoadBtn", "Load"));
         return root;
     }
 

--- a/test/SimpleViewModelTest/ViewModels/MainViewModel.Serialization.cs
+++ b/test/SimpleViewModelTest/ViewModels/MainViewModel.Serialization.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using System.Linq;
+using Generated.Protos;
+
+namespace SimpleViewModelTest.ViewModels;
+
+public partial class MainViewModel
+{
+    public void SaveToFile(string path)
+    {
+        var state = new MainViewModelState();
+        if (Devices != null)
+            state.Devices.AddRange(Devices.Where(d => d != null).Select(ProtoStateConverters.ToProto).Where(s => s != null));
+        using var fs = File.Create(path);
+        state.WriteTo(fs);
+    }
+
+    public void LoadFromFile(string path)
+    {
+        using var fs = File.OpenRead(path);
+        var state = MainViewModelState.Parser.ParseFrom(fs);
+        Devices = state.Devices.Select(ProtoStateConverters.FromProto).ToList();
+    }
+}

--- a/test/SimpleViewModelTest/ViewModels/generated/MainViewModelRemoteClient.Serialization.cs
+++ b/test/SimpleViewModelTest/ViewModels/generated/MainViewModelRemoteClient.Serialization.cs
@@ -1,0 +1,28 @@
+using System.IO;
+using System.Linq;
+using Generated.Protos;
+using SimpleViewModelTest.ViewModels;
+
+namespace SimpleViewModelTest.ViewModels.RemoteClients;
+
+public partial class MainViewModelRemoteClient
+{
+    public void SaveToFile(string path)
+    {
+        var state = new MainViewModelState();
+        if (Devices != null)
+            state.Devices.AddRange(Devices.Where(d => d != null).Select(ProtoStateConverters.ToProto).Where(s => s != null));
+        using var fs = File.Create(path);
+        state.WriteTo(fs);
+    }
+
+    public void LoadFromFile(string path)
+    {
+        using var fs = File.OpenRead(path);
+        var state = MainViewModelState.Parser.ParseFrom(fs);
+        _suppressLocalUpdates = true;
+        Devices = state.Devices.Select(ProtoStateConverters.FromProto).ToList();
+        _suppressLocalUpdates = false;
+        UpdatePropertyValueAsync(nameof(Devices), Devices).GetAwaiter().GetResult();
+    }
+}


### PR DESCRIPTION
## Summary
- extend WPF client/server generators with Save/Load buttons and handlers
- add WinForms client/server serialization hooks
- provide partial classes to save and load ViewModel state via protobuf

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c60441a954832089ece78ae2946514