### PR TITLE
Fix WinForms generator tree logic indentation

### DIFF
--- a/src/RemoteMvvmTool/Generators/UIGeneratorBase.cs
+++ b/src/RemoteMvvmTool/Generators/UIGeneratorBase.cs
@@ -80,6 +80,34 @@ public abstract class UIGeneratorBase
     }
 
     /// <summary>
+    /// Indents a multi-line code block with the provided indent while preserving line breaks.
+    /// </summary>
+    /// <param name="code">Code that should be indented.</param>
+    /// <param name="indent">Indentation prefix applied to every non-empty line.</param>
+    /// <returns>Indented code block.</returns>
+    protected static string IndentCodeBlock(string code, string indent)
+    {
+        var normalized = code.Replace("\r\n", "\n");
+        var lines = normalized.Split('\n');
+        var sb = new StringBuilder();
+
+        foreach (var line in lines)
+        {
+            if (line.Length == 0)
+            {
+                sb.AppendLine();
+            }
+            else
+            {
+                sb.Append(indent);
+                sb.AppendLine(line);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
     /// Generates framework-agnostic tree loading logic that can be converted to specific frameworks
     /// </summary>
     protected string GenerateFrameworkAgnosticTreeLogic(string treeVariableName, string viewModelVariableName)

--- a/src/RemoteMvvmTool/Generators/WinFormsClientUIGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/WinFormsClientUIGenerator.cs
@@ -100,18 +100,10 @@ public class WinFormsClientUIGenerator : UIGeneratorBase
         sb.AppendLine("                    ShowClientPropertyEditor(e.Node?.Tag as PropertyNodeInfo, detailLayout, vm);");
         sb.AppendLine("                };");
         sb.AppendLine();
-        // Generate static tree loading logic using precomputed property descriptors
-        sb.Append("                " + GenerateFrameworkAgnosticTreeLogic("tree", "vm").Replace("\n", "\n                "));
-        sb.AppendLine();
-        // Generate property tree loading using compile-time analysis
-        sb.Append("        " + GenerateFrameworkAgnosticTreeLogic("tree", "vm").Replace("\n", "\n        "));
-        sb.AppendLine();
+        sb.AppendLine("                // Populate the tree using compile-time metadata");
+        sb.Append(IndentCodeBlock(GenerateFrameworkAgnosticTreeLogic("tree", "vm"), "                "));
         sb.AppendLine("            // Load initial tree");
         sb.AppendLine("            LoadTree();");
-        sb.AppendLine();
-
-        // Generate property change monitoring
-        sb.Append(GeneratePropertyChangeMonitoring());
         sb.AppendLine();
 
         sb.AppendLine("                Application.Run(form);");

--- a/src/RemoteMvvmTool/Generators/WinFormsServerUIGenerator.cs
+++ b/src/RemoteMvvmTool/Generators/WinFormsServerUIGenerator.cs
@@ -94,19 +94,10 @@ public class WinFormsServerUIGenerator : UIGeneratorBase
         sb.AppendLine("                    ShowServerPropertyEditor(e.Node?.Tag as PropertyNodeInfo, detailLayout, vm);");
         sb.AppendLine("                };");
         sb.AppendLine();
-        // Generate static tree loading logic using precomputed property descriptors
-        sb.Append("                " + GenerateFrameworkAgnosticTreeLogic("tree", "vm").Replace("\\n", "\\n                "));
-        sb.AppendLine();
-        
-        // Generate property tree loading using compile-time analysis
-        sb.Append("        " + GenerateFrameworkAgnosticTreeLogic("tree", "vm").Replace("\n", "\n        "));
-        sb.AppendLine();
+        sb.AppendLine("                // Populate the tree using compile-time metadata");
+        sb.Append(IndentCodeBlock(GenerateFrameworkAgnosticTreeLogic("tree", "vm"), "                "));
         sb.AppendLine("            // Load initial tree");
         sb.AppendLine("            LoadTree();");
-        sb.AppendLine();
-
-        // Generate property change monitoring
-        sb.Append(GeneratePropertyChangeMonitoring());
         sb.AppendLine();
 
         sb.AppendLine("                Application.Run(form);");


### PR DESCRIPTION
## Summary
- add an IndentCodeBlock helper so generators can indent emitted methods consistently
- update the WinForms client and server UI generators to use the helper, producing a single well-formed LoadTree local function and removing the stray CodeBlock append

## Testing
- dotnet test *(fails: requires Microsoft.NET.Sdk.WindowsDesktop and snapshot comparison tests also fail on this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c890fe47ec8320b2e670c392f57301