### PR TITLE
Refresh WPF property tree on nested updates

### DIFF
--- a/test/GameViewModel/expected/GameViewModelRemoteClient.cs
+++ b/test/GameViewModel/expected/GameViewModelRemoteClient.cs
@@ -38,6 +38,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
 
         [ObservableProperty]
         private string _monsterName;
+
         partial void OnMonsterNameChanged(string value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -46,6 +47,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
 
         [ObservableProperty]
         private int _monsterMaxHealth;
+
         partial void OnMonsterMaxHealthChanged(int value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -54,6 +56,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
 
         [ObservableProperty]
         private int _monsterCurrentHealth;
+
         partial void OnMonsterCurrentHealthChanged(int value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -62,6 +65,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
 
         [ObservableProperty]
         private int _playerDamage;
+
         partial void OnPlayerDamageChanged(int value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -70,6 +74,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
 
         [ObservableProperty]
         private string _gameMessage;
+
         partial void OnGameMessageChanged(string value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -78,6 +83,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
 
         [ObservableProperty]
         private bool _isMonsterDefeated;
+
         partial void OnIsMonsterDefeatedChanged(bool value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -86,6 +92,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
 
         [ObservableProperty]
         private bool _canUseSpecialAttack;
+
         partial void OnCanUseSpecialAttackChanged(bool value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -94,6 +101,7 @@ namespace MonsterClicker.ViewModels.RemoteClients
 
         [ObservableProperty]
         private bool _isSpecialAttackOnCooldown;
+
         partial void OnIsSpecialAttackOnCooldownChanged(bool value)
         {
             if (_isInitialized && !_suppressLocalUpdates)

--- a/test/RemoteMvvmTool.Tests/CsProjectGeneratorTests.cs
+++ b/test/RemoteMvvmTool.Tests/CsProjectGeneratorTests.cs
@@ -244,7 +244,7 @@ namespace TestNamespace
     }
 
     [Fact]
-    public void GenerateWpfMainWindowXaml_HandlesCollections()
+    public void GenerateWpfMainWindowXaml_OmitsCollectionSections()
     {
         var props = new List<PropertyInfo>
         {
@@ -253,18 +253,19 @@ namespace TestNamespace
         };
         var cmds = new List<CommandInfo>();
         string xaml = CsProjectGenerator.GenerateWpfMainWindowXaml("TestApp", "TestRemoteClient", props, cmds);
-        
-        // Should create ListBox for collections
-        Assert.Contains("<ListBox ItemsSource=\"{Binding ZoneList}\"", xaml);
-        Assert.Contains("<ListBox.ItemTemplate>", xaml);
-        Assert.Contains("<DataTemplate>", xaml);
-        
-        // Updated: New approach uses generic {Binding} instead of specific property bindings
-        Assert.Contains("Text=\"{Binding}\"", xaml); // Generic item binding instead of specific Zone/Temperature
-        
-        // Should create TextBox for simple properties  
+
+        // Should not create ListBox for collections
+        Assert.DoesNotContain("<ListBox ItemsSource=\"{Binding ZoneList}\"", xaml);
+
+        // Should still include property details section
+        Assert.Contains("<GroupBox Header=\"Property Details\"", xaml);
+
+        // Should create TextBox for simple properties
         Assert.Contains("{Binding Status, Mode=TwoWay}", xaml);
-        
+
+        // Key Properties section should be omitted
+        Assert.DoesNotContain("Header=\"Key Properties\"", xaml);
+
         // Test server UI generation if enabled
         TestServerUIGenerationIfEnabled("TestApp", "TestService", props, cmds);
     }

--- a/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
+++ b/test/SampleViewModel/expected/SampleViewModelRemoteClient.cs
@@ -38,6 +38,7 @@ namespace SampleApp.ViewModels.RemoteClients
 
         [ObservableProperty]
         private string _name;
+
         partial void OnNameChanged(string value)
         {
             if (_isInitialized && !_suppressLocalUpdates)
@@ -46,6 +47,7 @@ namespace SampleApp.ViewModels.RemoteClients
 
         [ObservableProperty]
         private int _count;
+
         partial void OnCountChanged(int value)
         {
             if (_isInitialized && !_suppressLocalUpdates)


### PR DESCRIPTION
## Summary
- refresh WPF property tree when nested view model properties change by subscribing to `INotifyPropertyChanged`
- drop Key Properties and collection displays from generated WPF client so right pane only shows selected property's details
- update generator tests to assert Key Properties and collection sections are omitted

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c7500644808320a47ef0f2deac28bf