### PR TITLE
feat: add partial change hooks in generated clients

### DIFF
--- a/test/GameViewModel/expected/GameViewModelRemoteClient.cs
+++ b/test/GameViewModel/expected/GameViewModelRemoteClient.cs
@@ -42,12 +42,19 @@ namespace MonsterClicker.ViewModels.RemoteClients
             get => _monsterName;
             set
             {
-                if (SetProperty(ref _monsterName, value) && _isInitialized)
+                var oldValue = _monsterName;
+                if (SetProperty(ref _monsterName, value))
                 {
-                    _ = UpdatePropertyValueAsync("MonsterName", value);
+                    OnMonsterNameChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("MonsterName", value);
+                    }
                 }
             }
         }
+
+        partial void OnMonsterNameChanged(string oldValue, string newValue);
 
         private int _monsterMaxHealth = default!;
         public int MonsterMaxHealth
@@ -55,12 +62,19 @@ namespace MonsterClicker.ViewModels.RemoteClients
             get => _monsterMaxHealth;
             set
             {
-                if (SetProperty(ref _monsterMaxHealth, value) && _isInitialized)
+                var oldValue = _monsterMaxHealth;
+                if (SetProperty(ref _monsterMaxHealth, value))
                 {
-                    _ = UpdatePropertyValueAsync("MonsterMaxHealth", value);
+                    OnMonsterMaxHealthChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("MonsterMaxHealth", value);
+                    }
                 }
             }
         }
+
+        partial void OnMonsterMaxHealthChanged(int oldValue, int newValue);
 
         private int _monsterCurrentHealth = default!;
         public int MonsterCurrentHealth
@@ -68,12 +82,19 @@ namespace MonsterClicker.ViewModels.RemoteClients
             get => _monsterCurrentHealth;
             set
             {
-                if (SetProperty(ref _monsterCurrentHealth, value) && _isInitialized)
+                var oldValue = _monsterCurrentHealth;
+                if (SetProperty(ref _monsterCurrentHealth, value))
                 {
-                    _ = UpdatePropertyValueAsync("MonsterCurrentHealth", value);
+                    OnMonsterCurrentHealthChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("MonsterCurrentHealth", value);
+                    }
                 }
             }
         }
+
+        partial void OnMonsterCurrentHealthChanged(int oldValue, int newValue);
 
         private int _playerDamage = default!;
         public int PlayerDamage
@@ -81,12 +102,19 @@ namespace MonsterClicker.ViewModels.RemoteClients
             get => _playerDamage;
             set
             {
-                if (SetProperty(ref _playerDamage, value) && _isInitialized)
+                var oldValue = _playerDamage;
+                if (SetProperty(ref _playerDamage, value))
                 {
-                    _ = UpdatePropertyValueAsync("PlayerDamage", value);
+                    OnPlayerDamageChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("PlayerDamage", value);
+                    }
                 }
             }
         }
+
+        partial void OnPlayerDamageChanged(int oldValue, int newValue);
 
         private string _gameMessage = default!;
         public string GameMessage
@@ -94,12 +122,19 @@ namespace MonsterClicker.ViewModels.RemoteClients
             get => _gameMessage;
             set
             {
-                if (SetProperty(ref _gameMessage, value) && _isInitialized)
+                var oldValue = _gameMessage;
+                if (SetProperty(ref _gameMessage, value))
                 {
-                    _ = UpdatePropertyValueAsync("GameMessage", value);
+                    OnGameMessageChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("GameMessage", value);
+                    }
                 }
             }
         }
+
+        partial void OnGameMessageChanged(string oldValue, string newValue);
 
         private bool _isMonsterDefeated = default!;
         public bool IsMonsterDefeated
@@ -107,12 +142,19 @@ namespace MonsterClicker.ViewModels.RemoteClients
             get => _isMonsterDefeated;
             set
             {
-                if (SetProperty(ref _isMonsterDefeated, value) && _isInitialized)
+                var oldValue = _isMonsterDefeated;
+                if (SetProperty(ref _isMonsterDefeated, value))
                 {
-                    _ = UpdatePropertyValueAsync("IsMonsterDefeated", value);
+                    OnIsMonsterDefeatedChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("IsMonsterDefeated", value);
+                    }
                 }
             }
         }
