### PR TITLE
Fix WinForms tree layout and save/load feedback

### DIFF
--- a/src/RemoteMvvmTool/Generators/WinFormsClientUIGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/WinFormsClientUIGenerator.cs
@@ -258,7 +258,11 @@ public class WinFormsClientUIGenerator : UIGeneratorBase
         sb.AppendLine("            {");
         sb.AppendLine("                try");
         sb.AppendLine("                {");
-        sb.AppendLine("                    vm.GetType().GetMethod(\"SaveToFile\")?.Invoke(vm, new object[] { dlg.FileName });");
+        sb.AppendLine("                    var method = vm.GetType().GetMethod(\"SaveToFile\");");
+        sb.AppendLine("                    if (method != null)");
+        sb.AppendLine("                        method.Invoke(vm, new object[] { dlg.FileName });");
+        sb.AppendLine("                    else");
+        sb.AppendLine("                        MessageBox.Show(\"SaveToFile method not found on view model\", \"Save Error\", MessageBoxButtons.OK, MessageBoxIcon.Warning);");
         sb.AppendLine("                }");
         sb.AppendLine("                catch (Exception ex)");
         sb.AppendLine("                {");
@@ -274,7 +278,11 @@ public class WinFormsClientUIGenerator : UIGeneratorBase
         sb.AppendLine("            {");
         sb.AppendLine("                try");
         sb.AppendLine("                {");
-        sb.AppendLine("                    vm.GetType().GetMethod(\"LoadFromFile\")?.Invoke(vm, new object[] { dlg.FileName });");
+        sb.AppendLine("                    var method = vm.GetType().GetMethod(\"LoadFromFile\");");
+        sb.AppendLine("                    if (method != null)");
+        sb.AppendLine("                        method.Invoke(vm, new object[] { dlg.FileName });");
+        sb.AppendLine("                    else");
+        sb.AppendLine("                        MessageBox.Show(\"LoadFromFile method not found on view model\", \"Load Error\", MessageBoxButtons.OK, MessageBoxIcon.Warning);");
         sb.AppendLine("                }");
         sb.AppendLine("                catch (Exception ex)");
         sb.AppendLine("                {");

--- a/src/RemoteMvvmTool/Generators/WinFormsServerUIGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/WinFormsServerUIGenerator.cs
@@ -160,7 +160,11 @@ public class WinFormsServerUIGenerator : UIGeneratorBase
         sb.AppendLine("            {");
         sb.AppendLine("                try");
         sb.AppendLine("                {");
-        sb.AppendLine("                    vm.GetType().GetMethod(\"SaveToFile\")?.Invoke(vm, new object[] { dlg.FileName });");
+        sb.AppendLine("                    var method = vm.GetType().GetMethod(\"SaveToFile\");");
+        sb.AppendLine("                    if (method != null)");
+        sb.AppendLine("                        method.Invoke(vm, new object[] { dlg.FileName });");
+        sb.AppendLine("                    else");
+        sb.AppendLine("                        MessageBox.Show(\"SaveToFile method not found on view model\", \"Save Error\", MessageBoxButtons.OK, MessageBoxIcon.Warning);");
         sb.AppendLine("                }");
         sb.AppendLine("                catch (Exception ex)");
         sb.AppendLine("                {");
@@ -176,7 +180,11 @@ public class WinFormsServerUIGenerator : UIGeneratorBase
         sb.AppendLine("            {");
         sb.AppendLine("                try");
         sb.AppendLine("                {");
-        sb.AppendLine("                    vm.GetType().GetMethod(\"LoadFromFile\")?.Invoke(vm, new object[] { dlg.FileName });");
+        sb.AppendLine("                    var method = vm.GetType().GetMethod(\"LoadFromFile\");");
+        sb.AppendLine("                    if (method != null)");
+        sb.AppendLine("                        method.Invoke(vm, new object[] { dlg.FileName });");
+        sb.AppendLine("                    else");
+        sb.AppendLine("                        MessageBox.Show(\"LoadFromFile method not found on view model\", \"Load Error\", MessageBoxButtons.OK, MessageBoxIcon.Warning);");
         sb.AppendLine("                }");
         sb.AppendLine("                catch (Exception ex)");
         sb.AppendLine("                {");

--- a/src/RemoteMvvmTool/Generators/WinFormsUITranslator.cs
+++ b/src/RemoteMvvmTool/Generators/WinFormsUITranslator.cs
@@ -34,9 +34,10 @@ public class WinFormsUITranslator : IUITranslator
                         parent = name;
                     }
 
-                    foreach (var child in container.Children.Where(c => c is not TreeViewComponent))
-                        Translate(child, sb, indent, parent);
+                    // Add tree views first so they dock correctly beneath top-docked controls
                     foreach (var child in container.Children.Where(c => c is TreeViewComponent))
+                        Translate(child, sb, indent, parent);
+                    foreach (var child in container.Children.Where(c => c is not TreeViewComponent))
                         Translate(child, sb, indent, parent);
                 }
                 else


### PR DESCRIPTION
## Summary
- ensure WinForms tree views are added before buttons so property nodes render
- show warnings when Save/Load methods are missing on WinForms client and server view models

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c770f5ed708320947a922be26b268a