### PR TITLE
Avoid field keyword in generated clients

### DIFF
--- a/test/GameViewModel/expected/GameViewModelRemoteClient.cs
+++ b/test/GameViewModel/expected/GameViewModelRemoteClient.cs
@@ -37,7 +37,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
         }
 
         [ObservableProperty]
-        public partial string MonsterName { get; set; }
+        private string _monsterName;
         partial void OnMonsterNameChanged(string value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -45,7 +45,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
         }
 
         [ObservableProperty]
-        public partial int MonsterMaxHealth { get; set; }
+        private int _monsterMaxHealth;
         partial void OnMonsterMaxHealthChanged(int value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -53,7 +53,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
         }
 
         [ObservableProperty]
-        public partial int MonsterCurrentHealth { get; set; }
+        private int _monsterCurrentHealth;
         partial void OnMonsterCurrentHealthChanged(int value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -61,7 +61,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
         }
 
         [ObservableProperty]
-        public partial int PlayerDamage { get; set; }
+        private int _playerDamage;
         partial void OnPlayerDamageChanged(int value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -69,7 +69,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
         }
 
         [ObservableProperty]
-        public partial string GameMessage { get; set; }
+        private string _gameMessage;
         partial void OnGameMessageChanged(string value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -77,7 +77,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
         }
 
         [ObservableProperty]
-        public partial bool IsMonsterDefeated { get; set; }
+        private bool _isMonsterDefeated;
         partial void OnIsMonsterDefeatedChanged(bool value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -85,7 +85,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
         }
 
         [ObservableProperty]
-        public partial bool CanUseSpecialAttack { get; set; }
+        private bool _canUseSpecialAttack;
         partial void OnCanUseSpecialAttackChanged(bool value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -93,7 +93,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
         }
 
         [ObservableProperty]
-        public partial bool IsSpecialAttackOnCooldown { get; set; }
+        private bool _isSpecialAttackOnCooldown;
         partial void OnIsSpecialAttackOnCooldownChanged(bool value)
         {
             if (_isInitialized && !_suppressLocalUpdates)

--- a/test/PointerTestModel/expected/PointerViewModelRemoteClient.cs
+++ b/test/PointerTestModel/expected/PointerViewModelRemoteClient.cs
@@ -37,186 +37,116 @@ namespace Pointer.ViewModels.RemoteClients
             private set => SetProperty(ref _connectionStatus, value);
         }
 