+
+        partial void OnIsMonsterDefeatedChanged(bool oldValue, bool newValue);
 
         private bool _canUseSpecialAttack = default!;
         public bool CanUseSpecialAttack
@@ -120,12 +162,19 @@ namespace MonsterClicker.ViewModels.RemoteClients
             get => _canUseSpecialAttack;
             set
             {
-                if (SetProperty(ref _canUseSpecialAttack, value) && _isInitialized)
+                var oldValue = _canUseSpecialAttack;
+                if (SetProperty(ref _canUseSpecialAttack, value))
                 {
-                    _ = UpdatePropertyValueAsync("CanUseSpecialAttack", value);
+                    OnCanUseSpecialAttackChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("CanUseSpecialAttack", value);
+                    }
                 }
             }
         }
+
+        partial void OnCanUseSpecialAttackChanged(bool oldValue, bool newValue);
 
         private bool _isSpecialAttackOnCooldown = default!;
         public bool IsSpecialAttackOnCooldown
@@ -133,12 +182,19 @@ namespace MonsterClicker.ViewModels.RemoteClients
             get => _isSpecialAttackOnCooldown;
             set
             {
-                if (SetProperty(ref _isSpecialAttackOnCooldown, value) && _isInitialized)
+                var oldValue = _isSpecialAttackOnCooldown;
+                if (SetProperty(ref _isSpecialAttackOnCooldown, value))
                 {
-                    _ = UpdatePropertyValueAsync("IsSpecialAttackOnCooldown", value);
+                    OnIsSpecialAttackOnCooldownChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("IsSpecialAttackOnCooldown", value);
+                    }
                 }
             }
         }
+
+        partial void OnIsSpecialAttackOnCooldownChanged(bool oldValue, bool newValue);
 
         public IRelayCommand AttackMonsterCommand { get; }
         public IAsyncRelayCommand SpecialAttackCommand { get; }

--- a/test/PointerTestModel/RemoteGenerated/PointerViewModelRemoteClient.cs
+++ b/test/PointerTestModel/RemoteGenerated/PointerViewModelRemoteClient.cs
@@ -42,12 +42,19 @@ namespace HPSystemsTools.RemoteClients
             get => _show;
             set
             {
-                if (SetProperty(ref _show, value) && _isInitialized)
+                var oldValue = _show;
+                if (SetProperty(ref _show, value))
                 {
-                    _ = UpdatePropertyValueAsync("Show", value);
+                    OnShowChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("Show", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowChanged(bool oldValue, bool newValue);
 
         private bool _showSpinner = default!;
         public bool ShowSpinner
@@ -55,12 +62,19 @@ namespace HPSystemsTools.RemoteClients
             get => _showSpinner;
             set
             {
-                if (SetProperty(ref _showSpinner, value) && _isInitialized)
+                var oldValue = _showSpinner;
+                if (SetProperty(ref _showSpinner, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowSpinner", value);
+                    OnShowSpinnerChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowSpinner", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowSpinnerChanged(bool oldValue, bool newValue);
 
         private int _clicksToPass = default!;
         public int ClicksToPass
@@ -68,12 +82,19 @@ namespace HPSystemsTools.RemoteClients
             get => _clicksToPass;
             set
             {
-                if (SetProperty(ref _clicksToPass, value) && _isInitialized)
+                var oldValue = _clicksToPass;
+                if (SetProperty(ref _clicksToPass, value))
                 {
-                    _ = UpdatePropertyValueAsync("ClicksToPass", value);
+                    OnClicksToPassChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ClicksToPass", value);
+                    }
                 }
             }
         }
+
+        partial void OnClicksToPassChanged(int oldValue, int newValue);
 
         private bool _is3Btn = default!;
         public bool Is3Btn
@@ -81,12 +102,19 @@ namespace HPSystemsTools.RemoteClients
             get => _is3Btn;
             set
             {
-                if (SetProperty(ref _is3Btn, value) && _isInitialized)
+                var oldValue = _is3Btn;
+                if (SetProperty(ref _is3Btn, value))
                 {
-                    _ = UpdatePropertyValueAsync("Is3Btn", value);
+                    OnIs3BtnChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("Is3Btn", value);
+                    }
                 }
             }
         }
+
+        partial void OnIs3BtnChanged(bool oldValue, bool newValue);
 
         private int _testTimeoutSec = default!;
         public int TestTimeoutSec
@@ -94,12 +122,19 @@ namespace HPSystemsTools.RemoteClients
             get => _testTimeoutSec;
             set
             {
-                if (SetProperty(ref _testTimeoutSec, value) && _isInitialized)
+                var oldValue = _testTimeoutSec;
+                if (SetProperty(ref _testTimeoutSec, value))
                 {
-                    _ = UpdatePropertyValueAsync("TestTimeoutSec", value);
+                    OnTestTimeoutSecChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("TestTimeoutSec", value);
+                    }
                 }
             }
         }