-        private bool _show = default!;
-        public bool Show
+        [ObservableProperty]
+        private bool _show;
+        partial void OnShowChanged(bool value)
         {
-            get => _show;
-            set
-            {
-                if (SetProperty(ref _show, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("Show", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("Show", value);
         }
 
-        private bool _showSpinner = default!;
-        public bool ShowSpinner
+        [ObservableProperty]
+        private bool _showSpinner;
+        partial void OnShowSpinnerChanged(bool value)
         {
-            get => _showSpinner;
-            set
-            {
-                if (SetProperty(ref _showSpinner, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("ShowSpinner", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("ShowSpinner", value);
         }
 
-        private int _clicksToPass = default!;
-        public int ClicksToPass
+        [ObservableProperty]
+        private int _clicksToPass;
+        partial void OnClicksToPassChanged(int value)
         {
-            get => _clicksToPass;
-            set
-            {
-                if (SetProperty(ref _clicksToPass, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("ClicksToPass", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("ClicksToPass", value);
         }
 
-        private bool _is3Btn = default!;
-        public bool Is3Btn
+        [ObservableProperty]
+        private bool _is3Btn;
+        partial void OnIs3BtnChanged(bool value)
         {
-            get => _is3Btn;
-            set
-            {
-                if (SetProperty(ref _is3Btn, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("Is3Btn", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("Is3Btn", value);
         }
 
-        private int _testTimeoutSec = default!;
-        public int TestTimeoutSec
+        [ObservableProperty]
+        private int _testTimeoutSec;
+        partial void OnTestTimeoutSecChanged(int value)
         {
-            get => _testTimeoutSec;
-            set
-            {
-                if (SetProperty(ref _testTimeoutSec, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("TestTimeoutSec", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("TestTimeoutSec", value);
         }
 
-        private string _instructions = default!;
-        public string Instructions
+        [ObservableProperty]
+        private string _instructions;
+        partial void OnInstructionsChanged(string value)
         {
-            get => _instructions;
-            set
-            {
-                if (SetProperty(ref _instructions, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("Instructions", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("Instructions", value);
         }
 
-        private bool _showCursorTest = default!;
-        public bool ShowCursorTest
+        [ObservableProperty]
+        private bool _showCursorTest;
+        partial void OnShowCursorTestChanged(bool value)
         {
-            get => _showCursorTest;
-            set
-            {
-                if (SetProperty(ref _showCursorTest, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("ShowCursorTest", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("ShowCursorTest", value);
         }
 
-        private bool _showConfigSelection = default!;
-        public bool ShowConfigSelection
+        [ObservableProperty]
+        private bool _showConfigSelection;
+        partial void OnShowConfigSelectionChanged(bool value)
         {
-            get => _showConfigSelection;
-            set
-            {
-                if (SetProperty(ref _showConfigSelection, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("ShowConfigSelection", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("ShowConfigSelection", value);
         }
 
-        private bool _showClickInstructions = default!;
-        public bool ShowClickInstructions
+        [ObservableProperty]
+        private bool _showClickInstructions;
+        partial void OnShowClickInstructionsChanged(bool value)
         {
-            get => _showClickInstructions;
-            set
-            {
-                if (SetProperty(ref _showClickInstructions, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("ShowClickInstructions", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("ShowClickInstructions", value);
         }
 
-        private bool _showTimer = default!;
-        public bool ShowTimer
+        [ObservableProperty]
+        private bool _showTimer;
+        partial void OnShowTimerChanged(bool value)
         {
-            get => _showTimer;
-            set
-            {
-                if (SetProperty(ref _showTimer, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("ShowTimer", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("ShowTimer", value);
         }
 
-        private bool _showBottom = default!;
-        public bool ShowBottom
+        [ObservableProperty]
+        private bool _showBottom;
+        partial void OnShowBottomChanged(bool value)
         {
-            get => _showBottom;
-            set
-            {
-                if (SetProperty(ref _showBottom, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("ShowBottom", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("ShowBottom", value);
         }
 
-        private string _timerText = default!;
-        public string TimerText
+        [ObservableProperty]
+        private string _timerText;
+        partial void OnTimerTextChanged(string value)
         {
-            get => _timerText;
-            set
-            {
-                if (SetProperty(ref _timerText, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("TimerText", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("TimerText", value);
         }
 
-        private string _selectedDevice = default!;
-        public string SelectedDevice
+        [ObservableProperty]
+        private string _selectedDevice;
+        partial void OnSelectedDeviceChanged(string value)
         {
-            get => _selectedDevice;
-            set
-            {
-                if (SetProperty(ref _selectedDevice, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("SelectedDevice", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("SelectedDevice", value);
         }
 
-        private int _lastClickCount = default!;
-        public int LastClickCount
+        [ObservableProperty]
+        private int _lastClickCount;
+        partial void OnLastClickCountChanged(int value)
         {
-            get => _lastClickCount;
-            set
-            {
-                if (SetProperty(ref _lastClickCount, value) && _isInitialized)
-                {
-                    _ = UpdatePropertyValueAsync("LastClickCount", value);
-                }
-            }
+            if (_isInitialized && !_suppressLocalUpdates)
+                _ = UpdatePropertyValueAsync("LastClickCount", value);
         }
 
         public IRelayCommand InitializeCommand { get; }

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
@@ -37,7 +37,7 @@ namespace SampleApp.ViewModels.RemoteClients
         }
 
         [ObservableProperty]
-        public partial string Name { get; set; }
+        private string _name;
         partial void OnNameChanged(string value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -45,7 +45,7 @@ namespace SampleApp.ViewModels.RemoteClients
         }
 
         [ObservableProperty]
-        public partial int Count { get; set; }
+        private int _count;
         partial void OnCountChanged(int value)
         {
             if (_isInitialized && !_suppressLocalUpdates)


### PR DESCRIPTION
## Summary
- generate remote client properties with explicit backing fields
- update test expectations for new property style

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c73a8edf1c8320b792f61b5e1ec27f