+
+        partial void OnTestTimeoutSecChanged(int oldValue, int newValue);
 
         private string _instructions = default!;
         public string Instructions
@@ -107,12 +142,19 @@ namespace HPSystemsTools.RemoteClients
             get => _instructions;
             set
             {
-                if (SetProperty(ref _instructions, value) && _isInitialized)
+                var oldValue = _instructions;
+                if (SetProperty(ref _instructions, value))
                 {
-                    _ = UpdatePropertyValueAsync("Instructions", value);
+                    OnInstructionsChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("Instructions", value);
+                    }
                 }
             }
         }
+
+        partial void OnInstructionsChanged(string oldValue, string newValue);
 
         private bool _showCursorTest = default!;
         public bool ShowCursorTest
@@ -120,12 +162,19 @@ namespace HPSystemsTools.RemoteClients
             get => _showCursorTest;
             set
             {
-                if (SetProperty(ref _showCursorTest, value) && _isInitialized)
+                var oldValue = _showCursorTest;
+                if (SetProperty(ref _showCursorTest, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowCursorTest", value);
+                    OnShowCursorTestChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowCursorTest", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowCursorTestChanged(bool oldValue, bool newValue);
 
         private bool _showConfigSelection = default!;
         public bool ShowConfigSelection
@@ -133,12 +182,19 @@ namespace HPSystemsTools.RemoteClients
             get => _showConfigSelection;
             set
             {
-                if (SetProperty(ref _showConfigSelection, value) && _isInitialized)
+                var oldValue = _showConfigSelection;
+                if (SetProperty(ref _showConfigSelection, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowConfigSelection", value);
+                    OnShowConfigSelectionChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowConfigSelection", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowConfigSelectionChanged(bool oldValue, bool newValue);
 
         private bool _showClickInstructions = default!;
         public bool ShowClickInstructions
@@ -146,12 +202,19 @@ namespace HPSystemsTools.RemoteClients
             get => _showClickInstructions;
             set
             {
-                if (SetProperty(ref _showClickInstructions, value) && _isInitialized)
+                var oldValue = _showClickInstructions;
+                if (SetProperty(ref _showClickInstructions, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowClickInstructions", value);
+                    OnShowClickInstructionsChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowClickInstructions", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowClickInstructionsChanged(bool oldValue, bool newValue);
 
         private bool _showTimer = default!;
         public bool ShowTimer
@@ -159,12 +222,19 @@ namespace HPSystemsTools.RemoteClients
             get => _showTimer;
             set
             {
-                if (SetProperty(ref _showTimer, value) && _isInitialized)
+                var oldValue = _showTimer;
+                if (SetProperty(ref _showTimer, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowTimer", value);
+                    OnShowTimerChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowTimer", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowTimerChanged(bool oldValue, bool newValue);
 
         private bool _showBottom = default!;
         public bool ShowBottom
@@ -172,12 +242,19 @@ namespace HPSystemsTools.RemoteClients
             get => _showBottom;
             set
             {
-                if (SetProperty(ref _showBottom, value) && _isInitialized)
+                var oldValue = _showBottom;
+                if (SetProperty(ref _showBottom, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowBottom", value);
+                    OnShowBottomChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowBottom", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowBottomChanged(bool oldValue, bool newValue);
 
         private string _timerText = default!;
         public string TimerText
@@ -185,12 +262,19 @@ namespace HPSystemsTools.RemoteClients
             get => _timerText;
             set
             {
-                if (SetProperty(ref _timerText, value) && _isInitialized)
+                var oldValue = _timerText;
+                if (SetProperty(ref _timerText, value))
                 {
-                    _ = UpdatePropertyValueAsync("TimerText", value);
+                    OnTimerTextChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("TimerText", value);
+                    }
                 }
             }
         }
+
+        partial void OnTimerTextChanged(string oldValue, string newValue);
 
         private string _selectedDevice = default!;
         public string SelectedDevice
@@ -198,12 +282,19 @@ namespace HPSystemsTools.RemoteClients
             get => _selectedDevice;
             set
             {
-                if (SetProperty(ref _selectedDevice, value) && _isInitialized)
+                var oldValue = _selectedDevice;
+                if (SetProperty(ref _selectedDevice, value))
                 {
-                    _ = UpdatePropertyValueAsync("SelectedDevice", value);
+                    OnSelectedDeviceChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("SelectedDevice", value);
+                    }
                 }
             }
         }
+
+        partial void OnSelectedDeviceChanged(string oldValue, string newValue);
 
         private int _lastClickCount = default!;
         public int LastClickCount
@@ -211,12 +302,19 @@ namespace HPSystemsTools.RemoteClients
             get => _lastClickCount;
             set
             {
-                if (SetProperty(ref _lastClickCount, value) && _isInitialized)
+                var oldValue = _lastClickCount;
+                if (SetProperty(ref _lastClickCount, value))
                 {
-                    _ = UpdatePropertyValueAsync("LastClickCount", value);
+                    OnLastClickCountChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("LastClickCount", value);
+                    }
                 }
             }
         }
+
+        partial void OnLastClickCountChanged(int oldValue, int newValue);
 
         public IRelayCommand InitializeCommand { get; }
         public IRelayCommand OnCursorTestCommand { get; }

--- a/test/PointerTestModel/expected/PointerViewModelRemoteClient.cs
+++ b/test/PointerTestModel/expected/PointerViewModelRemoteClient.cs
@@ -42,12 +42,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _show;
             set
             {
-                if (SetProperty(ref _show, value) && _isInitialized)
+                var oldValue = _show;
+                if (SetProperty(ref _show, value))
                 {
-                    _ = UpdatePropertyValueAsync("Show", value);
+                    OnShowChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("Show", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowChanged(bool oldValue, bool newValue);
 
         private bool _showSpinner = default!;
         public bool ShowSpinner
@@ -55,12 +62,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _showSpinner;
             set
             {
-                if (SetProperty(ref _showSpinner, value) && _isInitialized)
+                var oldValue = _showSpinner;
+                if (SetProperty(ref _showSpinner, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowSpinner", value);
+                    OnShowSpinnerChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowSpinner", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowSpinnerChanged(bool oldValue, bool newValue);
 
         private int _clicksToPass = default!;
         public int ClicksToPass
@@ -68,12 +82,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _clicksToPass;
             set
             {
-                if (SetProperty(ref _clicksToPass, value) && _isInitialized)
+                var oldValue = _clicksToPass;
+                if (SetProperty(ref _clicksToPass, value))
                 {
-                    _ = UpdatePropertyValueAsync("ClicksToPass", value);
+                    OnClicksToPassChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ClicksToPass", value);
+                    }
                 }
             }
         }
+
+        partial void OnClicksToPassChanged(int oldValue, int newValue);
 
         private bool _is3Btn = default!;
         public bool Is3Btn
@@ -81,12 +102,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _is3Btn;
             set
             {
-                if (SetProperty(ref _is3Btn, value) && _isInitialized)
+                var oldValue = _is3Btn;
+                if (SetProperty(ref _is3Btn, value))
                 {
-                    _ = UpdatePropertyValueAsync("Is3Btn", value);
+                    OnIs3BtnChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("Is3Btn", value);
+                    }
                 }
             }
         }
+
+        partial void OnIs3BtnChanged(bool oldValue, bool newValue);
 
         private int _testTimeoutSec = default!;
         public int TestTimeoutSec
@@ -94,12 +122,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _testTimeoutSec;
             set
             {
-                if (SetProperty(ref _testTimeoutSec, value) && _isInitialized)
+                var oldValue = _testTimeoutSec;
+                if (SetProperty(ref _testTimeoutSec, value))
                 {
-                    _ = UpdatePropertyValueAsync("TestTimeoutSec", value);
+                    OnTestTimeoutSecChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("TestTimeoutSec", value);
+                    }
                 }
             }
         }
+
+        partial void OnTestTimeoutSecChanged(int oldValue, int newValue);
 
         private string _instructions = default!;
         public string Instructions
@@ -107,12 +142,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _instructions;
             set
             {
-                if (SetProperty(ref _instructions, value) && _isInitialized)
+                var oldValue = _instructions;
+                if (SetProperty(ref _instructions, value))
                 {
-                    _ = UpdatePropertyValueAsync("Instructions", value);
+                    OnInstructionsChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("Instructions", value);
+                    }
                 }
             }
         }
+
+        partial void OnInstructionsChanged(string oldValue, string newValue);
 
         private bool _showCursorTest = default!;
         public bool ShowCursorTest
@@ -120,12 +162,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _showCursorTest;
             set
             {
-                if (SetProperty(ref _showCursorTest, value) && _isInitialized)
+                var oldValue = _showCursorTest;
+                if (SetProperty(ref _showCursorTest, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowCursorTest", value);
+                    OnShowCursorTestChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowCursorTest", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowCursorTestChanged(bool oldValue, bool newValue);
 
         private bool _showConfigSelection = default!;
         public bool ShowConfigSelection
@@ -133,12 +182,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _showConfigSelection;
             set
             {
-                if (SetProperty(ref _showConfigSelection, value) && _isInitialized)
+                var oldValue = _showConfigSelection;
+                if (SetProperty(ref _showConfigSelection, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowConfigSelection", value);
+                    OnShowConfigSelectionChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowConfigSelection", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowConfigSelectionChanged(bool oldValue, bool newValue);
 
         private bool _showClickInstructions = default!;
         public bool ShowClickInstructions
@@ -146,12 +202,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _showClickInstructions;
             set
             {
-                if (SetProperty(ref _showClickInstructions, value) && _isInitialized)
+                var oldValue = _showClickInstructions;
+                if (SetProperty(ref _showClickInstructions, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowClickInstructions", value);
+                    OnShowClickInstructionsChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowClickInstructions", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowClickInstructionsChanged(bool oldValue, bool newValue);
 
         private bool _showTimer = default!;
         public bool ShowTimer
@@ -159,12 +222,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _showTimer;
             set
             {
-                if (SetProperty(ref _showTimer, value) && _isInitialized)
+                var oldValue = _showTimer;
+                if (SetProperty(ref _showTimer, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowTimer", value);
+                    OnShowTimerChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowTimer", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowTimerChanged(bool oldValue, bool newValue);
 
         private bool _showBottom = default!;
         public bool ShowBottom
@@ -172,12 +242,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _showBottom;
             set
             {
-                if (SetProperty(ref _showBottom, value) && _isInitialized)
+                var oldValue = _showBottom;
+                if (SetProperty(ref _showBottom, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowBottom", value);
+                    OnShowBottomChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowBottom", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowBottomChanged(bool oldValue, bool newValue);
 
         private string _timerText = default!;
         public string TimerText
@@ -185,12 +262,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _timerText;
             set
             {
-                if (SetProperty(ref _timerText, value) && _isInitialized)
+                var oldValue = _timerText;
+                if (SetProperty(ref _timerText, value))
                 {
-                    _ = UpdatePropertyValueAsync("TimerText", value);
+                    OnTimerTextChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("TimerText", value);
+                    }
                 }
             }
         }
+
+        partial void OnTimerTextChanged(string oldValue, string newValue);
 
         private string _selectedDevice = default!;
         public string SelectedDevice
@@ -198,12 +282,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _selectedDevice;
             set
             {
-                if (SetProperty(ref _selectedDevice, value) && _isInitialized)
+                var oldValue = _selectedDevice;
+                if (SetProperty(ref _selectedDevice, value))
                 {
-                    _ = UpdatePropertyValueAsync("SelectedDevice", value);
+                    OnSelectedDeviceChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("SelectedDevice", value);
+                    }
                 }
             }
         }
+
+        partial void OnSelectedDeviceChanged(string oldValue, string newValue);
 
         private int _lastClickCount = default!;
         public int LastClickCount
@@ -211,12 +302,19 @@ namespace Pointer.ViewModels.RemoteClients
             get => _lastClickCount;
             set
             {
-                if (SetProperty(ref _lastClickCount, value) && _isInitialized)
+                var oldValue = _lastClickCount;
+                if (SetProperty(ref _lastClickCount, value))
                 {
-                    _ = UpdatePropertyValueAsync("LastClickCount", value);
+                    OnLastClickCountChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("LastClickCount", value);
+                    }
                 }
             }
         }
+
+        partial void OnLastClickCountChanged(int oldValue, int newValue);
 
         public IRelayCommand InitializeCommand { get; }
         public IRelayCommand OnCursorTestCommand { get; }

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
@@ -42,12 +42,19 @@ namespace SampleApp.ViewModels.RemoteClients
             get => _name;
             set
             {
-                if (SetProperty(ref _name, value) && _isInitialized)
+                var oldValue = _name;
+                if (SetProperty(ref _name, value))
                 {
-                    _ = UpdatePropertyValueAsync("Name", value);
+                    OnNameChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("Name", value);
+                    }
                 }
             }
         }
+
+        partial void OnNameChanged(string oldValue, string newValue);
 
         private int _count = default!;
         public int Count
@@ -55,12 +62,19 @@ namespace SampleApp.ViewModels.RemoteClients
             get => _count;
             set
             {
-                if (SetProperty(ref _count, value) && _isInitialized)
+                var oldValue = _count;
+                if (SetProperty(ref _count, value))
                 {
-                    _ = UpdatePropertyValueAsync("Count", value);
+                    OnCountChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("Count", value);
+                    }
                 }
             }
         }
+
+        partial void OnCountChanged(int oldValue, int newValue);
 
         public IRelayCommand IncrementCountCommand { get; }
         public IAsyncRelayCommand<int> DelayedIncrementCommand { get; }

--- a/test/SimpleViewModelTest/ViewModels/generated/MainViewModelRemoteClient.cs
+++ b/test/SimpleViewModelTest/ViewModels/generated/MainViewModelRemoteClient.cs
@@ -40,8 +40,17 @@ namespace SimpleViewModelTest.ViewModels.RemoteClients
         public System.Collections.Generic.List<SimpleViewModelTest.ViewModels.DeviceInfo> Devices
         {
             get => _devices;
-            private set => SetProperty(ref _devices, value);
+            private set
+            {
+                var oldValue = _devices;
+                if (SetProperty(ref _devices, value))
+                {
+                    OnDevicesChanged(oldValue, value);
+                }
+            }
         }
+
+        partial void OnDevicesChanged(System.Collections.Generic.List<SimpleViewModelTest.ViewModels.DeviceInfo> oldValue, System.Collections.Generic.List<SimpleViewModelTest.ViewModels.DeviceInfo> newValue);
 
         public IRelayCommand<SimpleViewModelTest.ViewModels.DeviceStatus> UpdateStatusCommand { get; }
 

--- a/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelRemoteClient.cs
+++ b/test/ThermalTest/ViewModels/generated/HP3LSThermalTestViewModelRemoteClient.cs
@@ -40,8 +40,17 @@ namespace HPSystemsTools.ViewModels.RemoteClients
         public string Instructions
         {
             get => _instructions;
-            private set => SetProperty(ref _instructions, value);
+            private set
+            {
+                var oldValue = _instructions;
+                if (SetProperty(ref _instructions, value))
+                {
+                    OnInstructionsChanged(oldValue, value);
+                }
+            }
         }
+
+        partial void OnInstructionsChanged(string oldValue, string newValue);
 
         private int _cpuTemperatureThreshold = default!;
         public int CpuTemperatureThreshold
@@ -49,12 +58,19 @@ namespace HPSystemsTools.ViewModels.RemoteClients
             get => _cpuTemperatureThreshold;
             set
             {
-                if (SetProperty(ref _cpuTemperatureThreshold, value) && _isInitialized)
+                var oldValue = _cpuTemperatureThreshold;
+                if (SetProperty(ref _cpuTemperatureThreshold, value))
                 {
-                    _ = UpdatePropertyValueAsync("CpuTemperatureThreshold", value);
+                    OnCpuTemperatureThresholdChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("CpuTemperatureThreshold", value);
+                    }
                 }
             }
         }
+
+        partial void OnCpuTemperatureThresholdChanged(int oldValue, int newValue);
 
         private int _cpuLoadThreshold = default!;
         public int CpuLoadThreshold
@@ -62,12 +78,19 @@ namespace HPSystemsTools.ViewModels.RemoteClients
             get => _cpuLoadThreshold;
             set
             {
-                if (SetProperty(ref _cpuLoadThreshold, value) && _isInitialized)
+                var oldValue = _cpuLoadThreshold;
+                if (SetProperty(ref _cpuLoadThreshold, value))
                 {
-                    _ = UpdatePropertyValueAsync("CpuLoadThreshold", value);
+                    OnCpuLoadThresholdChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("CpuLoadThreshold", value);
+                    }
                 }
             }
         }
+
+        partial void OnCpuLoadThresholdChanged(int oldValue, int newValue);
 
         private int _cpuLoadTimeSpan = default!;
         public int CpuLoadTimeSpan
@@ -75,26 +98,51 @@ namespace HPSystemsTools.ViewModels.RemoteClients
             get => _cpuLoadTimeSpan;
             set
             {
-                if (SetProperty(ref _cpuLoadTimeSpan, value) && _isInitialized)
+                var oldValue = _cpuLoadTimeSpan;
+                if (SetProperty(ref _cpuLoadTimeSpan, value))
                 {
-                    _ = UpdatePropertyValueAsync("CpuLoadTimeSpan", value);
+                    OnCpuLoadTimeSpanChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("CpuLoadTimeSpan", value);
+                    }
                 }
             }
         }
+
+        partial void OnCpuLoadTimeSpanChanged(int oldValue, int newValue);
 
         private HPSystemsTools.ViewModels.ZoneCollection _zones = default!;
         public HPSystemsTools.ViewModels.ZoneCollection Zones
         {
             get => _zones;
-            private set => SetProperty(ref _zones, value);
+            private set
+            {
+                var oldValue = _zones;
+                if (SetProperty(ref _zones, value))
+                {
+                    OnZonesChanged(oldValue, value);
+                }
+            }
         }
+
+        partial void OnZonesChanged(HPSystemsTools.ViewModels.ZoneCollection oldValue, HPSystemsTools.ViewModels.ZoneCollection newValue);
 
         private HPSystemsTools.Models.TestSettingsModel _testSettings = default!;
         public HPSystemsTools.Models.TestSettingsModel TestSettings
         {
             get => _testSettings;
-            private set => SetProperty(ref _testSettings, value);
+            private set
+            {
+                var oldValue = _testSettings;
+                if (SetProperty(ref _testSettings, value))
+                {
+                    OnTestSettingsChanged(oldValue, value);
+                }
+            }
         }
+
+        partial void OnTestSettingsChanged(HPSystemsTools.Models.TestSettingsModel oldValue, HPSystemsTools.Models.TestSettingsModel newValue);
 
         private bool _showDescription = default!;
         public bool ShowDescription
@@ -102,12 +150,19 @@ namespace HPSystemsTools.ViewModels.RemoteClients
             get => _showDescription;
             set
             {
-                if (SetProperty(ref _showDescription, value) && _isInitialized)
+                var oldValue = _showDescription;
+                if (SetProperty(ref _showDescription, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowDescription", value);
+                    OnShowDescriptionChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowDescription", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowDescriptionChanged(bool oldValue, bool newValue);
 
         private bool _showReadme = default!;
         public bool ShowReadme
@@ -115,12 +170,19 @@ namespace HPSystemsTools.ViewModels.RemoteClients
             get => _showReadme;
             set
             {
-                if (SetProperty(ref _showReadme, value) && _isInitialized)
+                var oldValue = _showReadme;
+                if (SetProperty(ref _showReadme, value))
                 {
-                    _ = UpdatePropertyValueAsync("ShowReadme", value);
+                    OnShowReadmeChanged(oldValue, value);
+                    if (_isInitialized)
+                    {
+                        _ = UpdatePropertyValueAsync("ShowReadme", value);
+                    }
                 }
             }
         }
+
+        partial void OnShowReadmeChanged(bool oldValue, bool newValue);
 
         public IRelayCommand<HPSystemsTools.Models.ThermalStateEnum> StateChangedCommand { get; }
         public IRelayCommand CancelTestCommand { get; }

--- a/test/ThermalTest/ViewModels/generated/csProject/HP3LSThermalTestViewModelRemoteClient.cs
+++ b/test/ThermalTest/ViewModels/generated/csProject/HP3LSThermalTestViewModelRemoteClient.cs
@@ -39,57 +39,129 @@ namespace HPSystemsTools.ViewModels.RemoteClients
         public string Instructions
         {
             get => _instructions;
-            private set => SetProperty(ref _instructions, value);
+            private set
+            {
+                var oldValue = _instructions;
+                if (SetProperty(ref _instructions, value))
+                {
+                    OnInstructionsChanged(oldValue, value);
+                }
+            }
         }
+
+        partial void OnInstructionsChanged(string oldValue, string newValue);
 
         private int _cpuTemperatureThreshold = default!;
         public int CpuTemperatureThreshold
         {
             get => _cpuTemperatureThreshold;
-            private set => SetProperty(ref _cpuTemperatureThreshold, value);
+            private set
+            {
+                var oldValue = _cpuTemperatureThreshold;
+                if (SetProperty(ref _cpuTemperatureThreshold, value))
+                {
+                    OnCpuTemperatureThresholdChanged(oldValue, value);
+                }
+            }
         }
+
+        partial void OnCpuTemperatureThresholdChanged(int oldValue, int newValue);
 
         private int _cpuLoadThreshold = default!;
         public int CpuLoadThreshold
         {
             get => _cpuLoadThreshold;
-            private set => SetProperty(ref _cpuLoadThreshold, value);
+            private set
+            {
+                var oldValue = _cpuLoadThreshold;
+                if (SetProperty(ref _cpuLoadThreshold, value))
+                {
+                    OnCpuLoadThresholdChanged(oldValue, value);
+                }
+            }
         }
+
+        partial void OnCpuLoadThresholdChanged(int oldValue, int newValue);
 
         private int _cpuLoadTimeSpan = default!;
         public int CpuLoadTimeSpan
         {
             get => _cpuLoadTimeSpan;
-            private set => SetProperty(ref _cpuLoadTimeSpan, value);
+            private set
+            {
+                var oldValue = _cpuLoadTimeSpan;
+                if (SetProperty(ref _cpuLoadTimeSpan, value))
+                {
+                    OnCpuLoadTimeSpanChanged(oldValue, value);
+                }
+            }
         }
+
+        partial void OnCpuLoadTimeSpanChanged(int oldValue, int newValue);
 
         private HPSystemsTools.ViewModels.ZoneCollection _zones = default!;
         public HPSystemsTools.ViewModels.ZoneCollection Zones
         {
             get => _zones;
-            private set => SetProperty(ref _zones, value);
+            private set
+            {
+                var oldValue = _zones;
+                if (SetProperty(ref _zones, value))
+                {
+                    OnZonesChanged(oldValue, value);
+                }
+            }
         }
+
+        partial void OnZonesChanged(HPSystemsTools.ViewModels.ZoneCollection oldValue, HPSystemsTools.ViewModels.ZoneCollection newValue);
 
         private HPSystemsTools.Models.TestSettingsModel _testSettings = default!;
         public HPSystemsTools.Models.TestSettingsModel TestSettings
         {
             get => _testSettings;
-            private set => SetProperty(ref _testSettings, value);
+            private set
+            {
+                var oldValue = _testSettings;
+                if (SetProperty(ref _testSettings, value))
+                {
+                    OnTestSettingsChanged(oldValue, value);
+                }
+            }
         }
+
+        partial void OnTestSettingsChanged(HPSystemsTools.Models.TestSettingsModel oldValue, HPSystemsTools.Models.TestSettingsModel newValue);
 
         private bool _showDescription = default!;
         public bool ShowDescription
         {
             get => _showDescription;
-            private set => SetProperty(ref _showDescription, value);
+            private set
+            {
+                var oldValue = _showDescription;
+                if (SetProperty(ref _showDescription, value))
+                {
+                    OnShowDescriptionChanged(oldValue, value);
+                }
+            }
         }
+
+        partial void OnShowDescriptionChanged(bool oldValue, bool newValue);
 
         private bool _showReadme = default!;
         public bool ShowReadme
         {
             get => _showReadme;
-            private set => SetProperty(ref _showReadme, value);
+            private set
+            {
+                var oldValue = _showReadme;
+                if (SetProperty(ref _showReadme, value))
+                {
+                    OnShowReadmeChanged(oldValue, value);
+                }
+            }
         }
+
+        partial void OnShowReadmeChanged(bool oldValue, bool newValue);
 
         public IRelayCommand<HPSystemsTools.Models.ThermalStateEnum> StateChangedCommand { get; }
         public IRelayCommand CancelTestCommand { get; }


### PR DESCRIPTION
## Summary
- generate partial OnPropertyChanged methods for client properties
- update generated client baselines for new partial hooks

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c719fa03bc83208f704d6d2dfeba8a